### PR TITLE
refactor: Rename driver from AMD_EMRDMA to ROCM_ERNIC

### DIFF
--- a/.github/workflows/driver-build.yml
+++ b/.github/workflows/driver-build.yml
@@ -55,14 +55,14 @@ jobs:
     - name: Verify driver build
       run: |
         cd driver
-        if [ ! -f amd_emrdma.ko ]; then
-          echo "❌ Driver module amd_emrdma.ko not found!"
+        if [ ! -f rocm_ernic.ko ]; then
+          echo "❌ Driver module rocm_ernic.ko not found!"
           exit 1
         fi
         echo "✅ Driver module built successfully"
-        ls -lh amd_emrdma.ko
-        file amd_emrdma.ko
-        modinfo amd_emrdma.ko
+        ls -lh rocm_ernic.ko
+        file rocm_ernic.ko
+        modinfo rocm_ernic.ko
     
     - name: Check for build warnings
       run: |
@@ -77,8 +77,8 @@ jobs:
     - name: Upload driver artifact
       uses: actions/upload-artifact@v4
       with:
-        name: amd_emrdma-${{ matrix.os }}-$(uname -r)
-        path: driver/amd_emrdma.ko
+        name: rocm_ernic-${{ matrix.os }}-$(uname -r)
+        path: driver/rocm_ernic.ko
         retention-days: 7
     
     - name: Clean build artifacts

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -292,7 +292,7 @@ jobs:
         echo "=== Building Driver ==="
         cd /tmp/driver
         make KDIR=/lib/modules/$(uname -r)/build
-        ls -lh amd_emrdma.ko
+        ls -lh rocm_ernic.ko
         echo "✓ Driver built for kernel $(uname -r)"
         
         echo "=== PCI Devices ==="
@@ -335,7 +335,7 @@ jobs:
         fi
         
         echo "=== Loading Driver ==="
-        sudo insmod ./amd_emrdma.ko 2>&1 | tee /tmp/insmod.log
+        sudo insmod ./rocm_ernic.ko 2>&1 | tee /tmp/insmod.log
         INSMOD_EXIT=${PIPESTATUS[0]}
         
         if [ $INSMOD_EXIT -eq 0 ]; then
@@ -355,10 +355,10 @@ jobs:
         fi
         
         echo "=== Driver Loaded ==="
-        lsmod | grep amd_emrdma
+        lsmod | grep rocm_ernic
         
         echo "=== Kernel Messages ==="
-        sudo dmesg | grep -i "amd_emrdma\|pvrdma" | tail -30
+        sudo dmesg | grep -i "rocm_ernic" | tail -30
         
         echo "=== Checking /sys/class/infiniband ==="
         ls -la /sys/class/infiniband/ || echo "Directory empty or doesn't exist"
@@ -370,7 +370,7 @@ jobs:
         ibv_devices || echo "No RDMA devices found"
         
         echo "=== Device Info ==="
-        if ibv_devices | grep -E "rocep|amd_emrdma" || [ -d /sys/class/infiniband/rocep* ]; then
+        if ibv_devices | grep -E "rocep|rocm_ernic" || [ -d /sys/class/infiniband/rocep* ]; then
           ibv_devinfo || true
           echo "✓ Driver loaded and RDMA device detected"
         else
@@ -395,7 +395,7 @@ jobs:
         echo "=== Testing RDMA Stack ==="
         
         # Get device name
-        DEVICE=$(ibv_devices | grep amd_emrdma | awk '{print $1}' | head -1)
+          DEVICE=$(ibv_devices | grep rocm_ernic | awk '{print $1}' | head -1)
         echo "Testing device: $DEVICE"
         
         # Query port state

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -146,6 +146,7 @@ emrdmaX
 enum
 env
 ernic
+ernicX
 eth
 ethdev
 eventfd

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ networking with direct hardware access semantics.
 - RDMA verbs support via InfiniBand hardware backend
 - Three memory-mapped BARs (MSI-X, Registers, UAR)
 - MSI-X interrupt support (command ring, async events, completion queue)
-- Compatible with the Linux kernel `amd_emrdma` driver
+- Compatible with the Linux kernel `rocm_ernic` driver
 
 ## 🎉 **Current Status: WORKING!** 🎉
 
@@ -37,10 +37,10 @@ operational** with end-to-end vfio-user communication!
 
 ### 📊 Test Results
 ```bash
-$ lsmod | grep amd_emrdma
-amd_emrdma             69632  0
-ib_uverbs             184320  1 amd_emrdma
-ib_core               507904  2 amd_emrdma,ib_uverbs
+$ lsmod | grep rocm_ernic
+rocm_ernic             69632  0
+ib_uverbs             184320  1 rocm_ernic
+ib_core               507904  2 rocm_ernic,ib_uverbs
 
 $ ls -la /sys/class/infiniband/
 rocep0s4f0 -> ../../devices/pci0000:00/0000:00:04.0/infiniband/rocep0s4f0
@@ -58,7 +58,7 @@ for the key fixes that made this work.
 ┌─────────────────────────────────────────┐
 │          Virtual Machine (Guest)        │
 │  ┌────────────────────────────────────┐ │
-│  │   Linux Kernel amd_emrdma Driver  │ │
+│  │   Linux Kernel rocm_ernic Driver  │ │
 │  └─────────────┬──────────────────────┘ │
 │                │ PCI Interface          │
 └────────────────┼────────────────────────┘
@@ -118,7 +118,7 @@ standalone userspace operation.
 ### Linux Kernel Driver
 
 The Linux kernel includes a native PVRDMA driver
-(`drivers/infiniband/hw/amd_emrdma/`) that was merged in **Linux 4.5** (March
+(`drivers/infiniband/hw/rocm_ernic/`) that was merged in **Linux 4.5** (March
 2016). This driver:
 - Implements the standard RDMA verbs interface (`ib_*` APIs)
 - Communicates with the PVRDMA device via PCI memory-mapped I/O
@@ -291,8 +291,8 @@ ibv_devices
 
 ### PCI Configuration
 
-- **Vendor ID**: 0x15ad (VMware)
-- **Device ID**: 0x0820 (PVRDMA)
+- **Vendor ID**: 0x1022 (AMD)
+- **Device ID**: 0x1484 (ROCm ERNIC)
 - **Class Code**: 0x028000 (Network Controller - Other)
 - **PCI Type**: PCIe (PCI Express)
 - **Header Type**: 0x00 (Normal device)
@@ -389,7 +389,7 @@ libibverbs (Physical RDMA Hardware)
 
 1. **Prerequisites:**
    - Physical RDMA device (InfiniBand or RoCE NIC)
-   - Guest VM with `amd_emrdma` kernel driver
+   - Guest VM with `rocm_ernic` kernel driver
    - Linux kernel 4.18+
 
 2. **Running the Server:**
@@ -400,7 +400,7 @@ libibverbs (Physical RDMA Hardware)
 3. **Testing Workflow:**
    - Start server and verify socket creation
    - Connect guest VM via vfio-user
-   - Load `amd_emrdma` driver in guest
+   - Load `rocm_ernic` driver in guest
    - Verify DSR initialization in server logs
    - Run RDMA tests (`ibv_rc_pingpong`, etc.)
 
@@ -433,7 +433,7 @@ configured
 
 **Problem:** `Client disconnected` immediately  
 **Cause:** Guest driver incompatibility or protocol mismatch  
-**Solution:** Use kernel 4.18+ with upstream `amd_emrdma` driver
+**Solution:** Use kernel 4.18+ with upstream `rocm_ernic` driver
 
 **Problem:** Build error: `fatal error: rdma/rdma_cma.h: No such
 file or directory`  
@@ -484,7 +484,7 @@ Triggered interrupt vector 2            # Completion notification
   Ethernet
 
 [qemu-pvrdma-docs]: https://www.qemu.org/docs/master/system/devices/pvrdma.html
-[linux-pvrdma-driver]: https://github.com/torvalds/linux/tree/master/drivers/infiniband/hw/amd_emrdma
+[linux-pvrdma-driver]: https://github.com/torvalds/linux/tree/master/drivers/infiniband/hw/vfu_pvrdma
 [ibverbs-api]: https://man7.org/linux/man-pages/man3/ibv_get_device_list.3.html
 [spdk-link]: https://spdk.io/
 
@@ -522,7 +522,7 @@ This script provides a **complete end-to-end test** that:
 5. ✅ Copies driver source into VM
 6. ✅ Builds driver against guest kernel
 7. ✅ Loads InfiniBand core modules
-8. ✅ Loads the `amd_emrdma` driver
+8. ✅ Loads the `rocm_ernic` driver
 9. ✅ Verifies RDMA device registration
 10. ✅ Shows device info via `ibv_devinfo`
 11. ✅ Keeps VM running for manual testing
@@ -585,23 +585,23 @@ Once the VM boots (SSH on port 2222):
 ssh -p 2222 ubuntu@localhost
 ```
 
-**1. Check for PVRDMA Device:**
+**1. Check for ROCm ERNIC Device:**
 ```bash
-lspci -nn | grep 15ad
-# Expected: 00:XX.0 Network controller [0280]: VMware PVRDMA Device [15ad:0820]
+lspci -nn | grep 1022:1484
+# Expected: 00:XX.0 Network controller [0280]: AMD ROCm ERNIC Device [1022:1484]
 ```
 
-**2. Load PVRDMA Driver:**
+**2. Load ROCm ERNIC Driver:**
 ```bash
-sudo modprobe amd_emrdma
-dmesg | grep amd_emrdma
+sudo modprobe rocm_ernic
+dmesg | grep rocm_ernic
 ```
 
 Expected output:
 ```
-[  X.XXXXXX] amd_emrdma 0000:00:XX.0: device version 1, dma mask 64
-[  X.XXXXXX] amd_emrdma 0000:00:XX.0: using DSR at 0xXXXXXXXXXXXX
-[  X.XXXXXX] amd_emrdma 0000:00:XX.0: initializing driver
+[  X.XXXXXX] rocm_ernic 0000:00:XX.0: device version 1, dma mask 64
+[  X.XXXXXX] rocm_ernic 0000:00:XX.0: using DSR at 0xXXXXXXXXXXXX
+[  X.XXXXXX] rocm_ernic 0000:00:XX.0: initializing driver
 ```
 
 **3. Verify RDMA Device:**
@@ -614,16 +614,16 @@ Expected output:
 ```
     device          node GUID
     ------          ---------
-    amd_emrdma0     xxxx:xxxx:xxxx:xxxx
+    rocm_ernic0     xxxx:xxxx:xxxx:xxxx
 ```
 
 **4. Run RDMA Tests:**
 ```bash
 # Ping-pong test (needs another endpoint)
-ibv_rc_pingpong -d amd_emrdma0
+ibv_rc_pingpong -d rocm_ernic0
 
 # Device info
-ibv_devinfo -d amd_emrdma0
+ibv_devinfo -d rocm_ernic0
 ```
 
 ### Creating New VM Images

--- a/driver/Kconfig
+++ b/driver/Kconfig
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-only
-config INFINIBAND_AMD_EMRDMA
+config INFINIBAND_ROCM_ERNIC
 	tristate "AMD ROCm ERNIC - Emulated RDMA NIC Driver"
 	depends on PCI && INET
 	help

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -1,12 +1,12 @@
-# Out-of-tree kernel module Makefile for amd_emrdma
+# Out-of-tree kernel module Makefile for rocm_ernic
 # Usage: make -f Makefile.out-of-tree
 
 # Kernel build directory
 KDIR ?= /lib/modules/$(shell uname -r)/build
 
 # Module name and object files
-obj-m := amd_emrdma.o
-amd_emrdma-y := rocm_ernic_cmd.o rocm_ernic_cq.o rocm_ernic_doorbell.o \
+obj-m := rocm_ernic.o
+rocm_ernic-y := rocm_ernic_cmd.o rocm_ernic_cq.o rocm_ernic_doorbell.o \
                 rocm_ernic_main.o rocm_ernic_misc.o rocm_ernic_mr.o \
                 rocm_ernic_qp.o rocm_ernic_srq.o rocm_ernic_verbs.o
 
@@ -28,18 +28,18 @@ install:
 
 # Load the module (requires root)
 load:
-	modprobe amd_emrdma
+	modprobe rocm_ernic
 
 # Unload the module (requires root)
 unload:
-	modprobe -r amd_emrdma || true
+	modprobe -r rocm_ernic || true
 
 # Reload the module (requires root)
 reload: unload load
 
 # Show module info
 info:
-	modinfo amd_emrdma.ko
+	modinfo rocm_ernic.ko
 
 # Show build configuration
 config:

--- a/driver/README.md
+++ b/driver/README.md
@@ -1,4 +1,4 @@
-# AMD ROCm ERNIC Driver (amd_emrdma)
+# AMD ROCm ERNIC Driver (rocm_ernic)
 
 ## Overview
 
@@ -33,7 +33,7 @@ has initialized the capabilities.
 ```c
 for (poll_count = 0; poll_count < 100; poll_count++) {
     mb();
-    if (AMD_EMRDMA_SUPPORTED(dev)) {
+    if (ROCM_ERNIC_SUPPORTED(dev)) {
         dsr_ready = true;
         break;
     }
@@ -78,16 +78,16 @@ sudo depmod -a
 
 ```bash
 # Load the module
-sudo modprobe amd_emrdma
+sudo modprobe rocm_ernic
 
 # Check dmesg for driver messages
-dmesg | grep amd_emrdma
+dmesg | grep rocm_ernic
 
 # Expected output when device is found:
-# [  xxx] amd_emrdma 0000:00:04.0: device version 17, driver version 20
-# [  xxx] amd_emrdma 0000:00:04.0: DSR initialized after N polls
-# [  xxx] amd_emrdma 0000:00:04.0: running in standalone mode (no netdev)
-# [  xxx] amd_emrdma 0000:00:04.0: registered ibdev amd_emrdmaX
+# [  xxx] rocm_ernic 0000:00:04.0: device version 17, driver version 20
+# [  xxx] rocm_ernic 0000:00:04.0: DSR initialized after N polls
+# [  xxx] rocm_ernic 0000:00:04.0: running in standalone mode (no netdev)
+# [  xxx] rocm_ernic 0000:00:04.0: registered ibdev rocm_ernicX
 ```
 
 ## Testing with rocm_ernic Server
@@ -116,7 +116,7 @@ dmesg | grep amd_emrdma
 
 3. Inside the guest, load the driver:
    ```bash
-   sudo modprobe amd_emrdma
+   sudo modprobe rocm_ernic
    ```
 
 4. Verify the device is recognized:
@@ -146,8 +146,8 @@ This is expected in standalone mode:
 
 ## Comparison with VMware PVRDMA
 
-| Feature | VMware PVRDMA | AMD EMRDMA |
-|---------|---------------|------------|
+| Feature | VMware PVRDMA | AMD ROCm ERNIC |
+|---------|---------------|----------------|
 | Vendor ID | 0x15ad (VMware) | 0x1022 (AMD) |
 | Device ID | 0x0820 | 0x1484 |
 | DSR Init | Synchronous (assumes immediate) | Polls for completion |
@@ -169,5 +169,5 @@ Dual licensed under GPLv2 and BSD 2-Clause (inherited from VMware PVRDMA).
 ## Authors
 
 - Original PVRDMA: VMware, Inc. (Copyright 2012-2016)
-- AMD EMRDMA modifications: Stephen Bates <stephen@elmail.org> (2025)
+- AMD ROCm ERNIC modifications: Stephen Bates <stephen@elmail.org> (2025)
 

--- a/driver/rocm_ernic-abi.h
+++ b/driver/rocm_ernic-abi.h
@@ -45,141 +45,141 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __AMD_EMRDMA_ABI_H__
-#define __AMD_EMRDMA_ABI_H__
+#ifndef __ROCM_ERNIC_ABI_H__
+#define __ROCM_ERNIC_ABI_H__
 
 #include <linux/types.h>
 
-#define AMD_EMRDMA_UVERBS_ABI_VERSION 3          /* ABI Version. */
-#define AMD_EMRDMA_UAR_HANDLE_MASK    0x00FFFFFF /* Bottom 24 bits. */
-#define AMD_EMRDMA_UAR_QP_OFFSET      0          /* QP doorbell. */
-#define AMD_EMRDMA_UAR_QP_SEND        (1 << 30)  /* Send bit. */
-#define AMD_EMRDMA_UAR_QP_RECV        (1 << 31)  /* Recv bit. */
-#define AMD_EMRDMA_UAR_CQ_OFFSET      4          /* CQ doorbell. */
-#define AMD_EMRDMA_UAR_CQ_ARM_SOL     (1 << 29)  /* Arm solicited bit. */
-#define AMD_EMRDMA_UAR_CQ_ARM         (1 << 30)  /* Arm bit. */
-#define AMD_EMRDMA_UAR_CQ_POLL        (1 << 31)  /* Poll bit. */
-#define AMD_EMRDMA_UAR_SRQ_OFFSET     8          /* SRQ doorbell. */
-#define AMD_EMRDMA_UAR_SRQ_RECV       (1 << 30)  /* Recv bit. */
+#define ROCM_ERNIC_UVERBS_ABI_VERSION 3          /* ABI Version. */
+#define ROCM_ERNIC_UAR_HANDLE_MASK    0x00FFFFFF /* Bottom 24 bits. */
+#define ROCM_ERNIC_UAR_QP_OFFSET      0          /* QP doorbell. */
+#define ROCM_ERNIC_UAR_QP_SEND        (1 << 30)  /* Send bit. */
+#define ROCM_ERNIC_UAR_QP_RECV        (1 << 31)  /* Recv bit. */
+#define ROCM_ERNIC_UAR_CQ_OFFSET      4          /* CQ doorbell. */
+#define ROCM_ERNIC_UAR_CQ_ARM_SOL     (1 << 29)  /* Arm solicited bit. */
+#define ROCM_ERNIC_UAR_CQ_ARM         (1 << 30)  /* Arm bit. */
+#define ROCM_ERNIC_UAR_CQ_POLL        (1 << 31)  /* Poll bit. */
+#define ROCM_ERNIC_UAR_SRQ_OFFSET     8          /* SRQ doorbell. */
+#define ROCM_ERNIC_UAR_SRQ_RECV       (1 << 30)  /* Recv bit. */
 
-enum amd_emrdma_wr_opcode {
-    AMD_EMRDMA_WR_RDMA_WRITE,
-    AMD_EMRDMA_WR_RDMA_WRITE_WITH_IMM,
-    AMD_EMRDMA_WR_SEND,
-    AMD_EMRDMA_WR_SEND_WITH_IMM,
-    AMD_EMRDMA_WR_RDMA_READ,
-    AMD_EMRDMA_WR_ATOMIC_CMP_AND_SWP,
-    AMD_EMRDMA_WR_ATOMIC_FETCH_AND_ADD,
-    AMD_EMRDMA_WR_LSO,
-    AMD_EMRDMA_WR_SEND_WITH_INV,
-    AMD_EMRDMA_WR_RDMA_READ_WITH_INV,
-    AMD_EMRDMA_WR_LOCAL_INV,
-    AMD_EMRDMA_WR_FAST_REG_MR,
-    AMD_EMRDMA_WR_MASKED_ATOMIC_CMP_AND_SWP,
-    AMD_EMRDMA_WR_MASKED_ATOMIC_FETCH_AND_ADD,
-    AMD_EMRDMA_WR_BIND_MW,
-    AMD_EMRDMA_WR_REG_SIG_MR,
-    AMD_EMRDMA_WR_ERROR,
+enum rocm_ernic_wr_opcode {
+    ROCM_ERNIC_WR_RDMA_WRITE,
+    ROCM_ERNIC_WR_RDMA_WRITE_WITH_IMM,
+    ROCM_ERNIC_WR_SEND,
+    ROCM_ERNIC_WR_SEND_WITH_IMM,
+    ROCM_ERNIC_WR_RDMA_READ,
+    ROCM_ERNIC_WR_ATOMIC_CMP_AND_SWP,
+    ROCM_ERNIC_WR_ATOMIC_FETCH_AND_ADD,
+    ROCM_ERNIC_WR_LSO,
+    ROCM_ERNIC_WR_SEND_WITH_INV,
+    ROCM_ERNIC_WR_RDMA_READ_WITH_INV,
+    ROCM_ERNIC_WR_LOCAL_INV,
+    ROCM_ERNIC_WR_FAST_REG_MR,
+    ROCM_ERNIC_WR_MASKED_ATOMIC_CMP_AND_SWP,
+    ROCM_ERNIC_WR_MASKED_ATOMIC_FETCH_AND_ADD,
+    ROCM_ERNIC_WR_BIND_MW,
+    ROCM_ERNIC_WR_REG_SIG_MR,
+    ROCM_ERNIC_WR_ERROR,
 };
 
-enum amd_emrdma_wc_status {
-    AMD_EMRDMA_WC_SUCCESS,
-    AMD_EMRDMA_WC_LOC_LEN_ERR,
-    AMD_EMRDMA_WC_LOC_QP_OP_ERR,
-    AMD_EMRDMA_WC_LOC_EEC_OP_ERR,
-    AMD_EMRDMA_WC_LOC_PROT_ERR,
-    AMD_EMRDMA_WC_WR_FLUSH_ERR,
-    AMD_EMRDMA_WC_MW_BIND_ERR,
-    AMD_EMRDMA_WC_BAD_RESP_ERR,
-    AMD_EMRDMA_WC_LOC_ACCESS_ERR,
-    AMD_EMRDMA_WC_REM_INV_REQ_ERR,
-    AMD_EMRDMA_WC_REM_ACCESS_ERR,
-    AMD_EMRDMA_WC_REM_OP_ERR,
-    AMD_EMRDMA_WC_RETRY_EXC_ERR,
-    AMD_EMRDMA_WC_RNR_RETRY_EXC_ERR,
-    AMD_EMRDMA_WC_LOC_RDD_VIOL_ERR,
-    AMD_EMRDMA_WC_REM_INV_RD_REQ_ERR,
-    AMD_EMRDMA_WC_REM_ABORT_ERR,
-    AMD_EMRDMA_WC_INV_EECN_ERR,
-    AMD_EMRDMA_WC_INV_EEC_STATE_ERR,
-    AMD_EMRDMA_WC_FATAL_ERR,
-    AMD_EMRDMA_WC_RESP_TIMEOUT_ERR,
-    AMD_EMRDMA_WC_GENERAL_ERR,
+enum rocm_ernic_wc_status {
+    ROCM_ERNIC_WC_SUCCESS,
+    ROCM_ERNIC_WC_LOC_LEN_ERR,
+    ROCM_ERNIC_WC_LOC_QP_OP_ERR,
+    ROCM_ERNIC_WC_LOC_EEC_OP_ERR,
+    ROCM_ERNIC_WC_LOC_PROT_ERR,
+    ROCM_ERNIC_WC_WR_FLUSH_ERR,
+    ROCM_ERNIC_WC_MW_BIND_ERR,
+    ROCM_ERNIC_WC_BAD_RESP_ERR,
+    ROCM_ERNIC_WC_LOC_ACCESS_ERR,
+    ROCM_ERNIC_WC_REM_INV_REQ_ERR,
+    ROCM_ERNIC_WC_REM_ACCESS_ERR,
+    ROCM_ERNIC_WC_REM_OP_ERR,
+    ROCM_ERNIC_WC_RETRY_EXC_ERR,
+    ROCM_ERNIC_WC_RNR_RETRY_EXC_ERR,
+    ROCM_ERNIC_WC_LOC_RDD_VIOL_ERR,
+    ROCM_ERNIC_WC_REM_INV_RD_REQ_ERR,
+    ROCM_ERNIC_WC_REM_ABORT_ERR,
+    ROCM_ERNIC_WC_INV_EECN_ERR,
+    ROCM_ERNIC_WC_INV_EEC_STATE_ERR,
+    ROCM_ERNIC_WC_FATAL_ERR,
+    ROCM_ERNIC_WC_RESP_TIMEOUT_ERR,
+    ROCM_ERNIC_WC_GENERAL_ERR,
 };
 
-enum amd_emrdma_wc_opcode {
-    AMD_EMRDMA_WC_SEND,
-    AMD_EMRDMA_WC_RDMA_WRITE,
-    AMD_EMRDMA_WC_RDMA_READ,
-    AMD_EMRDMA_WC_COMP_SWAP,
-    AMD_EMRDMA_WC_FETCH_ADD,
-    AMD_EMRDMA_WC_BIND_MW,
-    AMD_EMRDMA_WC_LSO,
-    AMD_EMRDMA_WC_LOCAL_INV,
-    AMD_EMRDMA_WC_FAST_REG_MR,
-    AMD_EMRDMA_WC_MASKED_COMP_SWAP,
-    AMD_EMRDMA_WC_MASKED_FETCH_ADD,
-    AMD_EMRDMA_WC_RECV = 1 << 7,
-    AMD_EMRDMA_WC_RECV_RDMA_WITH_IMM,
+enum rocm_ernic_wc_opcode {
+    ROCM_ERNIC_WC_SEND,
+    ROCM_ERNIC_WC_RDMA_WRITE,
+    ROCM_ERNIC_WC_RDMA_READ,
+    ROCM_ERNIC_WC_COMP_SWAP,
+    ROCM_ERNIC_WC_FETCH_ADD,
+    ROCM_ERNIC_WC_BIND_MW,
+    ROCM_ERNIC_WC_LSO,
+    ROCM_ERNIC_WC_LOCAL_INV,
+    ROCM_ERNIC_WC_FAST_REG_MR,
+    ROCM_ERNIC_WC_MASKED_COMP_SWAP,
+    ROCM_ERNIC_WC_MASKED_FETCH_ADD,
+    ROCM_ERNIC_WC_RECV = 1 << 7,
+    ROCM_ERNIC_WC_RECV_RDMA_WITH_IMM,
 };
 
-enum amd_emrdma_wc_flags {
-    AMD_EMRDMA_WC_GRH = 1 << 0,
-    AMD_EMRDMA_WC_WITH_IMM = 1 << 1,
-    AMD_EMRDMA_WC_WITH_INVALIDATE = 1 << 2,
-    AMD_EMRDMA_WC_IP_CSUM_OK = 1 << 3,
-    AMD_EMRDMA_WC_WITH_SMAC = 1 << 4,
-    AMD_EMRDMA_WC_WITH_VLAN = 1 << 5,
-    AMD_EMRDMA_WC_WITH_NETWORK_HDR_TYPE = 1 << 6,
-    AMD_EMRDMA_WC_FLAGS_MAX = AMD_EMRDMA_WC_WITH_NETWORK_HDR_TYPE,
+enum rocm_ernic_wc_flags {
+    ROCM_ERNIC_WC_GRH = 1 << 0,
+    ROCM_ERNIC_WC_WITH_IMM = 1 << 1,
+    ROCM_ERNIC_WC_WITH_INVALIDATE = 1 << 2,
+    ROCM_ERNIC_WC_IP_CSUM_OK = 1 << 3,
+    ROCM_ERNIC_WC_WITH_SMAC = 1 << 4,
+    ROCM_ERNIC_WC_WITH_VLAN = 1 << 5,
+    ROCM_ERNIC_WC_WITH_NETWORK_HDR_TYPE = 1 << 6,
+    ROCM_ERNIC_WC_FLAGS_MAX = ROCM_ERNIC_WC_WITH_NETWORK_HDR_TYPE,
 };
 
-enum amd_emrdma_network_type {
-    AMD_EMRDMA_NETWORK_IB,
-    AMD_EMRDMA_NETWORK_ROCE_V1 = AMD_EMRDMA_NETWORK_IB,
-    AMD_EMRDMA_NETWORK_IPV4,
-    AMD_EMRDMA_NETWORK_IPV6
+enum rocm_ernic_network_type {
+    ROCM_ERNIC_NETWORK_IB,
+    ROCM_ERNIC_NETWORK_ROCE_V1 = ROCM_ERNIC_NETWORK_IB,
+    ROCM_ERNIC_NETWORK_IPV4,
+    ROCM_ERNIC_NETWORK_IPV6
 };
 
-struct amd_emrdma_alloc_ucontext_resp {
+struct rocm_ernic_alloc_ucontext_resp {
     __u32 qp_tab_size;
     __u32 reserved;
 };
 
-struct amd_emrdma_alloc_pd_resp {
+struct rocm_ernic_alloc_pd_resp {
     __u32 pdn;
     __u32 reserved;
 };
 
-struct amd_emrdma_create_cq {
+struct rocm_ernic_create_cq {
     __aligned_u64 buf_addr;
     __u32 buf_size;
     __u32 reserved;
 };
 
-struct amd_emrdma_create_cq_resp {
+struct rocm_ernic_create_cq_resp {
     __u32 cqn;
     __u32 reserved;
 };
 
-struct amd_emrdma_resize_cq {
+struct rocm_ernic_resize_cq {
     __aligned_u64 buf_addr;
     __u32 buf_size;
     __u32 reserved;
 };
 
-struct amd_emrdma_create_srq {
+struct rocm_ernic_create_srq {
     __aligned_u64 buf_addr;
     __u32 buf_size;
     __u32 reserved;
 };
 
-struct amd_emrdma_create_srq_resp {
+struct rocm_ernic_create_srq_resp {
     __u32 srqn;
     __u32 reserved;
 };
 
-struct amd_emrdma_create_qp {
+struct rocm_ernic_create_qp {
     __aligned_u64 rbuf_addr;
     __aligned_u64 sbuf_addr;
     __u32 rbuf_size;
@@ -187,27 +187,27 @@ struct amd_emrdma_create_qp {
     __aligned_u64 qp_addr;
 };
 
-struct amd_emrdma_create_qp_resp {
+struct rocm_ernic_create_qp_resp {
     __u32 qpn;
     __u32 qp_handle;
 };
 
-/* AMD_EMRDMA masked atomic compare and swap */
-struct amd_emrdma_ex_cmp_swap {
+/* ROCM_ERNIC masked atomic compare and swap */
+struct rocm_ernic_ex_cmp_swap {
     __aligned_u64 swap_val;
     __aligned_u64 compare_val;
     __aligned_u64 swap_mask;
     __aligned_u64 compare_mask;
 };
 
-/* AMD_EMRDMA masked atomic fetch and add */
-struct amd_emrdma_ex_fetch_add {
+/* ROCM_ERNIC masked atomic fetch and add */
+struct rocm_ernic_ex_fetch_add {
     __aligned_u64 add_val;
     __aligned_u64 field_boundary;
 };
 
-/* AMD_EMRDMA address vector. */
-struct amd_emrdma_av {
+/* ROCM_ERNIC address vector. */
+struct rocm_ernic_av {
     __u32 port_pd;
     __u32 sl_tclass_flowlabel;
     __u8 dgid[16];
@@ -219,23 +219,23 @@ struct amd_emrdma_av {
     __u8 reserved[6];
 };
 
-/* AMD_EMRDMA scatter/gather entry */
-struct amd_emrdma_sge {
+/* ROCM_ERNIC scatter/gather entry */
+struct rocm_ernic_sge {
     __aligned_u64 addr;
     __u32 length;
     __u32 lkey;
 };
 
-/* AMD_EMRDMA receive queue work request */
-struct amd_emrdma_rq_wqe_hdr {
+/* ROCM_ERNIC receive queue work request */
+struct rocm_ernic_rq_wqe_hdr {
     __aligned_u64 wr_id; /* wr id */
     __u32 num_sge;       /* size of s/g array */
     __u32 total_len;     /* reserved */
 };
-/* Use amd_emrdma_sge (ib_sge) for receive queue s/g array elements. */
+/* Use rocm_ernic_sge (ib_sge) for receive queue s/g array elements. */
 
-/* AMD_EMRDMA send queue work request */
-struct amd_emrdma_sq_wqe_hdr {
+/* ROCM_ERNIC send queue work request */
+struct rocm_ernic_sq_wqe_hdr {
     __aligned_u64 wr_id; /* wr id */
     __u32 num_sge;       /* size of s/g array */
     __u32 total_len;     /* reserved */
@@ -264,8 +264,8 @@ struct amd_emrdma_sq_wqe_hdr {
             __u32 log_arg_sz;
             __u32 rkey;
             union {
-                struct amd_emrdma_ex_cmp_swap cmp_swap;
-                struct amd_emrdma_ex_fetch_add fetch_add;
+                struct rocm_ernic_ex_cmp_swap cmp_swap;
+                struct rocm_ernic_ex_fetch_add fetch_add;
             } wr_data;
         } masked_atomics;
         struct {
@@ -281,14 +281,14 @@ struct amd_emrdma_sq_wqe_hdr {
         struct {
             __u32 remote_qpn;
             __u32 remote_qkey;
-            struct amd_emrdma_av av;
+            struct rocm_ernic_av av;
         } ud;
     } wr;
 };
-/* Use amd_emrdma_sge (ib_sge) for send queue s/g array elements. */
+/* Use rocm_ernic_sge (ib_sge) for send queue s/g array elements. */
 
 /* Completion queue element. */
-struct amd_emrdma_cqe {
+struct rocm_ernic_cqe {
     __aligned_u64 wr_id;
     __aligned_u64 qp;
     __u32 opcode;
@@ -308,4 +308,4 @@ struct amd_emrdma_cqe {
     __u8 reserved2[6]; /* Pad to next power of 2 (64). */
 };
 
-#endif /* __AMD_EMRDMA_ABI_H__ */
+#endif /* __ROCM_ERNIC_ABI_H__ */

--- a/driver/rocm_ernic.h
+++ b/driver/rocm_ernic.h
@@ -43,8 +43,8 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __AMD_EMRDMA_H__
-#define __AMD_EMRDMA_H__
+#ifndef __ROCM_ERNIC_H__
+#define __ROCM_ERNIC_H__
 
 #include <linux/compiler.h>
 #include <linux/interrupt.h>
@@ -62,14 +62,14 @@
 #include "rocm_ernic_verbs.h"
 
 /* NOT the same as BIT_MASK(). */
-#define AMD_EMRDMA_MASK(n) ((n << 1) - 1)
+#define ROCM_ERNIC_MASK(n) ((n << 1) - 1)
 
-#define AMD_EMRDMA_NUM_RING_PAGES      4
-#define AMD_EMRDMA_QP_NUM_HEADER_PAGES 1
+#define ROCM_ERNIC_NUM_RING_PAGES      4
+#define ROCM_ERNIC_QP_NUM_HEADER_PAGES 1
 
-struct amd_emrdma_dev;
+struct rocm_ernic_dev;
 
-struct amd_emrdma_page_dir {
+struct rocm_ernic_page_dir {
     dma_addr_t dir_dma;
     u64 *dir;
     int ntables;
@@ -78,21 +78,21 @@ struct amd_emrdma_page_dir {
     void **pages;
 };
 
-struct amd_emrdma_cq {
+struct rocm_ernic_cq {
     struct ib_cq ibcq;
     int offset;
     spinlock_t cq_lock; /* Poll lock. */
-    struct amd_emrdma_uar_map *uar;
+    struct rocm_ernic_uar_map *uar;
     struct ib_umem *umem;
-    struct amd_emrdma_ring_state *ring_state;
-    struct amd_emrdma_page_dir pdir;
+    struct rocm_ernic_ring_state *ring_state;
+    struct rocm_ernic_page_dir pdir;
     u32 cq_handle;
     bool is_kernel;
     refcount_t refcnt;
     struct completion free;
 };
 
-struct amd_emrdma_id_table {
+struct rocm_ernic_id_table {
     u32 last;
     u32 top;
     u32 max;
@@ -101,50 +101,50 @@ struct amd_emrdma_id_table {
     unsigned long *table;
 };
 
-struct amd_emrdma_uar_map {
+struct rocm_ernic_uar_map {
     unsigned long pfn;
     void __iomem *map;
     int index;
 };
 
-struct amd_emrdma_uar_table {
-    struct amd_emrdma_id_table tbl;
+struct rocm_ernic_uar_table {
+    struct rocm_ernic_id_table tbl;
     int size;
 };
 
-struct amd_emrdma_ucontext {
+struct rocm_ernic_ucontext {
     struct ib_ucontext ibucontext;
-    struct amd_emrdma_dev *dev;
-    struct amd_emrdma_uar_map uar;
+    struct rocm_ernic_dev *dev;
+    struct rocm_ernic_uar_map uar;
     u64 ctx_handle;
 };
 
-struct amd_emrdma_pd {
+struct rocm_ernic_pd {
     struct ib_pd ibpd;
     u32 pdn;
     u32 pd_handle;
     int privileged;
 };
 
-struct amd_emrdma_mr {
+struct rocm_ernic_mr {
     u32 mr_handle;
     u64 iova;
     u64 size;
 };
 
-struct amd_emrdma_user_mr {
+struct rocm_ernic_user_mr {
     struct ib_mr ibmr;
     struct ib_umem *umem;
-    struct amd_emrdma_mr mmr;
-    struct amd_emrdma_page_dir pdir;
+    struct rocm_ernic_mr mmr;
+    struct rocm_ernic_page_dir pdir;
     u64 *pages;
     u32 npages;
     u32 max_pages;
     u32 page_shift;
 };
 
-struct amd_emrdma_wq {
-    struct amd_emrdma_ring *ring;
+struct rocm_ernic_wq {
+    struct rocm_ernic_ring *ring;
     spinlock_t lock; /* Work queue lock. */
     int wqe_cnt;
     int wqe_size;
@@ -152,12 +152,12 @@ struct amd_emrdma_wq {
     int offset;
 };
 
-struct amd_emrdma_ah {
+struct rocm_ernic_ah {
     struct ib_ah ibah;
-    struct amd_emrdma_av av;
+    struct rocm_ernic_av av;
 };
 
-struct amd_emrdma_srq {
+struct rocm_ernic_srq {
     struct ib_srq ibsrq;
     int offset;
     spinlock_t lock; /* SRQ lock. */
@@ -165,24 +165,24 @@ struct amd_emrdma_srq {
     int wqe_size;
     int max_gs;
     struct ib_umem *umem;
-    struct amd_emrdma_ring_state *ring;
-    struct amd_emrdma_page_dir pdir;
+    struct rocm_ernic_ring_state *ring;
+    struct rocm_ernic_page_dir pdir;
     u32 srq_handle;
     int npages;
     refcount_t refcnt;
     struct completion free;
 };
 
-struct amd_emrdma_qp {
+struct rocm_ernic_qp {
     struct ib_qp ibqp;
     u32 qp_handle;
     u32 qkey;
-    struct amd_emrdma_wq sq;
-    struct amd_emrdma_wq rq;
+    struct rocm_ernic_wq sq;
+    struct rocm_ernic_wq rq;
     struct ib_umem *rumem;
     struct ib_umem *sumem;
-    struct amd_emrdma_page_dir pdir;
-    struct amd_emrdma_srq *srq;
+    struct rocm_ernic_page_dir pdir;
+    struct rocm_ernic_srq *srq;
     int npages;
     int npages_send;
     int npages_recv;
@@ -195,12 +195,12 @@ struct amd_emrdma_qp {
     struct completion free;
 };
 
-struct amd_emrdma_dev {
+struct rocm_ernic_dev {
     /* PCI device-related information. */
     struct ib_device ib_dev;
     struct pci_dev *pdev;
     void __iomem *regs;
-    struct amd_emrdma_device_shared_region *dsr; /* Shared region pointer */
+    struct rocm_ernic_device_shared_region *dsr; /* Shared region pointer */
     dma_addr_t dsrbase; /* Shared region base address */
     void *cmd_slot;
     void *resp_slot;
@@ -216,18 +216,18 @@ struct amd_emrdma_dev {
 
     /* RDMA-related device information. */
     union ib_gid *sgid_tbl;
-    struct amd_emrdma_ring_state *async_ring_state;
-    struct amd_emrdma_page_dir async_pdir;
-    struct amd_emrdma_ring_state *cq_ring_state;
-    struct amd_emrdma_page_dir cq_pdir;
-    struct amd_emrdma_cq **cq_tbl;
+    struct rocm_ernic_ring_state *async_ring_state;
+    struct rocm_ernic_page_dir async_pdir;
+    struct rocm_ernic_ring_state *cq_ring_state;
+    struct rocm_ernic_page_dir cq_pdir;
+    struct rocm_ernic_cq **cq_tbl;
     spinlock_t cq_tbl_lock;
-    struct amd_emrdma_srq **srq_tbl;
+    struct rocm_ernic_srq **srq_tbl;
     spinlock_t srq_tbl_lock;
-    struct amd_emrdma_qp **qp_tbl;
+    struct rocm_ernic_qp **qp_tbl;
     spinlock_t qp_tbl_lock;
-    struct amd_emrdma_uar_table uar_table;
-    struct amd_emrdma_uar_map driver_uar;
+    struct rocm_ernic_uar_table uar_table;
+    struct rocm_ernic_uar_map driver_uar;
     __be64 sys_image_guid;
     spinlock_t desc_lock; /* Device modification lock. */
     u32 port_cap_mask;
@@ -244,318 +244,318 @@ struct amd_emrdma_dev {
     struct notifier_block nb_netdev;
 };
 
-struct amd_emrdma_netdevice_work {
+struct rocm_ernic_netdevice_work {
     struct work_struct work;
     struct net_device *event_netdev;
     unsigned long event;
 };
 
-static inline struct amd_emrdma_dev *to_vdev(struct ib_device *ibdev)
+static inline struct rocm_ernic_dev *to_vdev(struct ib_device *ibdev)
 {
-    return container_of(ibdev, struct amd_emrdma_dev, ib_dev);
+    return container_of(ibdev, struct rocm_ernic_dev, ib_dev);
 }
 
-static inline struct amd_emrdma_ucontext *to_vucontext(
+static inline struct rocm_ernic_ucontext *to_vucontext(
     struct ib_ucontext *ibucontext)
 {
-    return container_of(ibucontext, struct amd_emrdma_ucontext, ibucontext);
+    return container_of(ibucontext, struct rocm_ernic_ucontext, ibucontext);
 }
 
-static inline struct amd_emrdma_pd *to_vpd(struct ib_pd *ibpd)
+static inline struct rocm_ernic_pd *to_vpd(struct ib_pd *ibpd)
 {
-    return container_of(ibpd, struct amd_emrdma_pd, ibpd);
+    return container_of(ibpd, struct rocm_ernic_pd, ibpd);
 }
 
-static inline struct amd_emrdma_cq *to_vcq(struct ib_cq *ibcq)
+static inline struct rocm_ernic_cq *to_vcq(struct ib_cq *ibcq)
 {
-    return container_of(ibcq, struct amd_emrdma_cq, ibcq);
+    return container_of(ibcq, struct rocm_ernic_cq, ibcq);
 }
 
-static inline struct amd_emrdma_srq *to_vsrq(struct ib_srq *ibsrq)
+static inline struct rocm_ernic_srq *to_vsrq(struct ib_srq *ibsrq)
 {
-    return container_of(ibsrq, struct amd_emrdma_srq, ibsrq);
+    return container_of(ibsrq, struct rocm_ernic_srq, ibsrq);
 }
 
-static inline struct amd_emrdma_user_mr *to_vmr(struct ib_mr *ibmr)
+static inline struct rocm_ernic_user_mr *to_vmr(struct ib_mr *ibmr)
 {
-    return container_of(ibmr, struct amd_emrdma_user_mr, ibmr);
+    return container_of(ibmr, struct rocm_ernic_user_mr, ibmr);
 }
 
-static inline struct amd_emrdma_qp *to_vqp(struct ib_qp *ibqp)
+static inline struct rocm_ernic_qp *to_vqp(struct ib_qp *ibqp)
 {
-    return container_of(ibqp, struct amd_emrdma_qp, ibqp);
+    return container_of(ibqp, struct rocm_ernic_qp, ibqp);
 }
 
-static inline struct amd_emrdma_ah *to_vah(struct ib_ah *ibah)
+static inline struct rocm_ernic_ah *to_vah(struct ib_ah *ibah)
 {
-    return container_of(ibah, struct amd_emrdma_ah, ibah);
+    return container_of(ibah, struct rocm_ernic_ah, ibah);
 }
 
-static inline void amd_emrdma_write_reg(struct amd_emrdma_dev *dev, u32 reg,
+static inline void rocm_ernic_write_reg(struct rocm_ernic_dev *dev, u32 reg,
                                         u32 val)
 {
     writel(cpu_to_le32(val), dev->regs + reg);
 }
 
-static inline u32 amd_emrdma_read_reg(struct amd_emrdma_dev *dev, u32 reg)
+static inline u32 rocm_ernic_read_reg(struct rocm_ernic_dev *dev, u32 reg)
 {
     return le32_to_cpu(readl(dev->regs + reg));
 }
 
-static inline void amd_emrdma_write_uar_cq(struct amd_emrdma_dev *dev, u32 val)
+static inline void rocm_ernic_write_uar_cq(struct rocm_ernic_dev *dev, u32 val)
 {
-    writel(cpu_to_le32(val), dev->driver_uar.map + AMD_EMRDMA_UAR_CQ_OFFSET);
+    writel(cpu_to_le32(val), dev->driver_uar.map + ROCM_ERNIC_UAR_CQ_OFFSET);
 }
 
-static inline void amd_emrdma_write_uar_qp(struct amd_emrdma_dev *dev, u32 val)
+static inline void rocm_ernic_write_uar_qp(struct rocm_ernic_dev *dev, u32 val)
 {
-    writel(cpu_to_le32(val), dev->driver_uar.map + AMD_EMRDMA_UAR_QP_OFFSET);
+    writel(cpu_to_le32(val), dev->driver_uar.map + ROCM_ERNIC_UAR_QP_OFFSET);
 }
 
-static inline void *amd_emrdma_page_dir_get_ptr(
-    struct amd_emrdma_page_dir *pdir, u64 offset)
+static inline void *rocm_ernic_page_dir_get_ptr(
+    struct rocm_ernic_page_dir *pdir, u64 offset)
 {
     return pdir->pages[offset / PAGE_SIZE] + (offset % PAGE_SIZE);
 }
 
-static inline enum amd_emrdma_mtu ib_mtu_to_amd_emrdma(enum ib_mtu mtu)
+static inline enum rocm_ernic_mtu ib_mtu_to_rocm_ernic(enum ib_mtu mtu)
 {
-    return (enum amd_emrdma_mtu)mtu;
+    return (enum rocm_ernic_mtu)mtu;
 }
 
-static inline enum ib_mtu amd_emrdma_mtu_to_ib(enum amd_emrdma_mtu mtu)
+static inline enum ib_mtu rocm_ernic_mtu_to_ib(enum rocm_ernic_mtu mtu)
 {
     return (enum ib_mtu)mtu;
 }
 
-static inline enum amd_emrdma_port_state ib_port_state_to_amd_emrdma(
+static inline enum rocm_ernic_port_state ib_port_state_to_rocm_ernic(
     enum ib_port_state state)
 {
-    return (enum amd_emrdma_port_state)state;
+    return (enum rocm_ernic_port_state)state;
 }
 
-static inline enum ib_port_state amd_emrdma_port_state_to_ib(
-    enum amd_emrdma_port_state state)
+static inline enum ib_port_state rocm_ernic_port_state_to_ib(
+    enum rocm_ernic_port_state state)
 {
     return (enum ib_port_state)state;
 }
 
-static inline int amd_emrdma_port_cap_flags_to_ib(int flags)
+static inline int rocm_ernic_port_cap_flags_to_ib(int flags)
 {
     return flags;
 }
 
-static inline enum amd_emrdma_port_width ib_port_width_to_amd_emrdma(
+static inline enum rocm_ernic_port_width ib_port_width_to_rocm_ernic(
     enum ib_port_width width)
 {
-    return (enum amd_emrdma_port_width)width;
+    return (enum rocm_ernic_port_width)width;
 }
 
-static inline enum ib_port_width amd_emrdma_port_width_to_ib(
-    enum amd_emrdma_port_width width)
+static inline enum ib_port_width rocm_ernic_port_width_to_ib(
+    enum rocm_ernic_port_width width)
 {
     return (enum ib_port_width)width;
 }
 
-static inline enum amd_emrdma_port_speed ib_port_speed_to_amd_emrdma(
+static inline enum rocm_ernic_port_speed ib_port_speed_to_rocm_ernic(
     enum ib_port_speed speed)
 {
-    return (enum amd_emrdma_port_speed)speed;
+    return (enum rocm_ernic_port_speed)speed;
 }
 
-static inline enum ib_port_speed amd_emrdma_port_speed_to_ib(
-    enum amd_emrdma_port_speed speed)
+static inline enum ib_port_speed rocm_ernic_port_speed_to_ib(
+    enum rocm_ernic_port_speed speed)
 {
     return (enum ib_port_speed)speed;
 }
 
-static inline int ib_qp_attr_mask_to_amd_emrdma(int attr_mask)
+static inline int ib_qp_attr_mask_to_rocm_ernic(int attr_mask)
 {
-    return attr_mask & AMD_EMRDMA_MASK(AMD_EMRDMA_QP_ATTR_MASK_MAX);
+    return attr_mask & ROCM_ERNIC_MASK(ROCM_ERNIC_QP_ATTR_MASK_MAX);
 }
 
-static inline enum amd_emrdma_mig_state ib_mig_state_to_amd_emrdma(
+static inline enum rocm_ernic_mig_state ib_mig_state_to_rocm_ernic(
     enum ib_mig_state state)
 {
-    return (enum amd_emrdma_mig_state)state;
+    return (enum rocm_ernic_mig_state)state;
 }
 
-static inline enum ib_mig_state amd_emrdma_mig_state_to_ib(
-    enum amd_emrdma_mig_state state)
+static inline enum ib_mig_state rocm_ernic_mig_state_to_ib(
+    enum rocm_ernic_mig_state state)
 {
     return (enum ib_mig_state)state;
 }
 
-static inline int ib_access_flags_to_amd_emrdma(int flags)
+static inline int ib_access_flags_to_rocm_ernic(int flags)
 {
     return flags;
 }
 
-static inline int amd_emrdma_access_flags_to_ib(int flags)
+static inline int rocm_ernic_access_flags_to_ib(int flags)
 {
-    return flags & AMD_EMRDMA_MASK(AMD_EMRDMA_ACCESS_FLAGS_MAX);
+    return flags & ROCM_ERNIC_MASK(ROCM_ERNIC_ACCESS_FLAGS_MAX);
 }
 
-static inline enum amd_emrdma_qp_type ib_qp_type_to_amd_emrdma(
+static inline enum rocm_ernic_qp_type ib_qp_type_to_rocm_ernic(
     enum ib_qp_type type)
 {
-    return (enum amd_emrdma_qp_type)type;
+    return (enum rocm_ernic_qp_type)type;
 }
 
-static inline enum amd_emrdma_qp_state ib_qp_state_to_amd_emrdma(
+static inline enum rocm_ernic_qp_state ib_qp_state_to_rocm_ernic(
     enum ib_qp_state state)
 {
-    return (enum amd_emrdma_qp_state)state;
+    return (enum rocm_ernic_qp_state)state;
 }
 
-static inline enum ib_qp_state amd_emrdma_qp_state_to_ib(
-    enum amd_emrdma_qp_state state)
+static inline enum ib_qp_state rocm_ernic_qp_state_to_ib(
+    enum rocm_ernic_qp_state state)
 {
     return (enum ib_qp_state)state;
 }
 
-static inline enum amd_emrdma_wr_opcode ib_wr_opcode_to_amd_emrdma(
+static inline enum rocm_ernic_wr_opcode ib_wr_opcode_to_rocm_ernic(
     enum ib_wr_opcode op)
 {
     switch (op) {
     case IB_WR_RDMA_WRITE:
-        return AMD_EMRDMA_WR_RDMA_WRITE;
+        return ROCM_ERNIC_WR_RDMA_WRITE;
     case IB_WR_RDMA_WRITE_WITH_IMM:
-        return AMD_EMRDMA_WR_RDMA_WRITE_WITH_IMM;
+        return ROCM_ERNIC_WR_RDMA_WRITE_WITH_IMM;
     case IB_WR_SEND:
-        return AMD_EMRDMA_WR_SEND;
+        return ROCM_ERNIC_WR_SEND;
     case IB_WR_SEND_WITH_IMM:
-        return AMD_EMRDMA_WR_SEND_WITH_IMM;
+        return ROCM_ERNIC_WR_SEND_WITH_IMM;
     case IB_WR_RDMA_READ:
-        return AMD_EMRDMA_WR_RDMA_READ;
+        return ROCM_ERNIC_WR_RDMA_READ;
     case IB_WR_ATOMIC_CMP_AND_SWP:
-        return AMD_EMRDMA_WR_ATOMIC_CMP_AND_SWP;
+        return ROCM_ERNIC_WR_ATOMIC_CMP_AND_SWP;
     case IB_WR_ATOMIC_FETCH_AND_ADD:
-        return AMD_EMRDMA_WR_ATOMIC_FETCH_AND_ADD;
+        return ROCM_ERNIC_WR_ATOMIC_FETCH_AND_ADD;
     case IB_WR_LSO:
-        return AMD_EMRDMA_WR_LSO;
+        return ROCM_ERNIC_WR_LSO;
     case IB_WR_SEND_WITH_INV:
-        return AMD_EMRDMA_WR_SEND_WITH_INV;
+        return ROCM_ERNIC_WR_SEND_WITH_INV;
     case IB_WR_RDMA_READ_WITH_INV:
-        return AMD_EMRDMA_WR_RDMA_READ_WITH_INV;
+        return ROCM_ERNIC_WR_RDMA_READ_WITH_INV;
     case IB_WR_LOCAL_INV:
-        return AMD_EMRDMA_WR_LOCAL_INV;
+        return ROCM_ERNIC_WR_LOCAL_INV;
     case IB_WR_REG_MR:
-        return AMD_EMRDMA_WR_FAST_REG_MR;
+        return ROCM_ERNIC_WR_FAST_REG_MR;
     case IB_WR_MASKED_ATOMIC_CMP_AND_SWP:
-        return AMD_EMRDMA_WR_MASKED_ATOMIC_CMP_AND_SWP;
+        return ROCM_ERNIC_WR_MASKED_ATOMIC_CMP_AND_SWP;
     case IB_WR_MASKED_ATOMIC_FETCH_AND_ADD:
-        return AMD_EMRDMA_WR_MASKED_ATOMIC_FETCH_AND_ADD;
+        return ROCM_ERNIC_WR_MASKED_ATOMIC_FETCH_AND_ADD;
     case IB_WR_REG_MR_INTEGRITY:
-        return AMD_EMRDMA_WR_REG_SIG_MR;
+        return ROCM_ERNIC_WR_REG_SIG_MR;
     default:
-        return AMD_EMRDMA_WR_ERROR;
+        return ROCM_ERNIC_WR_ERROR;
     }
 }
 
-static inline enum ib_wc_status amd_emrdma_wc_status_to_ib(
-    enum amd_emrdma_wc_status status)
+static inline enum ib_wc_status rocm_ernic_wc_status_to_ib(
+    enum rocm_ernic_wc_status status)
 {
     return (enum ib_wc_status)status;
 }
 
-static inline int amd_emrdma_wc_opcode_to_ib(unsigned int opcode)
+static inline int rocm_ernic_wc_opcode_to_ib(unsigned int opcode)
 {
     switch (opcode) {
-    case AMD_EMRDMA_WC_SEND:
+    case ROCM_ERNIC_WC_SEND:
         return IB_WC_SEND;
-    case AMD_EMRDMA_WC_RDMA_WRITE:
+    case ROCM_ERNIC_WC_RDMA_WRITE:
         return IB_WC_RDMA_WRITE;
-    case AMD_EMRDMA_WC_RDMA_READ:
+    case ROCM_ERNIC_WC_RDMA_READ:
         return IB_WC_RDMA_READ;
-    case AMD_EMRDMA_WC_COMP_SWAP:
+    case ROCM_ERNIC_WC_COMP_SWAP:
         return IB_WC_COMP_SWAP;
-    case AMD_EMRDMA_WC_FETCH_ADD:
+    case ROCM_ERNIC_WC_FETCH_ADD:
         return IB_WC_FETCH_ADD;
-    case AMD_EMRDMA_WC_LOCAL_INV:
+    case ROCM_ERNIC_WC_LOCAL_INV:
         return IB_WC_LOCAL_INV;
-    case AMD_EMRDMA_WC_FAST_REG_MR:
+    case ROCM_ERNIC_WC_FAST_REG_MR:
         return IB_WC_REG_MR;
-    case AMD_EMRDMA_WC_MASKED_COMP_SWAP:
+    case ROCM_ERNIC_WC_MASKED_COMP_SWAP:
         return IB_WC_MASKED_COMP_SWAP;
-    case AMD_EMRDMA_WC_MASKED_FETCH_ADD:
+    case ROCM_ERNIC_WC_MASKED_FETCH_ADD:
         return IB_WC_MASKED_FETCH_ADD;
-    case AMD_EMRDMA_WC_RECV:
+    case ROCM_ERNIC_WC_RECV:
         return IB_WC_RECV;
-    case AMD_EMRDMA_WC_RECV_RDMA_WITH_IMM:
+    case ROCM_ERNIC_WC_RECV_RDMA_WITH_IMM:
         return IB_WC_RECV_RDMA_WITH_IMM;
     default:
         return IB_WC_SEND;
     }
 }
 
-static inline int amd_emrdma_wc_flags_to_ib(int flags)
+static inline int rocm_ernic_wc_flags_to_ib(int flags)
 {
     return flags;
 }
 
-static inline int ib_send_flags_to_amd_emrdma(int flags)
+static inline int ib_send_flags_to_rocm_ernic(int flags)
 {
-    return flags & AMD_EMRDMA_MASK(AMD_EMRDMA_SEND_FLAGS_MAX);
+    return flags & ROCM_ERNIC_MASK(ROCM_ERNIC_SEND_FLAGS_MAX);
 }
 
-static inline int amd_emrdma_network_type_to_ib(
-    enum amd_emrdma_network_type type)
+static inline int rocm_ernic_network_type_to_ib(
+    enum rocm_ernic_network_type type)
 {
     switch (type) {
-    case AMD_EMRDMA_NETWORK_ROCE_V1:
+    case ROCM_ERNIC_NETWORK_ROCE_V1:
         return RDMA_NETWORK_ROCE_V1;
-    case AMD_EMRDMA_NETWORK_IPV4:
+    case ROCM_ERNIC_NETWORK_IPV4:
         return RDMA_NETWORK_IPV4;
-    case AMD_EMRDMA_NETWORK_IPV6:
+    case ROCM_ERNIC_NETWORK_IPV6:
         return RDMA_NETWORK_IPV6;
     default:
         return RDMA_NETWORK_IPV6;
     }
 }
 
-void amd_emrdma_qp_cap_to_ib(struct ib_qp_cap *dst,
-                             const struct amd_emrdma_qp_cap *src);
-void ib_qp_cap_to_amd_emrdma(struct amd_emrdma_qp_cap *dst,
+void rocm_ernic_qp_cap_to_ib(struct ib_qp_cap *dst,
+                             const struct rocm_ernic_qp_cap *src);
+void ib_qp_cap_to_rocm_ernic(struct rocm_ernic_qp_cap *dst,
                              const struct ib_qp_cap *src);
-void amd_emrdma_gid_to_ib(union ib_gid *dst, const union amd_emrdma_gid *src);
-void ib_gid_to_amd_emrdma(union amd_emrdma_gid *dst, const union ib_gid *src);
-void amd_emrdma_global_route_to_ib(struct ib_global_route *dst,
-                                   const struct amd_emrdma_global_route *src);
-void ib_global_route_to_amd_emrdma(struct amd_emrdma_global_route *dst,
+void rocm_ernic_gid_to_ib(union ib_gid *dst, const union rocm_ernic_gid *src);
+void ib_gid_to_rocm_ernic(union rocm_ernic_gid *dst, const union ib_gid *src);
+void rocm_ernic_global_route_to_ib(struct ib_global_route *dst,
+                                   const struct rocm_ernic_global_route *src);
+void ib_global_route_to_rocm_ernic(struct rocm_ernic_global_route *dst,
                                    const struct ib_global_route *src);
-void amd_emrdma_ah_attr_to_rdma(struct rdma_ah_attr *dst,
-                                const struct amd_emrdma_ah_attr *src);
-void rdma_ah_attr_to_amd_emrdma(struct amd_emrdma_ah_attr *dst,
+void rocm_ernic_ah_attr_to_rdma(struct rdma_ah_attr *dst,
+                                const struct rocm_ernic_ah_attr *src);
+void rdma_ah_attr_to_rocm_ernic(struct rocm_ernic_ah_attr *dst,
                                 const struct rdma_ah_attr *src);
-u8 ib_gid_type_to_amd_emrdma(enum ib_gid_type gid_type);
+u8 ib_gid_type_to_rocm_ernic(enum ib_gid_type gid_type);
 
-int amd_emrdma_uar_table_init(struct amd_emrdma_dev *dev);
-void amd_emrdma_uar_table_cleanup(struct amd_emrdma_dev *dev);
+int rocm_ernic_uar_table_init(struct rocm_ernic_dev *dev);
+void rocm_ernic_uar_table_cleanup(struct rocm_ernic_dev *dev);
 
-int amd_emrdma_uar_alloc(struct amd_emrdma_dev *dev,
-                         struct amd_emrdma_uar_map *uar);
-void amd_emrdma_uar_free(struct amd_emrdma_dev *dev,
-                         struct amd_emrdma_uar_map *uar);
+int rocm_ernic_uar_alloc(struct rocm_ernic_dev *dev,
+                         struct rocm_ernic_uar_map *uar);
+void rocm_ernic_uar_free(struct rocm_ernic_dev *dev,
+                         struct rocm_ernic_uar_map *uar);
 
-void _amd_emrdma_flush_cqe(struct amd_emrdma_qp *qp, struct amd_emrdma_cq *cq);
+void _rocm_ernic_flush_cqe(struct rocm_ernic_qp *qp, struct rocm_ernic_cq *cq);
 
-int amd_emrdma_page_dir_init(struct amd_emrdma_dev *dev,
-                             struct amd_emrdma_page_dir *pdir, u64 npages,
+int rocm_ernic_page_dir_init(struct rocm_ernic_dev *dev,
+                             struct rocm_ernic_page_dir *pdir, u64 npages,
                              bool alloc_pages);
-void amd_emrdma_page_dir_cleanup(struct amd_emrdma_dev *dev,
-                                 struct amd_emrdma_page_dir *pdir);
-int amd_emrdma_page_dir_insert_dma(struct amd_emrdma_page_dir *pdir, u64 idx,
+void rocm_ernic_page_dir_cleanup(struct rocm_ernic_dev *dev,
+                                 struct rocm_ernic_page_dir *pdir);
+int rocm_ernic_page_dir_insert_dma(struct rocm_ernic_page_dir *pdir, u64 idx,
                                    dma_addr_t daddr);
-int amd_emrdma_page_dir_insert_umem(struct amd_emrdma_page_dir *pdir,
+int rocm_ernic_page_dir_insert_umem(struct rocm_ernic_page_dir *pdir,
                                     struct ib_umem *umem, u64 offset);
-dma_addr_t amd_emrdma_page_dir_get_dma(struct amd_emrdma_page_dir *pdir,
+dma_addr_t rocm_ernic_page_dir_get_dma(struct rocm_ernic_page_dir *pdir,
                                        u64 idx);
-int amd_emrdma_page_dir_insert_page_list(struct amd_emrdma_page_dir *pdir,
+int rocm_ernic_page_dir_insert_page_list(struct rocm_ernic_page_dir *pdir,
                                          u64 *page_list, int num_pages);
 
-int amd_emrdma_cmd_post(struct amd_emrdma_dev *dev,
-                        union amd_emrdma_cmd_req *req,
-                        union amd_emrdma_cmd_resp *rsp, unsigned resp_code);
+int rocm_ernic_cmd_post(struct rocm_ernic_dev *dev,
+                        union rocm_ernic_cmd_req *req,
+                        union rocm_ernic_cmd_resp *rsp, unsigned resp_code);
 
-#endif /* __AMD_EMRDMA_H__ */
+#endif /* __ROCM_ERNIC_H__ */

--- a/driver/rocm_ernic_cmd.c
+++ b/driver/rocm_ernic_cmd.c
@@ -47,10 +47,10 @@
 
 #include "rocm_ernic.h"
 
-#define AMD_EMRDMA_CMD_TIMEOUT 10000 /* ms */
+#define ROCM_ERNIC_CMD_TIMEOUT 10000 /* ms */
 
-static inline int amd_emrdma_cmd_recv(struct amd_emrdma_dev *dev,
-                                      union amd_emrdma_cmd_resp *resp,
+static inline int rocm_ernic_cmd_recv(struct rocm_ernic_dev *dev,
+                                      union rocm_ernic_cmd_resp *resp,
                                       unsigned resp_code)
 {
     int err;
@@ -58,7 +58,7 @@ static inline int amd_emrdma_cmd_recv(struct amd_emrdma_dev *dev,
     dev_dbg(&dev->pdev->dev, "receive response from device\n");
 
     err = wait_for_completion_interruptible_timeout(
-        &dev->cmd_done, msecs_to_jiffies(AMD_EMRDMA_CMD_TIMEOUT));
+        &dev->cmd_done, msecs_to_jiffies(ROCM_ERNIC_CMD_TIMEOUT));
     if (err == 0 || err == -ERESTARTSYS) {
         dev_warn(&dev->pdev->dev, "completion timeout or interrupted\n");
         return -ETIMEDOUT;
@@ -77,9 +77,9 @@ static inline int amd_emrdma_cmd_recv(struct amd_emrdma_dev *dev,
     return 0;
 }
 
-int amd_emrdma_cmd_post(struct amd_emrdma_dev *dev,
-                        union amd_emrdma_cmd_req *req,
-                        union amd_emrdma_cmd_resp *resp, unsigned resp_code)
+int rocm_ernic_cmd_post(struct rocm_ernic_dev *dev,
+                        union rocm_ernic_cmd_req *req,
+                        union rocm_ernic_cmd_resp *resp, unsigned resp_code)
 {
     int err;
 
@@ -88,23 +88,23 @@ int amd_emrdma_cmd_post(struct amd_emrdma_dev *dev,
     /* Serializiation */
     down(&dev->cmd_sema);
 
-    BUILD_BUG_ON(sizeof(union amd_emrdma_cmd_req) !=
-                 sizeof(struct amd_emrdma_cmd_modify_qp));
+    BUILD_BUG_ON(sizeof(union rocm_ernic_cmd_req) !=
+                 sizeof(struct rocm_ernic_cmd_modify_qp));
 
     spin_lock(&dev->cmd_lock);
     memcpy(dev->cmd_slot, req, sizeof(*req));
     spin_unlock(&dev->cmd_lock);
 
     init_completion(&dev->cmd_done);
-    amd_emrdma_write_reg(dev, AMD_EMRDMA_REG_REQUEST, 0);
+    rocm_ernic_write_reg(dev, ROCM_ERNIC_REG_REQUEST, 0);
 
     /* Make sure the request is written before reading status. */
     mb();
 
-    err = amd_emrdma_read_reg(dev, AMD_EMRDMA_REG_ERR);
+    err = rocm_ernic_read_reg(dev, ROCM_ERNIC_REG_ERR);
     if (err == 0) {
         if (resp != NULL)
-            err = amd_emrdma_cmd_recv(dev, resp, resp_code);
+            err = rocm_ernic_cmd_recv(dev, resp, resp_code);
     } else {
         dev_warn(&dev->pdev->dev, "failed to write request error reg: %d\n",
                  err);

--- a/driver/rocm_ernic_cq.c
+++ b/driver/rocm_ernic_cq.c
@@ -55,35 +55,35 @@
 #include "rocm_ernic.h"
 
 /**
- * amd_emrdma_req_notify_cq - request notification for a completion queue
+ * rocm_ernic_req_notify_cq - request notification for a completion queue
  * @ibcq: the completion queue
  * @notify_flags: notification flags
  *
  * @return: 0 for success.
  */
-int amd_emrdma_req_notify_cq(struct ib_cq *ibcq,
+int rocm_ernic_req_notify_cq(struct ib_cq *ibcq,
                              enum ib_cq_notify_flags notify_flags)
 {
-    struct amd_emrdma_dev *dev = to_vdev(ibcq->device);
-    struct amd_emrdma_cq *cq = to_vcq(ibcq);
+    struct rocm_ernic_dev *dev = to_vdev(ibcq->device);
+    struct rocm_ernic_cq *cq = to_vcq(ibcq);
     u32 val = cq->cq_handle;
     unsigned long flags;
     int has_data = 0;
 
     val |= (notify_flags & IB_CQ_SOLICITED_MASK) == IB_CQ_SOLICITED
-               ? AMD_EMRDMA_UAR_CQ_ARM_SOL
-               : AMD_EMRDMA_UAR_CQ_ARM;
+               ? ROCM_ERNIC_UAR_CQ_ARM_SOL
+               : ROCM_ERNIC_UAR_CQ_ARM;
 
     spin_lock_irqsave(&cq->cq_lock, flags);
 
-    amd_emrdma_write_uar_cq(dev, val);
+    rocm_ernic_write_uar_cq(dev, val);
 
     if (notify_flags & IB_CQ_REPORT_MISSED_EVENTS) {
         unsigned int head;
 
-        has_data = amd_emrdma_idx_ring_has_data(&cq->ring_state->rx,
+        has_data = rocm_ernic_idx_ring_has_data(&cq->ring_state->rx,
                                                 cq->ibcq.cqe, &head);
-        if (unlikely(has_data == AMD_EMRDMA_INVALID_IDX))
+        if (unlikely(has_data == ROCM_ERNIC_INVALID_IDX))
             dev_err(&dev->pdev->dev, "CQ ring state invalid\n");
     }
 
@@ -93,14 +93,14 @@ int amd_emrdma_req_notify_cq(struct ib_cq *ibcq,
 }
 
 /**
- * amd_emrdma_create_cq - create completion queue
+ * rocm_ernic_create_cq - create completion queue
  * @ibcq: Allocated CQ
  * @attr: completion queue attributes
  * @attrs: bundle
  *
  * @return: 0 on success
  */
-int amd_emrdma_create_cq(struct ib_cq *ibcq, const struct ib_cq_init_attr *attr,
+int rocm_ernic_create_cq(struct ib_cq *ibcq, const struct ib_cq_init_attr *attr,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
                          struct uverbs_attr_bundle *attrs)
 #else
@@ -112,21 +112,21 @@ int amd_emrdma_create_cq(struct ib_cq *ibcq, const struct ib_cq_init_attr *attr,
 #endif
     struct ib_device *ibdev = ibcq->device;
     int entries = attr->cqe;
-    struct amd_emrdma_dev *dev = to_vdev(ibdev);
-    struct amd_emrdma_cq *cq = to_vcq(ibcq);
+    struct rocm_ernic_dev *dev = to_vdev(ibdev);
+    struct rocm_ernic_cq *cq = to_vcq(ibcq);
     int ret;
     int npages;
     unsigned long flags;
-    union amd_emrdma_cmd_req req;
-    union amd_emrdma_cmd_resp rsp;
-    struct amd_emrdma_cmd_create_cq *cmd = &req.create_cq;
-    struct amd_emrdma_cmd_create_cq_resp *resp = &rsp.create_cq_resp;
-    struct amd_emrdma_create_cq_resp cq_resp = {};
-    struct amd_emrdma_create_cq ucmd;
-    struct amd_emrdma_ucontext *context = rdma_udata_to_drv_context(
-        udata, struct amd_emrdma_ucontext, ibucontext);
+    union rocm_ernic_cmd_req req;
+    union rocm_ernic_cmd_resp rsp;
+    struct rocm_ernic_cmd_create_cq *cmd = &req.create_cq;
+    struct rocm_ernic_cmd_create_cq_resp *resp = &rsp.create_cq_resp;
+    struct rocm_ernic_create_cq_resp cq_resp = {};
+    struct rocm_ernic_create_cq ucmd;
+    struct rocm_ernic_ucontext *context = rdma_udata_to_drv_context(
+        udata, struct rocm_ernic_ucontext, ibucontext);
 
-    BUILD_BUG_ON(sizeof(struct amd_emrdma_cqe) != 64);
+    BUILD_BUG_ON(sizeof(struct rocm_ernic_cqe) != 64);
 
     dev_info(&dev->pdev->dev,
              "CQ create: ENTRY (entries=%d, flags=0x%x, is_kernel=%d)\n",
@@ -173,14 +173,14 @@ int amd_emrdma_create_cq(struct ib_cq *ibcq, const struct ib_cq_init_attr *attr,
         npages = ib_umem_num_dma_blocks(cq->umem, PAGE_SIZE);
     } else {
         /* One extra page for shared ring state */
-        npages = 1 + (entries * sizeof(struct amd_emrdma_cqe) + PAGE_SIZE - 1) /
+        npages = 1 + (entries * sizeof(struct rocm_ernic_cqe) + PAGE_SIZE - 1) /
                          PAGE_SIZE;
 
         /* Skip header page. */
         cq->offset = PAGE_SIZE;
     }
 
-    if (npages < 0 || npages > AMD_EMRDMA_PAGE_DIR_MAX_PAGES) {
+    if (npages < 0 || npages > ROCM_ERNIC_PAGE_DIR_MAX_PAGES) {
         dev_warn(&dev->pdev->dev, "overflow pages in completion queue\n");
         ret = -EINVAL;
         goto err_umem;
@@ -189,7 +189,7 @@ int amd_emrdma_create_cq(struct ib_cq *ibcq, const struct ib_cq_init_attr *attr,
     dev_info(&dev->pdev->dev,
              "CQ create: about to init page dir (npages=%d, is_kernel=%d)\n",
              npages, cq->is_kernel);
-    ret = amd_emrdma_page_dir_init(dev, &cq->pdir, npages, cq->is_kernel);
+    ret = rocm_ernic_page_dir_init(dev, &cq->pdir, npages, cq->is_kernel);
     if (ret) {
         dev_warn(&dev->pdev->dev,
                  "could not allocate page directory (ret=%d, npages=%d)\n", ret,
@@ -202,19 +202,19 @@ int amd_emrdma_create_cq(struct ib_cq *ibcq, const struct ib_cq_init_attr *attr,
     if (cq->is_kernel)
         cq->ring_state = cq->pdir.pages[0];
     else
-        amd_emrdma_page_dir_insert_umem(&cq->pdir, cq->umem, 0);
+        rocm_ernic_page_dir_insert_umem(&cq->pdir, cq->umem, 0);
 
     refcount_set(&cq->refcnt, 1);
     init_completion(&cq->free);
     spin_lock_init(&cq->cq_lock);
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_CREATE_CQ;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_CREATE_CQ;
     cmd->nchunks = npages;
     cmd->ctx_handle = context ? context->ctx_handle : 0;
     cmd->cqe = entries;
     cmd->pdir_dma = cq->pdir.dir_dma;
-    ret = amd_emrdma_cmd_post(dev, &req, &rsp, AMD_EMRDMA_CMD_CREATE_CQ_RESP);
+    ret = rocm_ernic_cmd_post(dev, &req, &rsp, ROCM_ERNIC_CMD_CREATE_CQ_RESP);
     if (ret < 0) {
         dev_warn(&dev->pdev->dev,
                  "could not create completion queue, error: %d\n", ret);
@@ -234,7 +234,7 @@ int amd_emrdma_create_cq(struct ib_cq *ibcq, const struct ib_cq_init_attr *attr,
         /* Copy udata back. */
         if (ib_copy_to_udata(udata, &cq_resp, sizeof(cq_resp))) {
             dev_warn(&dev->pdev->dev, "failed to copy back udata\n");
-            amd_emrdma_destroy_cq(&cq->ibcq, udata);
+            rocm_ernic_destroy_cq(&cq->ibcq, udata);
             return -EINVAL;
         }
     }
@@ -242,7 +242,7 @@ int amd_emrdma_create_cq(struct ib_cq *ibcq, const struct ib_cq_init_attr *attr,
     return 0;
 
 err_page_dir:
-    amd_emrdma_page_dir_cleanup(dev, &cq->pdir);
+    rocm_ernic_page_dir_cleanup(dev, &cq->pdir);
 err_umem:
     ib_umem_release(cq->umem);
 err_cq:
@@ -250,8 +250,8 @@ err_cq:
     return ret;
 }
 
-static void amd_emrdma_free_cq(struct amd_emrdma_dev *dev,
-                               struct amd_emrdma_cq *cq)
+static void rocm_ernic_free_cq(struct rocm_ernic_dev *dev,
+                               struct rocm_ernic_cq *cq)
 {
     if (refcount_dec_and_test(&cq->refcnt))
         complete(&cq->free);
@@ -259,28 +259,28 @@ static void amd_emrdma_free_cq(struct amd_emrdma_dev *dev,
 
     ib_umem_release(cq->umem);
 
-    amd_emrdma_page_dir_cleanup(dev, &cq->pdir);
+    rocm_ernic_page_dir_cleanup(dev, &cq->pdir);
 }
 
 /**
- * amd_emrdma_destroy_cq - destroy completion queue
+ * rocm_ernic_destroy_cq - destroy completion queue
  * @cq: the completion queue to destroy.
  * @udata: user data or null for kernel object
  */
-int amd_emrdma_destroy_cq(struct ib_cq *cq, struct ib_udata *udata)
+int rocm_ernic_destroy_cq(struct ib_cq *cq, struct ib_udata *udata)
 {
-    struct amd_emrdma_cq *vcq = to_vcq(cq);
-    union amd_emrdma_cmd_req req;
-    struct amd_emrdma_cmd_destroy_cq *cmd = &req.destroy_cq;
-    struct amd_emrdma_dev *dev = to_vdev(cq->device);
+    struct rocm_ernic_cq *vcq = to_vcq(cq);
+    union rocm_ernic_cmd_req req;
+    struct rocm_ernic_cmd_destroy_cq *cmd = &req.destroy_cq;
+    struct rocm_ernic_dev *dev = to_vdev(cq->device);
     unsigned long flags;
     int ret;
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_DESTROY_CQ;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_DESTROY_CQ;
     cmd->cq_handle = vcq->cq_handle;
 
-    ret = amd_emrdma_cmd_post(dev, &req, NULL, 0);
+    ret = rocm_ernic_cmd_post(dev, &req, NULL, 0);
     if (ret < 0)
         dev_warn(&dev->pdev->dev,
                  "could not destroy completion queue, error: %d\n", ret);
@@ -290,18 +290,18 @@ int amd_emrdma_destroy_cq(struct ib_cq *cq, struct ib_udata *udata)
     dev->cq_tbl[vcq->cq_handle] = NULL;
     spin_unlock_irqrestore(&dev->cq_tbl_lock, flags);
 
-    amd_emrdma_free_cq(dev, vcq);
+    rocm_ernic_free_cq(dev, vcq);
     atomic_dec(&dev->num_cqs);
     return 0;
 }
 
-static inline struct amd_emrdma_cqe *get_cqe(struct amd_emrdma_cq *cq, int i)
+static inline struct rocm_ernic_cqe *get_cqe(struct rocm_ernic_cq *cq, int i)
 {
-    return (struct amd_emrdma_cqe *)amd_emrdma_page_dir_get_ptr(
-        &cq->pdir, cq->offset + sizeof(struct amd_emrdma_cqe) * i);
+    return (struct rocm_ernic_cqe *)rocm_ernic_page_dir_get_ptr(
+        &cq->pdir, cq->offset + sizeof(struct rocm_ernic_cqe) * i);
 }
 
-void _amd_emrdma_flush_cqe(struct amd_emrdma_qp *qp, struct amd_emrdma_cq *cq)
+void _rocm_ernic_flush_cqe(struct rocm_ernic_qp *qp, struct rocm_ernic_cq *cq)
 {
     unsigned int head;
     int has_data;
@@ -311,13 +311,13 @@ void _amd_emrdma_flush_cqe(struct amd_emrdma_qp *qp, struct amd_emrdma_cq *cq)
 
     /* Lock held */
     has_data =
-        amd_emrdma_idx_ring_has_data(&cq->ring_state->rx, cq->ibcq.cqe, &head);
+        rocm_ernic_idx_ring_has_data(&cq->ring_state->rx, cq->ibcq.cqe, &head);
     if (unlikely(has_data > 0)) {
         int items;
         int curr;
-        int tail = amd_emrdma_idx(&cq->ring_state->rx.prod_tail, cq->ibcq.cqe);
-        struct amd_emrdma_cqe *cqe;
-        struct amd_emrdma_cqe *curr_cqe;
+        int tail = rocm_ernic_idx(&cq->ring_state->rx.prod_tail, cq->ibcq.cqe);
+        struct rocm_ernic_cqe *cqe;
+        struct rocm_ernic_cqe *curr_cqe;
 
         items = (tail > head) ? (tail - head) : (cq->ibcq.cqe - head + tail);
         curr = --tail;
@@ -334,7 +334,7 @@ void _amd_emrdma_flush_cqe(struct amd_emrdma_qp *qp, struct amd_emrdma_cq *cq)
                 }
                 tail--;
             } else {
-                amd_emrdma_idx_ring_inc(&cq->ring_state->rx.cons_head,
+                rocm_ernic_idx_ring_inc(&cq->ring_state->rx.cons_head,
                                         cq->ibcq.cqe);
             }
             curr--;
@@ -342,27 +342,27 @@ void _amd_emrdma_flush_cqe(struct amd_emrdma_qp *qp, struct amd_emrdma_cq *cq)
     }
 }
 
-static int amd_emrdma_poll_one(struct amd_emrdma_cq *cq,
-                               struct amd_emrdma_qp **cur_qp, struct ib_wc *wc)
+static int rocm_ernic_poll_one(struct rocm_ernic_cq *cq,
+                               struct rocm_ernic_qp **cur_qp, struct ib_wc *wc)
 {
-    struct amd_emrdma_dev *dev = to_vdev(cq->ibcq.device);
+    struct rocm_ernic_dev *dev = to_vdev(cq->ibcq.device);
     int has_data;
     unsigned int head;
     bool tried = false;
-    struct amd_emrdma_cqe *cqe;
+    struct rocm_ernic_cqe *cqe;
 
 retry:
     has_data =
-        amd_emrdma_idx_ring_has_data(&cq->ring_state->rx, cq->ibcq.cqe, &head);
+        rocm_ernic_idx_ring_has_data(&cq->ring_state->rx, cq->ibcq.cqe, &head);
     if (has_data == 0) {
         if (tried)
             return -EAGAIN;
 
-        amd_emrdma_write_uar_cq(dev, cq->cq_handle | AMD_EMRDMA_UAR_CQ_POLL);
+        rocm_ernic_write_uar_cq(dev, cq->cq_handle | ROCM_ERNIC_UAR_CQ_POLL);
 
         tried = true;
         goto retry;
-    } else if (has_data == AMD_EMRDMA_INVALID_IDX) {
+    } else if (has_data == ROCM_ERNIC_INVALID_IDX) {
         dev_err(&dev->pdev->dev, "CQ ring state invalid\n");
         return -EAGAIN;
     }
@@ -372,44 +372,44 @@ retry:
     /* Ensure cqe is valid. */
     rmb();
     if (dev->qp_tbl[cqe->qp & 0xffff])
-        *cur_qp = (struct amd_emrdma_qp *)dev->qp_tbl[cqe->qp & 0xffff];
+        *cur_qp = (struct rocm_ernic_qp *)dev->qp_tbl[cqe->qp & 0xffff];
     else
         return -EAGAIN;
 
-    wc->opcode = amd_emrdma_wc_opcode_to_ib(cqe->opcode);
-    wc->status = amd_emrdma_wc_status_to_ib(cqe->status);
+    wc->opcode = rocm_ernic_wc_opcode_to_ib(cqe->opcode);
+    wc->status = rocm_ernic_wc_status_to_ib(cqe->status);
     wc->wr_id = cqe->wr_id;
     wc->qp = &(*cur_qp)->ibqp;
     wc->byte_len = cqe->byte_len;
     wc->ex.imm_data = cqe->imm_data;
     wc->src_qp = cqe->src_qp;
-    wc->wc_flags = amd_emrdma_wc_flags_to_ib(cqe->wc_flags);
+    wc->wc_flags = rocm_ernic_wc_flags_to_ib(cqe->wc_flags);
     wc->pkey_index = cqe->pkey_index;
     wc->slid = cqe->slid;
     wc->sl = cqe->sl;
     wc->dlid_path_bits = cqe->dlid_path_bits;
     wc->port_num = cqe->port_num;
     wc->vendor_err = cqe->vendor_err;
-    wc->network_hdr_type = amd_emrdma_network_type_to_ib(cqe->network_hdr_type);
+    wc->network_hdr_type = rocm_ernic_network_type_to_ib(cqe->network_hdr_type);
 
     /* Update shared ring state */
-    amd_emrdma_idx_ring_inc(&cq->ring_state->rx.cons_head, cq->ibcq.cqe);
+    rocm_ernic_idx_ring_inc(&cq->ring_state->rx.cons_head, cq->ibcq.cqe);
 
     return 0;
 }
 
 /**
- * amd_emrdma_poll_cq - poll for work completion queue entries
+ * rocm_ernic_poll_cq - poll for work completion queue entries
  * @ibcq: completion queue
  * @num_entries: the maximum number of entries
  * @wc: pointer to work completion array
  *
  * @return: number of polled completion entries
  */
-int amd_emrdma_poll_cq(struct ib_cq *ibcq, int num_entries, struct ib_wc *wc)
+int rocm_ernic_poll_cq(struct ib_cq *ibcq, int num_entries, struct ib_wc *wc)
 {
-    struct amd_emrdma_cq *cq = to_vcq(ibcq);
-    struct amd_emrdma_qp *cur_qp = NULL;
+    struct rocm_ernic_cq *cq = to_vcq(ibcq);
+    struct rocm_ernic_qp *cur_qp = NULL;
     unsigned long flags;
     int npolled;
 
@@ -418,7 +418,7 @@ int amd_emrdma_poll_cq(struct ib_cq *ibcq, int num_entries, struct ib_wc *wc)
 
     spin_lock_irqsave(&cq->cq_lock, flags);
     for (npolled = 0; npolled < num_entries; ++npolled) {
-        if (amd_emrdma_poll_one(cq, &cur_qp, wc + npolled))
+        if (rocm_ernic_poll_one(cq, &cur_qp, wc + npolled))
             break;
     }
 

--- a/driver/rocm_ernic_dev_api.h
+++ b/driver/rocm_ernic_dev_api.h
@@ -43,27 +43,27 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __AMD_EMRDMA_DEV_API_H__
-#define __AMD_EMRDMA_DEV_API_H__
+#ifndef __ROCM_ERNIC_DEV_API_H__
+#define __ROCM_ERNIC_DEV_API_H__
 
 #include <linux/types.h>
 
 #include "rocm_ernic_verbs.h"
 
 /*
- * AMD_EMRDMA version macros. Some new features require updates to
- * AMD_EMRDMA_VERSION. These macros allow us to check for different features if
+ * ROCM_ERNIC version macros. Some new features require updates to
+ * ROCM_ERNIC_VERSION. These macros allow us to check for different features if
  * necessary.
  */
 
-#define AMD_EMRDMA_ROCEV1_VERSION   17
-#define AMD_EMRDMA_ROCEV2_VERSION   18
-#define AMD_EMRDMA_PPN64_VERSION    19
-#define AMD_EMRDMA_QPHANDLE_VERSION 20
-#define AMD_EMRDMA_VERSION          AMD_EMRDMA_QPHANDLE_VERSION
+#define ROCM_ERNIC_ROCEV1_VERSION   17
+#define ROCM_ERNIC_ROCEV2_VERSION   18
+#define ROCM_ERNIC_PPN64_VERSION    19
+#define ROCM_ERNIC_QPHANDLE_VERSION 20
+#define ROCM_ERNIC_VERSION          ROCM_ERNIC_QPHANDLE_VERSION
 
-#define AMD_EMRDMA_BOARD_ID 1
-#define AMD_EMRDMA_REV_ID   1
+#define ROCM_ERNIC_BOARD_ID 1
+#define ROCM_ERNIC_REV_ID   1
 
 /*
  * Masks and accessors for page directory, which is a two-level lookup:
@@ -72,48 +72,48 @@
  * gigabyte for memory regions and so forth.
  */
 
-#define AMD_EMRDMA_PDIR_SHIFT         18
-#define AMD_EMRDMA_PTABLE_SHIFT       9
-#define AMD_EMRDMA_PAGE_DIR_DIR(x)    (((x) >> AMD_EMRDMA_PDIR_SHIFT) & 0x1)
-#define AMD_EMRDMA_PAGE_DIR_TABLE(x)  (((x) >> AMD_EMRDMA_PTABLE_SHIFT) & 0x1ff)
-#define AMD_EMRDMA_PAGE_DIR_PAGE(x)   ((x) & 0x1ff)
-#define AMD_EMRDMA_PAGE_DIR_MAX_PAGES (1 * 512 * 512)
-#define AMD_EMRDMA_MAX_FAST_REG_PAGES 128
+#define ROCM_ERNIC_PDIR_SHIFT         18
+#define ROCM_ERNIC_PTABLE_SHIFT       9
+#define ROCM_ERNIC_PAGE_DIR_DIR(x)    (((x) >> ROCM_ERNIC_PDIR_SHIFT) & 0x1)
+#define ROCM_ERNIC_PAGE_DIR_TABLE(x)  (((x) >> ROCM_ERNIC_PTABLE_SHIFT) & 0x1ff)
+#define ROCM_ERNIC_PAGE_DIR_PAGE(x)   ((x) & 0x1ff)
+#define ROCM_ERNIC_PAGE_DIR_MAX_PAGES (1 * 512 * 512)
+#define ROCM_ERNIC_MAX_FAST_REG_PAGES 128
 
 /*
  * Max MSI-X vectors.
  */
 
-#define AMD_EMRDMA_MAX_INTERRUPTS 3
+#define ROCM_ERNIC_MAX_INTERRUPTS 3
 
 /* Register offsets within PCI resource on BAR1. */
-#define AMD_EMRDMA_REG_VERSION 0x00 /* R: Version of device. */
-#define AMD_EMRDMA_REG_DSRLOW  0x04 /* W: Device shared region low PA. */
-#define AMD_EMRDMA_REG_DSRHIGH 0x08 /* W: Device shared region high PA. */
-#define AMD_EMRDMA_REG_CTL     0x0c /* W: AMD_EMRDMA_DEVICE_CTL */
-#define AMD_EMRDMA_REG_REQUEST 0x10 /* W: Indicate device request. */
-#define AMD_EMRDMA_REG_ERR     0x14 /* R: Device error. */
-#define AMD_EMRDMA_REG_ICR     0x18 /* R: Interrupt cause. */
-#define AMD_EMRDMA_REG_IMR     0x1c /* R/W: Interrupt mask. */
-#define AMD_EMRDMA_REG_MACL    0x20 /* R/W: MAC address low. */
-#define AMD_EMRDMA_REG_MACH    0x24 /* R/W: MAC address high. */
+#define ROCM_ERNIC_REG_VERSION 0x00 /* R: Version of device. */
+#define ROCM_ERNIC_REG_DSRLOW  0x04 /* W: Device shared region low PA. */
+#define ROCM_ERNIC_REG_DSRHIGH 0x08 /* W: Device shared region high PA. */
+#define ROCM_ERNIC_REG_CTL     0x0c /* W: ROCM_ERNIC_DEVICE_CTL */
+#define ROCM_ERNIC_REG_REQUEST 0x10 /* W: Indicate device request. */
+#define ROCM_ERNIC_REG_ERR     0x14 /* R: Device error. */
+#define ROCM_ERNIC_REG_ICR     0x18 /* R: Interrupt cause. */
+#define ROCM_ERNIC_REG_IMR     0x1c /* R/W: Interrupt mask. */
+#define ROCM_ERNIC_REG_MACL    0x20 /* R/W: MAC address low. */
+#define ROCM_ERNIC_REG_MACH    0x24 /* R/W: MAC address high. */
 
 /* Object flags. */
-#define AMD_EMRDMA_CQ_FLAG_ARMED_SOL BIT(0) /* Armed for solicited-only. */
-#define AMD_EMRDMA_CQ_FLAG_ARMED     BIT(1) /* Armed. */
-#define AMD_EMRDMA_MR_FLAG_DMA       BIT(0) /* DMA region. */
-#define AMD_EMRDMA_MR_FLAG_FRMR      BIT(1) /* Fast reg memory region. */
+#define ROCM_ERNIC_CQ_FLAG_ARMED_SOL BIT(0) /* Armed for solicited-only. */
+#define ROCM_ERNIC_CQ_FLAG_ARMED     BIT(1) /* Armed. */
+#define ROCM_ERNIC_MR_FLAG_DMA       BIT(0) /* DMA region. */
+#define ROCM_ERNIC_MR_FLAG_FRMR      BIT(1) /* Fast reg memory region. */
 
 /*
  * Atomic operation capability (masked versions are extended atomic
  * operations.
  */
 
-#define AMD_EMRDMA_ATOMIC_OP_COMP_SWAP BIT(0) /* Compare and swap. */
-#define AMD_EMRDMA_ATOMIC_OP_FETCH_ADD BIT(1) /* Fetch and add. */
-#define AMD_EMRDMA_ATOMIC_OP_MASK_COMP_SWAP \
+#define ROCM_ERNIC_ATOMIC_OP_COMP_SWAP BIT(0) /* Compare and swap. */
+#define ROCM_ERNIC_ATOMIC_OP_FETCH_ADD BIT(1) /* Fetch and add. */
+#define ROCM_ERNIC_ATOMIC_OP_MASK_COMP_SWAP \
     BIT(2) /* Masked compare and swap. */
-#define AMD_EMRDMA_ATOMIC_OP_MASK_FETCH_ADD BIT(3) /* Masked fetch and add. */
+#define ROCM_ERNIC_ATOMIC_OP_MASK_FETCH_ADD BIT(3) /* Masked fetch and add. */
 
 /*
  * Base Memory Management Extension flags to support Fast Reg Memory Regions
@@ -121,9 +121,9 @@
  * must support all of them to qualify for the BMME device cap.
  */
 
-#define AMD_EMRDMA_BMME_FLAG_LOCAL_INV   BIT(0) /* Local Invalidate. */
-#define AMD_EMRDMA_BMME_FLAG_REMOTE_INV  BIT(1) /* Remote Invalidate. */
-#define AMD_EMRDMA_BMME_FLAG_FAST_REG_WR BIT(2) /* Fast Reg Work Request. */
+#define ROCM_ERNIC_BMME_FLAG_LOCAL_INV   BIT(0) /* Local Invalidate. */
+#define ROCM_ERNIC_BMME_FLAG_REMOTE_INV  BIT(1) /* Remote Invalidate. */
+#define ROCM_ERNIC_BMME_FLAG_FAST_REG_WR BIT(2) /* Fast Reg Work Request. */
 
 /*
  * GID types. The interpretation of the gid_types bit field in the device
@@ -132,86 +132,86 @@
  * defined.
  */
 
-#define AMD_EMRDMA_GID_TYPE_FLAG_ROCE_V1 BIT(0)
-#define AMD_EMRDMA_GID_TYPE_FLAG_ROCE_V2 BIT(1)
+#define ROCM_ERNIC_GID_TYPE_FLAG_ROCE_V1 BIT(0)
+#define ROCM_ERNIC_GID_TYPE_FLAG_ROCE_V2 BIT(1)
 
 /*
  * Version checks. This checks whether each version supports specific
  * capabilities from the device.
  */
 
-#define AMD_EMRDMA_IS_VERSION17(_dev)                  \
-    (_dev->dsr_version == AMD_EMRDMA_ROCEV1_VERSION && \
-     _dev->dsr->caps.gid_types == AMD_EMRDMA_GID_TYPE_FLAG_ROCE_V1)
+#define ROCM_ERNIC_IS_VERSION17(_dev)                  \
+    (_dev->dsr_version == ROCM_ERNIC_ROCEV1_VERSION && \
+     _dev->dsr->caps.gid_types == ROCM_ERNIC_GID_TYPE_FLAG_ROCE_V1)
 
-#define AMD_EMRDMA_IS_VERSION18(_dev)                                  \
-    (_dev->dsr_version >= AMD_EMRDMA_ROCEV2_VERSION &&                 \
-     (_dev->dsr->caps.gid_types == AMD_EMRDMA_GID_TYPE_FLAG_ROCE_V1 || \
-      _dev->dsr->caps.gid_types == AMD_EMRDMA_GID_TYPE_FLAG_ROCE_V2))
+#define ROCM_ERNIC_IS_VERSION18(_dev)                                  \
+    (_dev->dsr_version >= ROCM_ERNIC_ROCEV2_VERSION &&                 \
+     (_dev->dsr->caps.gid_types == ROCM_ERNIC_GID_TYPE_FLAG_ROCE_V1 || \
+      _dev->dsr->caps.gid_types == ROCM_ERNIC_GID_TYPE_FLAG_ROCE_V2))
 
-#define AMD_EMRDMA_SUPPORTED(_dev)                            \
-    ((_dev->dsr->caps.mode == AMD_EMRDMA_DEVICE_MODE_ROCE) && \
-     (AMD_EMRDMA_IS_VERSION17(_dev) || AMD_EMRDMA_IS_VERSION18(_dev)))
+#define ROCM_ERNIC_SUPPORTED(_dev)                            \
+    ((_dev->dsr->caps.mode == ROCM_ERNIC_DEVICE_MODE_ROCE) && \
+     (ROCM_ERNIC_IS_VERSION17(_dev) || ROCM_ERNIC_IS_VERSION18(_dev)))
 
 /*
  * Get capability values based on device version.
  */
 
-#define AMD_EMRDMA_GET_CAP(_dev, _old_val, _val) \
-    ((AMD_EMRDMA_IS_VERSION18(_dev)) ? _val : _old_val)
+#define ROCM_ERNIC_GET_CAP(_dev, _old_val, _val) \
+    ((ROCM_ERNIC_IS_VERSION18(_dev)) ? _val : _old_val)
 
-enum amd_emrdma_pci_resource {
-    AMD_EMRDMA_PCI_RESOURCE_MSIX, /* BAR0: MSI-X, MMIO. */
-    AMD_EMRDMA_PCI_RESOURCE_REG,  /* BAR1: Registers, MMIO. */
-    AMD_EMRDMA_PCI_RESOURCE_UAR,  /* BAR2: UAR pages, MMIO, 64-bit. */
-    AMD_EMRDMA_PCI_RESOURCE_LAST, /* Last. */
+enum rocm_ernic_pci_resource {
+    ROCM_ERNIC_PCI_RESOURCE_MSIX, /* BAR0: MSI-X, MMIO. */
+    ROCM_ERNIC_PCI_RESOURCE_REG,  /* BAR1: Registers, MMIO. */
+    ROCM_ERNIC_PCI_RESOURCE_UAR,  /* BAR2: UAR pages, MMIO, 64-bit. */
+    ROCM_ERNIC_PCI_RESOURCE_LAST, /* Last. */
 };
 
-enum amd_emrdma_device_ctl {
-    AMD_EMRDMA_DEVICE_CTL_ACTIVATE,  /* Activate device. */
-    AMD_EMRDMA_DEVICE_CTL_UNQUIESCE, /* Unquiesce device. */
-    AMD_EMRDMA_DEVICE_CTL_RESET,     /* Reset device. */
+enum rocm_ernic_device_ctl {
+    ROCM_ERNIC_DEVICE_CTL_ACTIVATE,  /* Activate device. */
+    ROCM_ERNIC_DEVICE_CTL_UNQUIESCE, /* Unquiesce device. */
+    ROCM_ERNIC_DEVICE_CTL_RESET,     /* Reset device. */
 };
 
-enum amd_emrdma_intr_vector {
-    AMD_EMRDMA_INTR_VECTOR_RESPONSE, /* Command response. */
-    AMD_EMRDMA_INTR_VECTOR_ASYNC,    /* Async events. */
-    AMD_EMRDMA_INTR_VECTOR_CQ,       /* CQ notification. */
+enum rocm_ernic_intr_vector {
+    ROCM_ERNIC_INTR_VECTOR_RESPONSE, /* Command response. */
+    ROCM_ERNIC_INTR_VECTOR_ASYNC,    /* Async events. */
+    ROCM_ERNIC_INTR_VECTOR_CQ,       /* CQ notification. */
                                      /* Additional CQ notification vectors. */
 };
 
-enum amd_emrdma_intr_cause {
-    AMD_EMRDMA_INTR_CAUSE_RESPONSE = (1 << AMD_EMRDMA_INTR_VECTOR_RESPONSE),
-    AMD_EMRDMA_INTR_CAUSE_ASYNC = (1 << AMD_EMRDMA_INTR_VECTOR_ASYNC),
-    AMD_EMRDMA_INTR_CAUSE_CQ = (1 << AMD_EMRDMA_INTR_VECTOR_CQ),
+enum rocm_ernic_intr_cause {
+    ROCM_ERNIC_INTR_CAUSE_RESPONSE = (1 << ROCM_ERNIC_INTR_VECTOR_RESPONSE),
+    ROCM_ERNIC_INTR_CAUSE_ASYNC = (1 << ROCM_ERNIC_INTR_VECTOR_ASYNC),
+    ROCM_ERNIC_INTR_CAUSE_CQ = (1 << ROCM_ERNIC_INTR_VECTOR_CQ),
 };
 
-enum amd_emrdma_gos_bits {
-    AMD_EMRDMA_GOS_BITS_UNK, /* Unknown. */
-    AMD_EMRDMA_GOS_BITS_32,  /* 32-bit. */
-    AMD_EMRDMA_GOS_BITS_64,  /* 64-bit. */
+enum rocm_ernic_gos_bits {
+    ROCM_ERNIC_GOS_BITS_UNK, /* Unknown. */
+    ROCM_ERNIC_GOS_BITS_32,  /* 32-bit. */
+    ROCM_ERNIC_GOS_BITS_64,  /* 64-bit. */
 };
 
-enum amd_emrdma_gos_type {
-    AMD_EMRDMA_GOS_TYPE_UNK,   /* Unknown. */
-    AMD_EMRDMA_GOS_TYPE_LINUX, /* Linux. */
+enum rocm_ernic_gos_type {
+    ROCM_ERNIC_GOS_TYPE_UNK,   /* Unknown. */
+    ROCM_ERNIC_GOS_TYPE_LINUX, /* Linux. */
 };
 
-enum amd_emrdma_device_mode {
-    AMD_EMRDMA_DEVICE_MODE_ROCE,  /* RoCE. */
-    AMD_EMRDMA_DEVICE_MODE_IWARP, /* iWarp. */
-    AMD_EMRDMA_DEVICE_MODE_IB,    /* InfiniBand. */
+enum rocm_ernic_device_mode {
+    ROCM_ERNIC_DEVICE_MODE_ROCE,  /* RoCE. */
+    ROCM_ERNIC_DEVICE_MODE_IWARP, /* iWarp. */
+    ROCM_ERNIC_DEVICE_MODE_IB,    /* InfiniBand. */
 };
 
-struct amd_emrdma_gos_info {
-    u32 gos_bits : 2;  /* W: AMD_EMRDMA_GOS_BITS_ */
-    u32 gos_type : 4;  /* W: AMD_EMRDMA_GOS_TYPE_ */
+struct rocm_ernic_gos_info {
+    u32 gos_bits : 2;  /* W: ROCM_ERNIC_GOS_BITS_ */
+    u32 gos_type : 4;  /* W: ROCM_ERNIC_GOS_TYPE_ */
     u32 gos_ver : 16;  /* W: Guest OS version. */
     u32 gos_misc : 10; /* W: Other. */
     u32 pad;           /* Pad to 8-byte alignment. */
 };
 
-struct amd_emrdma_device_caps {
+struct rocm_ernic_device_caps {
     u64 fw_ver; /* R: Query device. */
     __be64 node_guid;
     __be64 sys_image_guid;
@@ -258,14 +258,14 @@ struct amd_emrdma_device_caps {
     u16 max_pkeys;
     u8 local_ca_ack_delay;
     u8 phys_port_cnt;
-    u8 mode;       /* AMD_EMRDMA_DEVICE_MODE_ */
-    u8 atomic_ops; /* AMD_EMRDMA_ATOMIC_OP_* bits */
+    u8 mode;       /* ROCM_ERNIC_DEVICE_MODE_ */
+    u8 atomic_ops; /* ROCM_ERNIC_ATOMIC_OP_* bits */
     u8 bmme_flags; /* FRWR Mem Mgmt Extensions */
-    u8 gid_types;  /* AMD_EMRDMA_GID_TYPE_FLAG_ */
+    u8 gid_types;  /* ROCM_ERNIC_GID_TYPE_FLAG_ */
     u32 max_fast_reg_page_list_len;
 };
 
-struct amd_emrdma_ring_page_info {
+struct rocm_ernic_ring_page_info {
     u32 num_pages; /* Num pages incl. header. */
     u32 reserved;  /* Reserved. */
     u64 pdir_dma;  /* Page directory PA. */
@@ -273,188 +273,188 @@ struct amd_emrdma_ring_page_info {
 
 #pragma pack(push, 1)
 
-struct amd_emrdma_device_shared_region {
+struct rocm_ernic_device_shared_region {
     u32 driver_version;                  /* W: Driver version. */
     u32 pad;                             /* Pad to 8-byte align. */
-    struct amd_emrdma_gos_info gos_info; /* W: Guest OS information. */
+    struct rocm_ernic_gos_info gos_info; /* W: Guest OS information. */
     u64 cmd_slot_dma;                    /* W: Command slot address. */
     u64 resp_slot_dma;                   /* W: Response slot address. */
-    struct amd_emrdma_ring_page_info async_ring_pages;
+    struct rocm_ernic_ring_page_info async_ring_pages;
     /* W: Async ring page info. */
-    struct amd_emrdma_ring_page_info cq_ring_pages;
+    struct rocm_ernic_ring_page_info cq_ring_pages;
     /* W: CQ ring page info. */
     union {
         u32 uar_pfn;   /* W: UAR pageframe. */
         u64 uar_pfn64; /* W: 64-bit UAR page frame. */
     };
-    struct amd_emrdma_device_caps caps; /* R: Device capabilities. */
+    struct rocm_ernic_device_caps caps; /* R: Device capabilities. */
 };
 
 #pragma pack(pop)
 
 /* Event types. Currently a 1:1 mapping with enum ib_event. */
-enum amd_emrdma_eqe_type {
-    AMD_EMRDMA_EVENT_CQ_ERR,
-    AMD_EMRDMA_EVENT_QP_FATAL,
-    AMD_EMRDMA_EVENT_QP_REQ_ERR,
-    AMD_EMRDMA_EVENT_QP_ACCESS_ERR,
-    AMD_EMRDMA_EVENT_COMM_EST,
-    AMD_EMRDMA_EVENT_SQ_DRAINED,
-    AMD_EMRDMA_EVENT_PATH_MIG,
-    AMD_EMRDMA_EVENT_PATH_MIG_ERR,
-    AMD_EMRDMA_EVENT_DEVICE_FATAL,
-    AMD_EMRDMA_EVENT_PORT_ACTIVE,
-    AMD_EMRDMA_EVENT_PORT_ERR,
-    AMD_EMRDMA_EVENT_LID_CHANGE,
-    AMD_EMRDMA_EVENT_PKEY_CHANGE,
-    AMD_EMRDMA_EVENT_SM_CHANGE,
-    AMD_EMRDMA_EVENT_SRQ_ERR,
-    AMD_EMRDMA_EVENT_SRQ_LIMIT_REACHED,
-    AMD_EMRDMA_EVENT_QP_LAST_WQE_REACHED,
-    AMD_EMRDMA_EVENT_CLIENT_REREGISTER,
-    AMD_EMRDMA_EVENT_GID_CHANGE,
+enum rocm_ernic_eqe_type {
+    ROCM_ERNIC_EVENT_CQ_ERR,
+    ROCM_ERNIC_EVENT_QP_FATAL,
+    ROCM_ERNIC_EVENT_QP_REQ_ERR,
+    ROCM_ERNIC_EVENT_QP_ACCESS_ERR,
+    ROCM_ERNIC_EVENT_COMM_EST,
+    ROCM_ERNIC_EVENT_SQ_DRAINED,
+    ROCM_ERNIC_EVENT_PATH_MIG,
+    ROCM_ERNIC_EVENT_PATH_MIG_ERR,
+    ROCM_ERNIC_EVENT_DEVICE_FATAL,
+    ROCM_ERNIC_EVENT_PORT_ACTIVE,
+    ROCM_ERNIC_EVENT_PORT_ERR,
+    ROCM_ERNIC_EVENT_LID_CHANGE,
+    ROCM_ERNIC_EVENT_PKEY_CHANGE,
+    ROCM_ERNIC_EVENT_SM_CHANGE,
+    ROCM_ERNIC_EVENT_SRQ_ERR,
+    ROCM_ERNIC_EVENT_SRQ_LIMIT_REACHED,
+    ROCM_ERNIC_EVENT_QP_LAST_WQE_REACHED,
+    ROCM_ERNIC_EVENT_CLIENT_REREGISTER,
+    ROCM_ERNIC_EVENT_GID_CHANGE,
 };
 
 /* Event queue element. */
-struct amd_emrdma_eqe {
+struct rocm_ernic_eqe {
     u32 type; /* Event type. */
     u32 info; /* Handle, other. */
 };
 
 /* CQ notification queue element. */
-struct amd_emrdma_cqne {
+struct rocm_ernic_cqne {
     u32 info; /* Handle */
 };
 
 enum {
-    AMD_EMRDMA_CMD_FIRST,
-    AMD_EMRDMA_CMD_QUERY_PORT = AMD_EMRDMA_CMD_FIRST,
-    AMD_EMRDMA_CMD_QUERY_PKEY,
-    AMD_EMRDMA_CMD_CREATE_PD,
-    AMD_EMRDMA_CMD_DESTROY_PD,
-    AMD_EMRDMA_CMD_CREATE_MR,
-    AMD_EMRDMA_CMD_DESTROY_MR,
-    AMD_EMRDMA_CMD_CREATE_CQ,
-    AMD_EMRDMA_CMD_RESIZE_CQ,
-    AMD_EMRDMA_CMD_DESTROY_CQ,
-    AMD_EMRDMA_CMD_CREATE_QP,
-    AMD_EMRDMA_CMD_MODIFY_QP,
-    AMD_EMRDMA_CMD_QUERY_QP,
-    AMD_EMRDMA_CMD_DESTROY_QP,
-    AMD_EMRDMA_CMD_CREATE_UC,
-    AMD_EMRDMA_CMD_DESTROY_UC,
-    AMD_EMRDMA_CMD_CREATE_BIND,
-    AMD_EMRDMA_CMD_DESTROY_BIND,
-    AMD_EMRDMA_CMD_CREATE_SRQ,
-    AMD_EMRDMA_CMD_MODIFY_SRQ,
-    AMD_EMRDMA_CMD_QUERY_SRQ,
-    AMD_EMRDMA_CMD_DESTROY_SRQ,
-    AMD_EMRDMA_CMD_MAX,
+    ROCM_ERNIC_CMD_FIRST,
+    ROCM_ERNIC_CMD_QUERY_PORT = ROCM_ERNIC_CMD_FIRST,
+    ROCM_ERNIC_CMD_QUERY_PKEY,
+    ROCM_ERNIC_CMD_CREATE_PD,
+    ROCM_ERNIC_CMD_DESTROY_PD,
+    ROCM_ERNIC_CMD_CREATE_MR,
+    ROCM_ERNIC_CMD_DESTROY_MR,
+    ROCM_ERNIC_CMD_CREATE_CQ,
+    ROCM_ERNIC_CMD_RESIZE_CQ,
+    ROCM_ERNIC_CMD_DESTROY_CQ,
+    ROCM_ERNIC_CMD_CREATE_QP,
+    ROCM_ERNIC_CMD_MODIFY_QP,
+    ROCM_ERNIC_CMD_QUERY_QP,
+    ROCM_ERNIC_CMD_DESTROY_QP,
+    ROCM_ERNIC_CMD_CREATE_UC,
+    ROCM_ERNIC_CMD_DESTROY_UC,
+    ROCM_ERNIC_CMD_CREATE_BIND,
+    ROCM_ERNIC_CMD_DESTROY_BIND,
+    ROCM_ERNIC_CMD_CREATE_SRQ,
+    ROCM_ERNIC_CMD_MODIFY_SRQ,
+    ROCM_ERNIC_CMD_QUERY_SRQ,
+    ROCM_ERNIC_CMD_DESTROY_SRQ,
+    ROCM_ERNIC_CMD_MAX,
 };
 
 enum {
-    AMD_EMRDMA_CMD_FIRST_RESP = (1 << 31),
-    AMD_EMRDMA_CMD_QUERY_PORT_RESP = AMD_EMRDMA_CMD_FIRST_RESP,
-    AMD_EMRDMA_CMD_QUERY_PKEY_RESP,
-    AMD_EMRDMA_CMD_CREATE_PD_RESP,
-    AMD_EMRDMA_CMD_DESTROY_PD_RESP_NOOP,
-    AMD_EMRDMA_CMD_CREATE_MR_RESP,
-    AMD_EMRDMA_CMD_DESTROY_MR_RESP_NOOP,
-    AMD_EMRDMA_CMD_CREATE_CQ_RESP,
-    AMD_EMRDMA_CMD_RESIZE_CQ_RESP,
-    AMD_EMRDMA_CMD_DESTROY_CQ_RESP_NOOP,
-    AMD_EMRDMA_CMD_CREATE_QP_RESP,
-    AMD_EMRDMA_CMD_MODIFY_QP_RESP,
-    AMD_EMRDMA_CMD_QUERY_QP_RESP,
-    AMD_EMRDMA_CMD_DESTROY_QP_RESP,
-    AMD_EMRDMA_CMD_CREATE_UC_RESP,
-    AMD_EMRDMA_CMD_DESTROY_UC_RESP_NOOP,
-    AMD_EMRDMA_CMD_CREATE_BIND_RESP_NOOP,
-    AMD_EMRDMA_CMD_DESTROY_BIND_RESP_NOOP,
-    AMD_EMRDMA_CMD_CREATE_SRQ_RESP,
-    AMD_EMRDMA_CMD_MODIFY_SRQ_RESP,
-    AMD_EMRDMA_CMD_QUERY_SRQ_RESP,
-    AMD_EMRDMA_CMD_DESTROY_SRQ_RESP,
-    AMD_EMRDMA_CMD_MAX_RESP,
+    ROCM_ERNIC_CMD_FIRST_RESP = (1 << 31),
+    ROCM_ERNIC_CMD_QUERY_PORT_RESP = ROCM_ERNIC_CMD_FIRST_RESP,
+    ROCM_ERNIC_CMD_QUERY_PKEY_RESP,
+    ROCM_ERNIC_CMD_CREATE_PD_RESP,
+    ROCM_ERNIC_CMD_DESTROY_PD_RESP_NOOP,
+    ROCM_ERNIC_CMD_CREATE_MR_RESP,
+    ROCM_ERNIC_CMD_DESTROY_MR_RESP_NOOP,
+    ROCM_ERNIC_CMD_CREATE_CQ_RESP,
+    ROCM_ERNIC_CMD_RESIZE_CQ_RESP,
+    ROCM_ERNIC_CMD_DESTROY_CQ_RESP_NOOP,
+    ROCM_ERNIC_CMD_CREATE_QP_RESP,
+    ROCM_ERNIC_CMD_MODIFY_QP_RESP,
+    ROCM_ERNIC_CMD_QUERY_QP_RESP,
+    ROCM_ERNIC_CMD_DESTROY_QP_RESP,
+    ROCM_ERNIC_CMD_CREATE_UC_RESP,
+    ROCM_ERNIC_CMD_DESTROY_UC_RESP_NOOP,
+    ROCM_ERNIC_CMD_CREATE_BIND_RESP_NOOP,
+    ROCM_ERNIC_CMD_DESTROY_BIND_RESP_NOOP,
+    ROCM_ERNIC_CMD_CREATE_SRQ_RESP,
+    ROCM_ERNIC_CMD_MODIFY_SRQ_RESP,
+    ROCM_ERNIC_CMD_QUERY_SRQ_RESP,
+    ROCM_ERNIC_CMD_DESTROY_SRQ_RESP,
+    ROCM_ERNIC_CMD_MAX_RESP,
 };
 
-struct amd_emrdma_cmd_hdr {
+struct rocm_ernic_cmd_hdr {
     u64 response; /* Key for response lookup. */
-    u32 cmd;      /* AMD_EMRDMA_CMD_ */
+    u32 cmd;      /* ROCM_ERNIC_CMD_ */
     u32 reserved; /* Reserved. */
 };
 
-struct amd_emrdma_cmd_resp_hdr {
+struct rocm_ernic_cmd_resp_hdr {
     u64 response;   /* From cmd hdr. */
-    u32 ack;        /* AMD_EMRDMA_CMD_XXX_RESP */
+    u32 ack;        /* ROCM_ERNIC_CMD_XXX_RESP */
     u8 err;         /* Error. */
     u8 reserved[3]; /* Reserved. */
 };
 
-struct amd_emrdma_cmd_query_port {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_query_port {
+    struct rocm_ernic_cmd_hdr hdr;
     u8 port_num;
     u8 reserved[7];
 };
 
-struct amd_emrdma_cmd_query_port_resp {
-    struct amd_emrdma_cmd_resp_hdr hdr;
-    struct amd_emrdma_port_attr attrs;
+struct rocm_ernic_cmd_query_port_resp {
+    struct rocm_ernic_cmd_resp_hdr hdr;
+    struct rocm_ernic_port_attr attrs;
 };
 
-struct amd_emrdma_cmd_query_pkey {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_query_pkey {
+    struct rocm_ernic_cmd_hdr hdr;
     u8 port_num;
     u8 index;
     u8 reserved[6];
 };
 
-struct amd_emrdma_cmd_query_pkey_resp {
-    struct amd_emrdma_cmd_resp_hdr hdr;
+struct rocm_ernic_cmd_query_pkey_resp {
+    struct rocm_ernic_cmd_resp_hdr hdr;
     u16 pkey;
     u8 reserved[6];
 };
 
-struct amd_emrdma_cmd_create_uc {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_create_uc {
+    struct rocm_ernic_cmd_hdr hdr;
     union {
         u32 pfn;   /* UAR page frame number */
         u64 pfn64; /* 64-bit UAR page frame number */
     };
 };
 
-struct amd_emrdma_cmd_create_uc_resp {
-    struct amd_emrdma_cmd_resp_hdr hdr;
+struct rocm_ernic_cmd_create_uc_resp {
+    struct rocm_ernic_cmd_resp_hdr hdr;
     u32 ctx_handle;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_destroy_uc {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_destroy_uc {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 ctx_handle;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_create_pd {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_create_pd {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 ctx_handle;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_create_pd_resp {
-    struct amd_emrdma_cmd_resp_hdr hdr;
+struct rocm_ernic_cmd_create_pd_resp {
+    struct rocm_ernic_cmd_resp_hdr hdr;
     u32 pd_handle;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_destroy_pd {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_destroy_pd {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 pd_handle;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_create_mr {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_create_mr {
+    struct rocm_ernic_cmd_hdr hdr;
     u64 start;
     u64 length;
     u64 pdir_dma;
@@ -464,22 +464,22 @@ struct amd_emrdma_cmd_create_mr {
     u32 nchunks;
 };
 
-struct amd_emrdma_cmd_create_mr_resp {
-    struct amd_emrdma_cmd_resp_hdr hdr;
+struct rocm_ernic_cmd_create_mr_resp {
+    struct rocm_ernic_cmd_resp_hdr hdr;
     u32 mr_handle;
     u32 lkey;
     u32 rkey;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_destroy_mr {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_destroy_mr {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 mr_handle;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_create_cq {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_create_cq {
+    struct rocm_ernic_cmd_hdr hdr;
     u64 pdir_dma;
     u32 ctx_handle;
     u32 cqe;
@@ -487,72 +487,72 @@ struct amd_emrdma_cmd_create_cq {
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_create_cq_resp {
-    struct amd_emrdma_cmd_resp_hdr hdr;
+struct rocm_ernic_cmd_create_cq_resp {
+    struct rocm_ernic_cmd_resp_hdr hdr;
     u32 cq_handle;
     u32 cqe;
 };
 
-struct amd_emrdma_cmd_resize_cq {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_resize_cq {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 cq_handle;
     u32 cqe;
 };
 
-struct amd_emrdma_cmd_resize_cq_resp {
-    struct amd_emrdma_cmd_resp_hdr hdr;
+struct rocm_ernic_cmd_resize_cq_resp {
+    struct rocm_ernic_cmd_resp_hdr hdr;
     u32 cqe;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_destroy_cq {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_destroy_cq {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 cq_handle;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_create_srq {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_create_srq {
+    struct rocm_ernic_cmd_hdr hdr;
     u64 pdir_dma;
     u32 pd_handle;
     u32 nchunks;
-    struct amd_emrdma_srq_attr attrs;
+    struct rocm_ernic_srq_attr attrs;
     u8 srq_type;
     u8 reserved[7];
 };
 
-struct amd_emrdma_cmd_create_srq_resp {
-    struct amd_emrdma_cmd_resp_hdr hdr;
+struct rocm_ernic_cmd_create_srq_resp {
+    struct rocm_ernic_cmd_resp_hdr hdr;
     u32 srqn;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_modify_srq {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_modify_srq {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 srq_handle;
     u32 attr_mask;
-    struct amd_emrdma_srq_attr attrs;
+    struct rocm_ernic_srq_attr attrs;
 };
 
-struct amd_emrdma_cmd_query_srq {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_query_srq {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 srq_handle;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_query_srq_resp {
-    struct amd_emrdma_cmd_resp_hdr hdr;
-    struct amd_emrdma_srq_attr attrs;
+struct rocm_ernic_cmd_query_srq_resp {
+    struct rocm_ernic_cmd_resp_hdr hdr;
+    struct rocm_ernic_srq_attr attrs;
 };
 
-struct amd_emrdma_cmd_destroy_srq {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_destroy_srq {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 srq_handle;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_create_qp {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_create_qp {
+    struct rocm_ernic_cmd_hdr hdr;
     u64 pdir_dma;
     u32 pd_handle;
     u32 send_cq_handle;
@@ -574,8 +574,8 @@ struct amd_emrdma_cmd_create_qp {
     u8 reserved[3];
 };
 
-struct amd_emrdma_cmd_create_qp_resp {
-    struct amd_emrdma_cmd_resp_hdr hdr;
+struct rocm_ernic_cmd_create_qp_resp {
+    struct rocm_ernic_cmd_resp_hdr hdr;
     u32 qpn;
     u32 max_send_wr;
     u32 max_recv_wr;
@@ -584,8 +584,8 @@ struct amd_emrdma_cmd_create_qp_resp {
     u32 max_inline_data;
 };
 
-struct amd_emrdma_cmd_create_qp_resp_v2 {
-    struct amd_emrdma_cmd_resp_hdr hdr;
+struct rocm_ernic_cmd_create_qp_resp_v2 {
+    struct rocm_ernic_cmd_resp_hdr hdr;
     u32 qpn;
     u32 qp_handle;
     u32 max_send_wr;
@@ -595,38 +595,38 @@ struct amd_emrdma_cmd_create_qp_resp_v2 {
     u32 max_inline_data;
 };
 
-struct amd_emrdma_cmd_modify_qp {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_modify_qp {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 qp_handle;
     u32 attr_mask;
-    struct amd_emrdma_qp_attr attrs;
+    struct rocm_ernic_qp_attr attrs;
 };
 
-struct amd_emrdma_cmd_query_qp {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_query_qp {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 qp_handle;
     u32 attr_mask;
 };
 
-struct amd_emrdma_cmd_query_qp_resp {
-    struct amd_emrdma_cmd_resp_hdr hdr;
-    struct amd_emrdma_qp_attr attrs;
+struct rocm_ernic_cmd_query_qp_resp {
+    struct rocm_ernic_cmd_resp_hdr hdr;
+    struct rocm_ernic_qp_attr attrs;
 };
 
-struct amd_emrdma_cmd_destroy_qp {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_destroy_qp {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 qp_handle;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_destroy_qp_resp {
-    struct amd_emrdma_cmd_resp_hdr hdr;
+struct rocm_ernic_cmd_destroy_qp_resp {
+    struct rocm_ernic_cmd_resp_hdr hdr;
     u32 events_reported;
     u8 reserved[4];
 };
 
-struct amd_emrdma_cmd_create_bind {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_create_bind {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 mtu;
     u32 vlan;
     u32 index;
@@ -635,53 +635,53 @@ struct amd_emrdma_cmd_create_bind {
     u8 reserved[3];
 };
 
-struct amd_emrdma_cmd_destroy_bind {
-    struct amd_emrdma_cmd_hdr hdr;
+struct rocm_ernic_cmd_destroy_bind {
+    struct rocm_ernic_cmd_hdr hdr;
     u32 index;
     u8 dest_gid[16];
     u8 reserved[4];
 };
 
-union amd_emrdma_cmd_req {
-    struct amd_emrdma_cmd_hdr hdr;
-    struct amd_emrdma_cmd_query_port query_port;
-    struct amd_emrdma_cmd_query_pkey query_pkey;
-    struct amd_emrdma_cmd_create_uc create_uc;
-    struct amd_emrdma_cmd_destroy_uc destroy_uc;
-    struct amd_emrdma_cmd_create_pd create_pd;
-    struct amd_emrdma_cmd_destroy_pd destroy_pd;
-    struct amd_emrdma_cmd_create_mr create_mr;
-    struct amd_emrdma_cmd_destroy_mr destroy_mr;
-    struct amd_emrdma_cmd_create_cq create_cq;
-    struct amd_emrdma_cmd_resize_cq resize_cq;
-    struct amd_emrdma_cmd_destroy_cq destroy_cq;
-    struct amd_emrdma_cmd_create_qp create_qp;
-    struct amd_emrdma_cmd_modify_qp modify_qp;
-    struct amd_emrdma_cmd_query_qp query_qp;
-    struct amd_emrdma_cmd_destroy_qp destroy_qp;
-    struct amd_emrdma_cmd_create_bind create_bind;
-    struct amd_emrdma_cmd_destroy_bind destroy_bind;
-    struct amd_emrdma_cmd_create_srq create_srq;
-    struct amd_emrdma_cmd_modify_srq modify_srq;
-    struct amd_emrdma_cmd_query_srq query_srq;
-    struct amd_emrdma_cmd_destroy_srq destroy_srq;
+union rocm_ernic_cmd_req {
+    struct rocm_ernic_cmd_hdr hdr;
+    struct rocm_ernic_cmd_query_port query_port;
+    struct rocm_ernic_cmd_query_pkey query_pkey;
+    struct rocm_ernic_cmd_create_uc create_uc;
+    struct rocm_ernic_cmd_destroy_uc destroy_uc;
+    struct rocm_ernic_cmd_create_pd create_pd;
+    struct rocm_ernic_cmd_destroy_pd destroy_pd;
+    struct rocm_ernic_cmd_create_mr create_mr;
+    struct rocm_ernic_cmd_destroy_mr destroy_mr;
+    struct rocm_ernic_cmd_create_cq create_cq;
+    struct rocm_ernic_cmd_resize_cq resize_cq;
+    struct rocm_ernic_cmd_destroy_cq destroy_cq;
+    struct rocm_ernic_cmd_create_qp create_qp;
+    struct rocm_ernic_cmd_modify_qp modify_qp;
+    struct rocm_ernic_cmd_query_qp query_qp;
+    struct rocm_ernic_cmd_destroy_qp destroy_qp;
+    struct rocm_ernic_cmd_create_bind create_bind;
+    struct rocm_ernic_cmd_destroy_bind destroy_bind;
+    struct rocm_ernic_cmd_create_srq create_srq;
+    struct rocm_ernic_cmd_modify_srq modify_srq;
+    struct rocm_ernic_cmd_query_srq query_srq;
+    struct rocm_ernic_cmd_destroy_srq destroy_srq;
 };
 
-union amd_emrdma_cmd_resp {
-    struct amd_emrdma_cmd_resp_hdr hdr;
-    struct amd_emrdma_cmd_query_port_resp query_port_resp;
-    struct amd_emrdma_cmd_query_pkey_resp query_pkey_resp;
-    struct amd_emrdma_cmd_create_uc_resp create_uc_resp;
-    struct amd_emrdma_cmd_create_pd_resp create_pd_resp;
-    struct amd_emrdma_cmd_create_mr_resp create_mr_resp;
-    struct amd_emrdma_cmd_create_cq_resp create_cq_resp;
-    struct amd_emrdma_cmd_resize_cq_resp resize_cq_resp;
-    struct amd_emrdma_cmd_create_qp_resp create_qp_resp;
-    struct amd_emrdma_cmd_create_qp_resp_v2 create_qp_resp_v2;
-    struct amd_emrdma_cmd_query_qp_resp query_qp_resp;
-    struct amd_emrdma_cmd_destroy_qp_resp destroy_qp_resp;
-    struct amd_emrdma_cmd_create_srq_resp create_srq_resp;
-    struct amd_emrdma_cmd_query_srq_resp query_srq_resp;
+union rocm_ernic_cmd_resp {
+    struct rocm_ernic_cmd_resp_hdr hdr;
+    struct rocm_ernic_cmd_query_port_resp query_port_resp;
+    struct rocm_ernic_cmd_query_pkey_resp query_pkey_resp;
+    struct rocm_ernic_cmd_create_uc_resp create_uc_resp;
+    struct rocm_ernic_cmd_create_pd_resp create_pd_resp;
+    struct rocm_ernic_cmd_create_mr_resp create_mr_resp;
+    struct rocm_ernic_cmd_create_cq_resp create_cq_resp;
+    struct rocm_ernic_cmd_resize_cq_resp resize_cq_resp;
+    struct rocm_ernic_cmd_create_qp_resp create_qp_resp;
+    struct rocm_ernic_cmd_create_qp_resp_v2 create_qp_resp_v2;
+    struct rocm_ernic_cmd_query_qp_resp query_qp_resp;
+    struct rocm_ernic_cmd_destroy_qp_resp destroy_qp_resp;
+    struct rocm_ernic_cmd_create_srq_resp create_srq_resp;
+    struct rocm_ernic_cmd_query_srq_resp query_srq_resp;
 };
 
-#endif /* __AMD_EMRDMA_DEV_API_H__ */
+#endif /* __ROCM_ERNIC_DEV_API_H__ */

--- a/driver/rocm_ernic_doorbell.c
+++ b/driver/rocm_ernic_doorbell.c
@@ -49,11 +49,11 @@
 
 #include "rocm_ernic.h"
 
-int amd_emrdma_uar_table_init(struct amd_emrdma_dev *dev)
+int rocm_ernic_uar_table_init(struct rocm_ernic_dev *dev)
 {
     u32 num = dev->dsr->caps.max_uar;
     u32 mask = num - 1;
-    struct amd_emrdma_id_table *tbl = &dev->uar_table.tbl;
+    struct rocm_ernic_id_table *tbl = &dev->uar_table.tbl;
 
     if (!is_power_of_2(num))
         return -EINVAL;
@@ -73,17 +73,17 @@ int amd_emrdma_uar_table_init(struct amd_emrdma_dev *dev)
     return 0;
 }
 
-void amd_emrdma_uar_table_cleanup(struct amd_emrdma_dev *dev)
+void rocm_ernic_uar_table_cleanup(struct rocm_ernic_dev *dev)
 {
-    struct amd_emrdma_id_table *tbl = &dev->uar_table.tbl;
+    struct rocm_ernic_id_table *tbl = &dev->uar_table.tbl;
 
     bitmap_free(tbl->table);
 }
 
-int amd_emrdma_uar_alloc(struct amd_emrdma_dev *dev,
-                         struct amd_emrdma_uar_map *uar)
+int rocm_ernic_uar_alloc(struct rocm_ernic_dev *dev,
+                         struct rocm_ernic_uar_map *uar)
 {
-    struct amd_emrdma_id_table *tbl;
+    struct rocm_ernic_id_table *tbl;
     unsigned long flags;
     u32 obj;
 
@@ -107,17 +107,17 @@ int amd_emrdma_uar_alloc(struct amd_emrdma_dev *dev,
     spin_unlock_irqrestore(&tbl->lock, flags);
 
     uar->index = obj;
-    uar->pfn = (pci_resource_start(dev->pdev, AMD_EMRDMA_PCI_RESOURCE_UAR) >>
+    uar->pfn = (pci_resource_start(dev->pdev, ROCM_ERNIC_PCI_RESOURCE_UAR) >>
                 PAGE_SHIFT) +
                uar->index;
 
     return 0;
 }
 
-void amd_emrdma_uar_free(struct amd_emrdma_dev *dev,
-                         struct amd_emrdma_uar_map *uar)
+void rocm_ernic_uar_free(struct rocm_ernic_dev *dev,
+                         struct rocm_ernic_uar_map *uar)
 {
-    struct amd_emrdma_id_table *tbl = &dev->uar_table.tbl;
+    struct rocm_ernic_id_table *tbl = &dev->uar_table.tbl;
     unsigned long flags;
     u32 obj;
 

--- a/driver/rocm_ernic_main.c
+++ b/driver/rocm_ernic_main.c
@@ -55,7 +55,7 @@
 
 #include "rocm_ernic.h"
 
-#define DRV_NAME    "amd_emrdma"
+#define DRV_NAME    "rocm_ernic"
 #define DRV_VERSION "1.0.1.0-k"
 
 /* Kernel compatibility: PCI_IRQ_LEGACY was renamed to PCI_IRQ_INTX in 5.17 */
@@ -63,59 +63,59 @@
 #define PCI_IRQ_INTX PCI_IRQ_LEGACY
 #endif
 
-static DEFINE_MUTEX(amd_emrdma_device_list_lock);
-static LIST_HEAD(amd_emrdma_device_list);
+static DEFINE_MUTEX(rocm_ernic_device_list_lock);
+static LIST_HEAD(rocm_ernic_device_list);
 static struct workqueue_struct *event_wq;
 
-static int amd_emrdma_add_gid(const struct ib_gid_attr *attr, void **context);
-static int amd_emrdma_del_gid(const struct ib_gid_attr *attr, void **context);
-static int amd_emrdma_add_gid_at_index(struct amd_emrdma_dev *dev,
+static int rocm_ernic_add_gid(const struct ib_gid_attr *attr, void **context);
+static int rocm_ernic_del_gid(const struct ib_gid_attr *attr, void **context);
+static int rocm_ernic_add_gid_at_index(struct rocm_ernic_dev *dev,
                                        const union ib_gid *gid, u8 gid_type,
                                        int index);
 
 static ssize_t hca_type_show(struct device *device,
                              struct device_attribute *attr, char *buf)
 {
-    return sysfs_emit(buf, "AMD_EMRDMA-%s\n", DRV_VERSION);
+    return sysfs_emit(buf, "ROCM_ERNIC-%s\n", DRV_VERSION);
 }
 static DEVICE_ATTR_RO(hca_type);
 
 static ssize_t hw_rev_show(struct device *device, struct device_attribute *attr,
                            char *buf)
 {
-    return sysfs_emit(buf, "%d\n", AMD_EMRDMA_REV_ID);
+    return sysfs_emit(buf, "%d\n", ROCM_ERNIC_REV_ID);
 }
 static DEVICE_ATTR_RO(hw_rev);
 
 static ssize_t board_id_show(struct device *device,
                              struct device_attribute *attr, char *buf)
 {
-    return sysfs_emit(buf, "%d\n", AMD_EMRDMA_BOARD_ID);
+    return sysfs_emit(buf, "%d\n", ROCM_ERNIC_BOARD_ID);
 }
 static DEVICE_ATTR_RO(board_id);
 
-static struct attribute *amd_emrdma_class_attributes[] = {
+static struct attribute *rocm_ernic_class_attributes[] = {
     &dev_attr_hw_rev.attr,
     &dev_attr_hca_type.attr,
     &dev_attr_board_id.attr,
     NULL,
 };
 
-static const struct attribute_group amd_emrdma_attr_group = {
-    .attrs = amd_emrdma_class_attributes,
+static const struct attribute_group rocm_ernic_attr_group = {
+    .attrs = rocm_ernic_class_attributes,
 };
 
-static void amd_emrdma_get_fw_ver_str(struct ib_device *device, char *str)
+static void rocm_ernic_get_fw_ver_str(struct ib_device *device, char *str)
 {
-    struct amd_emrdma_dev *dev =
-        container_of(device, struct amd_emrdma_dev, ib_dev);
+    struct rocm_ernic_dev *dev =
+        container_of(device, struct rocm_ernic_dev, ib_dev);
     snprintf(str, IB_FW_VERSION_NAME_MAX, "%d.%d.%d\n",
              (int)(dev->dsr->caps.fw_ver >> 32),
              (int)(dev->dsr->caps.fw_ver >> 16) & 0xffff,
              (int)dev->dsr->caps.fw_ver & 0xffff);
 }
 
-static int amd_emrdma_init_device(struct amd_emrdma_dev *dev)
+static int rocm_ernic_init_device(struct rocm_ernic_dev *dev)
 {
     /*  Initialize some device related stuff */
     spin_lock_init(&dev->cmd_lock);
@@ -129,16 +129,16 @@ static int amd_emrdma_init_device(struct amd_emrdma_dev *dev)
     return 0;
 }
 
-static int amd_emrdma_port_immutable(struct ib_device *ibdev, u32 port_num,
+static int rocm_ernic_port_immutable(struct ib_device *ibdev, u32 port_num,
                                      struct ib_port_immutable *immutable)
 {
-    struct amd_emrdma_dev *dev = to_vdev(ibdev);
+    struct rocm_ernic_dev *dev = to_vdev(ibdev);
     struct ib_port_attr attr;
     int err;
 
-    if (dev->dsr->caps.gid_types == AMD_EMRDMA_GID_TYPE_FLAG_ROCE_V1)
+    if (dev->dsr->caps.gid_types == ROCM_ERNIC_GID_TYPE_FLAG_ROCE_V1)
         immutable->core_cap_flags |= RDMA_CORE_PORT_IBA_ROCE;
-    else if (dev->dsr->caps.gid_types == AMD_EMRDMA_GID_TYPE_FLAG_ROCE_V2)
+    else if (dev->dsr->caps.gid_types == ROCM_ERNIC_GID_TYPE_FLAG_ROCE_V2)
         immutable->core_cap_flags |= RDMA_CORE_PORT_IBA_ROCE_UDP_ENCAP;
 
     err = ib_query_port(ibdev, port_num, &attr);
@@ -151,7 +151,7 @@ static int amd_emrdma_port_immutable(struct ib_device *ibdev, u32 port_num,
     return 0;
 }
 
-static void amd_emrdma_dispatch_event(struct amd_emrdma_dev *dev, int port,
+static void rocm_ernic_dispatch_event(struct rocm_ernic_dev *dev, int port,
                                       enum ib_event_type event)
 {
     struct ib_event ib_event;
@@ -163,63 +163,63 @@ static void amd_emrdma_dispatch_event(struct amd_emrdma_dev *dev, int port,
     ib_dispatch_event(&ib_event);
 }
 
-static const struct ib_device_ops amd_emrdma_dev_ops = {
+static const struct ib_device_ops rocm_ernic_dev_ops = {
     .owner = THIS_MODULE,
     .driver_id = RDMA_DRIVER_VMW_PVRDMA, /* Use VMware ID for compatibility */
-    .uverbs_abi_ver = AMD_EMRDMA_UVERBS_ABI_VERSION,
+    .uverbs_abi_ver = ROCM_ERNIC_UVERBS_ABI_VERSION,
 
-    .add_gid = amd_emrdma_add_gid,
-    .alloc_mr = amd_emrdma_alloc_mr,
-    .alloc_pd = amd_emrdma_alloc_pd,
-    .alloc_ucontext = amd_emrdma_alloc_ucontext,
-    .create_ah = amd_emrdma_create_ah,
-    .create_cq = amd_emrdma_create_cq,
-    .create_qp = amd_emrdma_create_qp,
-    .dealloc_pd = amd_emrdma_dealloc_pd,
-    .dealloc_ucontext = amd_emrdma_dealloc_ucontext,
-    .del_gid = amd_emrdma_del_gid,
-    .dereg_mr = amd_emrdma_dereg_mr,
-    .destroy_ah = amd_emrdma_destroy_ah,
-    .destroy_cq = amd_emrdma_destroy_cq,
-    .destroy_qp = amd_emrdma_destroy_qp,
-    .device_group = &amd_emrdma_attr_group,
-    .get_dev_fw_str = amd_emrdma_get_fw_ver_str,
-    .get_dma_mr = amd_emrdma_get_dma_mr,
-    .get_link_layer = amd_emrdma_port_link_layer,
-    .get_port_immutable = amd_emrdma_port_immutable,
-    .map_mr_sg = amd_emrdma_map_mr_sg,
-    .mmap = amd_emrdma_mmap,
-    .modify_port = amd_emrdma_modify_port,
-    .modify_qp = amd_emrdma_modify_qp,
-    .poll_cq = amd_emrdma_poll_cq,
-    .post_recv = amd_emrdma_post_recv,
-    .post_send = amd_emrdma_post_send,
-    .query_device = amd_emrdma_query_device,
-    .query_gid = amd_emrdma_query_gid,
-    .query_pkey = amd_emrdma_query_pkey,
-    .query_port = amd_emrdma_query_port,
-    .query_qp = amd_emrdma_query_qp,
-    .reg_user_mr = amd_emrdma_reg_user_mr,
-    .req_notify_cq = amd_emrdma_req_notify_cq,
+    .add_gid = rocm_ernic_add_gid,
+    .alloc_mr = rocm_ernic_alloc_mr,
+    .alloc_pd = rocm_ernic_alloc_pd,
+    .alloc_ucontext = rocm_ernic_alloc_ucontext,
+    .create_ah = rocm_ernic_create_ah,
+    .create_cq = rocm_ernic_create_cq,
+    .create_qp = rocm_ernic_create_qp,
+    .dealloc_pd = rocm_ernic_dealloc_pd,
+    .dealloc_ucontext = rocm_ernic_dealloc_ucontext,
+    .del_gid = rocm_ernic_del_gid,
+    .dereg_mr = rocm_ernic_dereg_mr,
+    .destroy_ah = rocm_ernic_destroy_ah,
+    .destroy_cq = rocm_ernic_destroy_cq,
+    .destroy_qp = rocm_ernic_destroy_qp,
+    .device_group = &rocm_ernic_attr_group,
+    .get_dev_fw_str = rocm_ernic_get_fw_ver_str,
+    .get_dma_mr = rocm_ernic_get_dma_mr,
+    .get_link_layer = rocm_ernic_port_link_layer,
+    .get_port_immutable = rocm_ernic_port_immutable,
+    .map_mr_sg = rocm_ernic_map_mr_sg,
+    .mmap = rocm_ernic_mmap,
+    .modify_port = rocm_ernic_modify_port,
+    .modify_qp = rocm_ernic_modify_qp,
+    .poll_cq = rocm_ernic_poll_cq,
+    .post_recv = rocm_ernic_post_recv,
+    .post_send = rocm_ernic_post_send,
+    .query_device = rocm_ernic_query_device,
+    .query_gid = rocm_ernic_query_gid,
+    .query_pkey = rocm_ernic_query_pkey,
+    .query_port = rocm_ernic_query_port,
+    .query_qp = rocm_ernic_query_qp,
+    .reg_user_mr = rocm_ernic_reg_user_mr,
+    .req_notify_cq = rocm_ernic_req_notify_cq,
     /* .report_port_event removed in kernel 6.8+ */
 
-    INIT_RDMA_OBJ_SIZE(ib_ah, amd_emrdma_ah, ibah),
-    INIT_RDMA_OBJ_SIZE(ib_cq, amd_emrdma_cq, ibcq),
-    INIT_RDMA_OBJ_SIZE(ib_pd, amd_emrdma_pd, ibpd),
-    INIT_RDMA_OBJ_SIZE(ib_qp, amd_emrdma_qp, ibqp),
-    INIT_RDMA_OBJ_SIZE(ib_ucontext, amd_emrdma_ucontext, ibucontext),
+    INIT_RDMA_OBJ_SIZE(ib_ah, rocm_ernic_ah, ibah),
+    INIT_RDMA_OBJ_SIZE(ib_cq, rocm_ernic_cq, ibcq),
+    INIT_RDMA_OBJ_SIZE(ib_pd, rocm_ernic_pd, ibpd),
+    INIT_RDMA_OBJ_SIZE(ib_qp, rocm_ernic_qp, ibqp),
+    INIT_RDMA_OBJ_SIZE(ib_ucontext, rocm_ernic_ucontext, ibucontext),
 };
 
-static const struct ib_device_ops amd_emrdma_dev_srq_ops = {
-    .create_srq = amd_emrdma_create_srq,
-    .destroy_srq = amd_emrdma_destroy_srq,
-    .modify_srq = amd_emrdma_modify_srq,
-    .query_srq = amd_emrdma_query_srq,
+static const struct ib_device_ops rocm_ernic_dev_srq_ops = {
+    .create_srq = rocm_ernic_create_srq,
+    .destroy_srq = rocm_ernic_destroy_srq,
+    .modify_srq = rocm_ernic_modify_srq,
+    .query_srq = rocm_ernic_query_srq,
 
-    INIT_RDMA_OBJ_SIZE(ib_srq, amd_emrdma_srq, ibsrq),
+    INIT_RDMA_OBJ_SIZE(ib_srq, rocm_ernic_srq, ibsrq),
 };
 
-static int amd_emrdma_register_device(struct amd_emrdma_dev *dev)
+static int rocm_ernic_register_device(struct rocm_ernic_dev *dev)
 {
     int ret = -1;
 
@@ -244,18 +244,18 @@ static int amd_emrdma_register_device(struct amd_emrdma_dev *dev)
     dev->ib_dev.node_type = RDMA_NODE_IB_CA;
     dev->ib_dev.phys_port_cnt = dev->dsr->caps.phys_port_cnt;
 
-    ib_set_device_ops(&dev->ib_dev, &amd_emrdma_dev_ops);
+    ib_set_device_ops(&dev->ib_dev, &rocm_ernic_dev_ops);
 
     mutex_init(&dev->port_mutex);
     spin_lock_init(&dev->desc_lock);
 
-    dev->cq_tbl = kcalloc(dev->dsr->caps.max_cq, sizeof(struct amd_emrdma_cq *),
+    dev->cq_tbl = kcalloc(dev->dsr->caps.max_cq, sizeof(struct rocm_ernic_cq *),
                           GFP_KERNEL);
     if (!dev->cq_tbl)
         return ret;
     spin_lock_init(&dev->cq_tbl_lock);
 
-    dev->qp_tbl = kcalloc(dev->dsr->caps.max_qp, sizeof(struct amd_emrdma_qp *),
+    dev->qp_tbl = kcalloc(dev->dsr->caps.max_qp, sizeof(struct rocm_ernic_qp *),
                           GFP_KERNEL);
     if (!dev->qp_tbl)
         goto err_cq_free;
@@ -263,10 +263,10 @@ static int amd_emrdma_register_device(struct amd_emrdma_dev *dev)
 
     /* Check if SRQ is supported by backend */
     if (dev->dsr->caps.max_srq) {
-        ib_set_device_ops(&dev->ib_dev, &amd_emrdma_dev_srq_ops);
+        ib_set_device_ops(&dev->ib_dev, &rocm_ernic_dev_srq_ops);
 
         dev->srq_tbl = kcalloc(dev->dsr->caps.max_srq,
-                               sizeof(struct amd_emrdma_srq *), GFP_KERNEL);
+                               sizeof(struct rocm_ernic_srq *), GFP_KERNEL);
         if (!dev->srq_tbl)
             goto err_qp_free;
     }
@@ -275,7 +275,7 @@ static int amd_emrdma_register_device(struct amd_emrdma_dev *dev)
         goto err_srq_free;
     spin_lock_init(&dev->srq_tbl_lock);
 
-    ret = ib_register_device(&dev->ib_dev, "amd_emrdma%d", &dev->pdev->dev);
+    ret = ib_register_device(&dev->ib_dev, "rocm_ernic%d", &dev->pdev->dev);
     if (ret)
         goto err_srq_free;
 
@@ -302,29 +302,29 @@ err_cq_free:
     return ret;
 }
 
-static irqreturn_t amd_emrdma_intr0_handler(int irq, void *dev_id)
+static irqreturn_t rocm_ernic_intr0_handler(int irq, void *dev_id)
 {
-    u32 icr = AMD_EMRDMA_INTR_CAUSE_RESPONSE;
-    struct amd_emrdma_dev *dev = dev_id;
+    u32 icr = ROCM_ERNIC_INTR_CAUSE_RESPONSE;
+    struct rocm_ernic_dev *dev = dev_id;
 
     dev_dbg(&dev->pdev->dev, "interrupt 0 (response) handler\n");
 
     if (!dev->pdev->msix_enabled) {
         /* Legacy intr */
-        icr = amd_emrdma_read_reg(dev, AMD_EMRDMA_REG_ICR);
+        icr = rocm_ernic_read_reg(dev, ROCM_ERNIC_REG_ICR);
         if (icr == 0)
             return IRQ_NONE;
     }
 
-    if (icr == AMD_EMRDMA_INTR_CAUSE_RESPONSE)
+    if (icr == ROCM_ERNIC_INTR_CAUSE_RESPONSE)
         complete(&dev->cmd_done);
 
     return IRQ_HANDLED;
 }
 
-static void amd_emrdma_qp_event(struct amd_emrdma_dev *dev, u32 qpn, int type)
+static void rocm_ernic_qp_event(struct rocm_ernic_dev *dev, u32 qpn, int type)
 {
-    struct amd_emrdma_qp *qp;
+    struct rocm_ernic_qp *qp;
     unsigned long flags;
 
     spin_lock_irqsave(&dev->qp_tbl_lock, flags);
@@ -348,9 +348,9 @@ static void amd_emrdma_qp_event(struct amd_emrdma_dev *dev, u32 qpn, int type)
     }
 }
 
-static void amd_emrdma_cq_event(struct amd_emrdma_dev *dev, u32 cqn, int type)
+static void rocm_ernic_cq_event(struct rocm_ernic_dev *dev, u32 cqn, int type)
 {
-    struct amd_emrdma_cq *cq;
+    struct rocm_ernic_cq *cq;
     unsigned long flags;
 
     spin_lock_irqsave(&dev->cq_tbl_lock, flags);
@@ -374,9 +374,9 @@ static void amd_emrdma_cq_event(struct amd_emrdma_dev *dev, u32 cqn, int type)
     }
 }
 
-static void amd_emrdma_srq_event(struct amd_emrdma_dev *dev, u32 srqn, int type)
+static void rocm_ernic_srq_event(struct rocm_ernic_dev *dev, u32 srqn, int type)
 {
-    struct amd_emrdma_srq *srq;
+    struct rocm_ernic_srq *srq;
     unsigned long flags;
 
     spin_lock_irqsave(&dev->srq_tbl_lock, flags);
@@ -403,29 +403,29 @@ static void amd_emrdma_srq_event(struct amd_emrdma_dev *dev, u32 srqn, int type)
     }
 }
 
-static void amd_emrdma_dev_event(struct amd_emrdma_dev *dev, u8 port, int type)
+static void rocm_ernic_dev_event(struct rocm_ernic_dev *dev, u8 port, int type)
 {
     if (port < 1 || port > dev->dsr->caps.phys_port_cnt) {
         dev_warn(&dev->pdev->dev, "event on port %d\n", port);
         return;
     }
 
-    amd_emrdma_dispatch_event(dev, port, type);
+    rocm_ernic_dispatch_event(dev, port, type);
 }
 
-static inline struct amd_emrdma_eqe *get_eqe(struct amd_emrdma_dev *dev,
+static inline struct rocm_ernic_eqe *get_eqe(struct rocm_ernic_dev *dev,
                                              unsigned int i)
 {
-    return (struct amd_emrdma_eqe *)amd_emrdma_page_dir_get_ptr(
-        &dev->async_pdir, PAGE_SIZE + sizeof(struct amd_emrdma_eqe) * i);
+    return (struct rocm_ernic_eqe *)rocm_ernic_page_dir_get_ptr(
+        &dev->async_pdir, PAGE_SIZE + sizeof(struct rocm_ernic_eqe) * i);
 }
 
-static irqreturn_t amd_emrdma_intr1_handler(int irq, void *dev_id)
+static irqreturn_t rocm_ernic_intr1_handler(int irq, void *dev_id)
 {
-    struct amd_emrdma_dev *dev = dev_id;
-    struct amd_emrdma_ring *ring = &dev->async_ring_state->rx;
+    struct rocm_ernic_dev *dev = dev_id;
+    struct rocm_ernic_ring *ring = &dev->async_ring_state->rx;
     int ring_slots = (dev->dsr->async_ring_pages.num_pages - 1) * PAGE_SIZE /
-                     sizeof(struct amd_emrdma_eqe);
+                     sizeof(struct rocm_ernic_eqe);
     unsigned int head;
 
     dev_dbg(&dev->pdev->dev, "interrupt 1 (async event) handler\n");
@@ -437,76 +437,76 @@ static irqreturn_t amd_emrdma_intr1_handler(int irq, void *dev_id)
     if (!dev->ib_active)
         return IRQ_HANDLED;
 
-    while (amd_emrdma_idx_ring_has_data(ring, ring_slots, &head) > 0) {
-        struct amd_emrdma_eqe *eqe;
+    while (rocm_ernic_idx_ring_has_data(ring, ring_slots, &head) > 0) {
+        struct rocm_ernic_eqe *eqe;
 
         eqe = get_eqe(dev, head);
 
         switch (eqe->type) {
-        case AMD_EMRDMA_EVENT_QP_FATAL:
-        case AMD_EMRDMA_EVENT_QP_REQ_ERR:
-        case AMD_EMRDMA_EVENT_QP_ACCESS_ERR:
-        case AMD_EMRDMA_EVENT_COMM_EST:
-        case AMD_EMRDMA_EVENT_SQ_DRAINED:
-        case AMD_EMRDMA_EVENT_PATH_MIG:
-        case AMD_EMRDMA_EVENT_PATH_MIG_ERR:
-        case AMD_EMRDMA_EVENT_QP_LAST_WQE_REACHED:
-            amd_emrdma_qp_event(dev, eqe->info, eqe->type);
+        case ROCM_ERNIC_EVENT_QP_FATAL:
+        case ROCM_ERNIC_EVENT_QP_REQ_ERR:
+        case ROCM_ERNIC_EVENT_QP_ACCESS_ERR:
+        case ROCM_ERNIC_EVENT_COMM_EST:
+        case ROCM_ERNIC_EVENT_SQ_DRAINED:
+        case ROCM_ERNIC_EVENT_PATH_MIG:
+        case ROCM_ERNIC_EVENT_PATH_MIG_ERR:
+        case ROCM_ERNIC_EVENT_QP_LAST_WQE_REACHED:
+            rocm_ernic_qp_event(dev, eqe->info, eqe->type);
             break;
 
-        case AMD_EMRDMA_EVENT_CQ_ERR:
-            amd_emrdma_cq_event(dev, eqe->info, eqe->type);
+        case ROCM_ERNIC_EVENT_CQ_ERR:
+            rocm_ernic_cq_event(dev, eqe->info, eqe->type);
             break;
 
-        case AMD_EMRDMA_EVENT_SRQ_ERR:
-        case AMD_EMRDMA_EVENT_SRQ_LIMIT_REACHED:
-            amd_emrdma_srq_event(dev, eqe->info, eqe->type);
+        case ROCM_ERNIC_EVENT_SRQ_ERR:
+        case ROCM_ERNIC_EVENT_SRQ_LIMIT_REACHED:
+            rocm_ernic_srq_event(dev, eqe->info, eqe->type);
             break;
 
-        case AMD_EMRDMA_EVENT_PORT_ACTIVE:
-        case AMD_EMRDMA_EVENT_PORT_ERR:
-        case AMD_EMRDMA_EVENT_LID_CHANGE:
-        case AMD_EMRDMA_EVENT_PKEY_CHANGE:
-        case AMD_EMRDMA_EVENT_SM_CHANGE:
-        case AMD_EMRDMA_EVENT_CLIENT_REREGISTER:
-        case AMD_EMRDMA_EVENT_GID_CHANGE:
-            amd_emrdma_dev_event(dev, eqe->info, eqe->type);
+        case ROCM_ERNIC_EVENT_PORT_ACTIVE:
+        case ROCM_ERNIC_EVENT_PORT_ERR:
+        case ROCM_ERNIC_EVENT_LID_CHANGE:
+        case ROCM_ERNIC_EVENT_PKEY_CHANGE:
+        case ROCM_ERNIC_EVENT_SM_CHANGE:
+        case ROCM_ERNIC_EVENT_CLIENT_REREGISTER:
+        case ROCM_ERNIC_EVENT_GID_CHANGE:
+            rocm_ernic_dev_event(dev, eqe->info, eqe->type);
             break;
 
-        case AMD_EMRDMA_EVENT_DEVICE_FATAL:
-            amd_emrdma_dev_event(dev, 1, eqe->type);
+        case ROCM_ERNIC_EVENT_DEVICE_FATAL:
+            rocm_ernic_dev_event(dev, 1, eqe->type);
             break;
 
         default:
             break;
         }
 
-        amd_emrdma_idx_ring_inc(&ring->cons_head, ring_slots);
+        rocm_ernic_idx_ring_inc(&ring->cons_head, ring_slots);
     }
 
     return IRQ_HANDLED;
 }
 
-static inline struct amd_emrdma_cqne *get_cqne(struct amd_emrdma_dev *dev,
+static inline struct rocm_ernic_cqne *get_cqne(struct rocm_ernic_dev *dev,
                                                unsigned int i)
 {
-    return (struct amd_emrdma_cqne *)amd_emrdma_page_dir_get_ptr(
-        &dev->cq_pdir, PAGE_SIZE + sizeof(struct amd_emrdma_cqne) * i);
+    return (struct rocm_ernic_cqne *)rocm_ernic_page_dir_get_ptr(
+        &dev->cq_pdir, PAGE_SIZE + sizeof(struct rocm_ernic_cqne) * i);
 }
 
-static irqreturn_t amd_emrdma_intrx_handler(int irq, void *dev_id)
+static irqreturn_t rocm_ernic_intrx_handler(int irq, void *dev_id)
 {
-    struct amd_emrdma_dev *dev = dev_id;
-    struct amd_emrdma_ring *ring = &dev->cq_ring_state->rx;
+    struct rocm_ernic_dev *dev = dev_id;
+    struct rocm_ernic_ring *ring = &dev->cq_ring_state->rx;
     int ring_slots = (dev->dsr->cq_ring_pages.num_pages - 1) * PAGE_SIZE /
-                     sizeof(struct amd_emrdma_cqne);
+                     sizeof(struct rocm_ernic_cqne);
     unsigned int head;
 
     dev_dbg(&dev->pdev->dev, "interrupt x (completion) handler\n");
 
-    while (amd_emrdma_idx_ring_has_data(ring, ring_slots, &head) > 0) {
-        struct amd_emrdma_cqne *cqne;
-        struct amd_emrdma_cq *cq;
+    while (rocm_ernic_idx_ring_has_data(ring, ring_slots, &head) > 0) {
+        struct rocm_ernic_cqne *cqne;
+        struct rocm_ernic_cq *cq;
 
         cqne = get_cqne(dev, head);
         spin_lock(&dev->cq_tbl_lock);
@@ -521,13 +521,13 @@ static irqreturn_t amd_emrdma_intrx_handler(int irq, void *dev_id)
             if (refcount_dec_and_test(&cq->refcnt))
                 complete(&cq->free);
         }
-        amd_emrdma_idx_ring_inc(&ring->cons_head, ring_slots);
+        rocm_ernic_idx_ring_inc(&ring->cons_head, ring_slots);
     }
 
     return IRQ_HANDLED;
 }
 
-static void amd_emrdma_free_irq(struct amd_emrdma_dev *dev)
+static void rocm_ernic_free_irq(struct rocm_ernic_dev *dev)
 {
     int i;
 
@@ -536,25 +536,25 @@ static void amd_emrdma_free_irq(struct amd_emrdma_dev *dev)
         free_irq(pci_irq_vector(dev->pdev, i), dev);
 }
 
-static void amd_emrdma_enable_intrs(struct amd_emrdma_dev *dev)
+static void rocm_ernic_enable_intrs(struct rocm_ernic_dev *dev)
 {
     dev_dbg(&dev->pdev->dev, "enable interrupts\n");
-    amd_emrdma_write_reg(dev, AMD_EMRDMA_REG_IMR, 0);
+    rocm_ernic_write_reg(dev, ROCM_ERNIC_REG_IMR, 0);
 }
 
-static void amd_emrdma_disable_intrs(struct amd_emrdma_dev *dev)
+static void rocm_ernic_disable_intrs(struct rocm_ernic_dev *dev)
 {
     dev_dbg(&dev->pdev->dev, "disable interrupts\n");
-    amd_emrdma_write_reg(dev, AMD_EMRDMA_REG_IMR, ~0);
+    rocm_ernic_write_reg(dev, ROCM_ERNIC_REG_IMR, ~0);
 }
 
-static int amd_emrdma_alloc_intrs(struct amd_emrdma_dev *dev)
+static int rocm_ernic_alloc_intrs(struct rocm_ernic_dev *dev)
 {
     struct pci_dev *pdev = dev->pdev;
     int ret = 0, i;
 
     ret =
-        pci_alloc_irq_vectors(pdev, 1, AMD_EMRDMA_MAX_INTERRUPTS, PCI_IRQ_MSIX);
+        pci_alloc_irq_vectors(pdev, 1, ROCM_ERNIC_MAX_INTERRUPTS, PCI_IRQ_MSIX);
     if (ret < 0) {
         ret = pci_alloc_irq_vectors(pdev, 1, 1, PCI_IRQ_MSI | PCI_IRQ_INTX);
         if (ret < 0)
@@ -562,7 +562,7 @@ static int amd_emrdma_alloc_intrs(struct amd_emrdma_dev *dev)
     }
     dev->nr_vectors = ret;
 
-    ret = request_irq(pci_irq_vector(dev->pdev, 0), amd_emrdma_intr0_handler,
+    ret = request_irq(pci_irq_vector(dev->pdev, 0), rocm_ernic_intr0_handler,
                       pdev->msix_enabled ? 0 : IRQF_SHARED, DRV_NAME, dev);
     if (ret) {
         dev_err(&dev->pdev->dev, "failed to request interrupt 0\n");
@@ -571,8 +571,8 @@ static int amd_emrdma_alloc_intrs(struct amd_emrdma_dev *dev)
 
     for (i = 1; i < dev->nr_vectors; i++) {
         ret = request_irq(pci_irq_vector(dev->pdev, i),
-                          i == 1 ? amd_emrdma_intr1_handler
-                                 : amd_emrdma_intrx_handler,
+                          i == 1 ? rocm_ernic_intr1_handler
+                                 : rocm_ernic_intrx_handler,
                           0, DRV_NAME, dev);
         if (ret) {
             dev_err(&dev->pdev->dev, "failed to request interrupt %d\n", i);
@@ -590,7 +590,7 @@ out_free_vectors:
     return ret;
 }
 
-static void amd_emrdma_free_slots(struct amd_emrdma_dev *dev)
+static void rocm_ernic_free_slots(struct rocm_ernic_dev *dev)
 {
     struct pci_dev *pdev = dev->pdev;
 
@@ -602,13 +602,13 @@ static void amd_emrdma_free_slots(struct amd_emrdma_dev *dev)
                           dev->dsr->cmd_slot_dma);
 }
 
-static int amd_emrdma_add_gid_at_index(struct amd_emrdma_dev *dev,
+static int rocm_ernic_add_gid_at_index(struct rocm_ernic_dev *dev,
                                        const union ib_gid *gid, u8 gid_type,
                                        int index)
 {
     int ret;
-    union amd_emrdma_cmd_req req;
-    struct amd_emrdma_cmd_create_bind *cmd_bind = &req.create_bind;
+    union rocm_ernic_cmd_req req;
+    struct rocm_ernic_cmd_create_bind *cmd_bind = &req.create_bind;
 
     if (!dev->sgid_tbl) {
         dev_warn(&dev->pdev->dev, "sgid table not initialized\n");
@@ -616,14 +616,14 @@ static int amd_emrdma_add_gid_at_index(struct amd_emrdma_dev *dev,
     }
 
     memset(cmd_bind, 0, sizeof(*cmd_bind));
-    cmd_bind->hdr.cmd = AMD_EMRDMA_CMD_CREATE_BIND;
+    cmd_bind->hdr.cmd = ROCM_ERNIC_CMD_CREATE_BIND;
     memcpy(cmd_bind->new_gid, gid->raw, 16);
     cmd_bind->mtu = ib_mtu_enum_to_int(IB_MTU_1024);
     cmd_bind->vlan = 0xfff;
     cmd_bind->index = index;
     cmd_bind->gid_type = gid_type;
 
-    ret = amd_emrdma_cmd_post(dev, &req, NULL, 0);
+    ret = rocm_ernic_cmd_post(dev, &req, NULL, 0);
     if (ret < 0) {
         dev_warn(&dev->pdev->dev, "could not create binding, error: %d\n", ret);
         return -EFAULT;
@@ -632,9 +632,9 @@ static int amd_emrdma_add_gid_at_index(struct amd_emrdma_dev *dev,
     return 0;
 }
 
-static int amd_emrdma_add_gid(const struct ib_gid_attr *attr, void **context)
+static int rocm_ernic_add_gid(const struct ib_gid_attr *attr, void **context)
 {
-    struct amd_emrdma_dev *dev = to_vdev(attr->device);
+    struct rocm_ernic_dev *dev = to_vdev(attr->device);
     bool is_loopback = dev->netdev && (dev->netdev->flags & IFF_LOOPBACK);
 
     dev_info(&dev->pdev->dev,
@@ -666,16 +666,16 @@ static int amd_emrdma_add_gid(const struct ib_gid_attr *attr, void **context)
     }
 
     /* For real netdev (vmxnet3), use full binding flow */
-    return amd_emrdma_add_gid_at_index(
-        dev, &attr->gid, ib_gid_type_to_amd_emrdma(attr->gid_type),
+    return rocm_ernic_add_gid_at_index(
+        dev, &attr->gid, ib_gid_type_to_rocm_ernic(attr->gid_type),
         attr->index);
 }
 
-static int amd_emrdma_del_gid_at_index(struct amd_emrdma_dev *dev, int index)
+static int rocm_ernic_del_gid_at_index(struct rocm_ernic_dev *dev, int index)
 {
     int ret;
-    union amd_emrdma_cmd_req req;
-    struct amd_emrdma_cmd_destroy_bind *cmd_dest = &req.destroy_bind;
+    union rocm_ernic_cmd_req req;
+    struct rocm_ernic_cmd_destroy_bind *cmd_dest = &req.destroy_bind;
 
     /* Update sgid table. */
     if (!dev->sgid_tbl) {
@@ -684,11 +684,11 @@ static int amd_emrdma_del_gid_at_index(struct amd_emrdma_dev *dev, int index)
     }
 
     memset(cmd_dest, 0, sizeof(*cmd_dest));
-    cmd_dest->hdr.cmd = AMD_EMRDMA_CMD_DESTROY_BIND;
+    cmd_dest->hdr.cmd = ROCM_ERNIC_CMD_DESTROY_BIND;
     memcpy(cmd_dest->dest_gid, &dev->sgid_tbl[index], 16);
     cmd_dest->index = index;
 
-    ret = amd_emrdma_cmd_post(dev, &req, NULL, 0);
+    ret = rocm_ernic_cmd_post(dev, &req, NULL, 0);
     if (ret < 0) {
         dev_warn(&dev->pdev->dev, "could not destroy binding, error: %d\n",
                  ret);
@@ -698,9 +698,9 @@ static int amd_emrdma_del_gid_at_index(struct amd_emrdma_dev *dev, int index)
     return 0;
 }
 
-static int amd_emrdma_del_gid(const struct ib_gid_attr *attr, void **context)
+static int rocm_ernic_del_gid(const struct ib_gid_attr *attr, void **context)
 {
-    struct amd_emrdma_dev *dev = to_vdev(attr->device);
+    struct rocm_ernic_dev *dev = to_vdev(attr->device);
     bool is_loopback = dev->netdev && (dev->netdev->flags & IFF_LOOPBACK);
 
     dev_info(&dev->pdev->dev, "del_gid called: index=%d netdev=%s%s\n",
@@ -725,10 +725,10 @@ static int amd_emrdma_del_gid(const struct ib_gid_attr *attr, void **context)
     /* For real netdev (vmxnet3), use full unbinding flow */
     dev_dbg(&dev->pdev->dev, "removing gid at index %u from %s", attr->index,
             dev->netdev->name);
-    return amd_emrdma_del_gid_at_index(dev, attr->index);
+    return rocm_ernic_del_gid_at_index(dev, attr->index);
 }
 
-static void amd_emrdma_netdevice_event_handle(struct amd_emrdma_dev *dev,
+static void rocm_ernic_netdevice_event_handle(struct rocm_ernic_dev *dev,
                                               struct net_device *ndev,
                                               unsigned long event)
 {
@@ -737,7 +737,7 @@ static void amd_emrdma_netdevice_event_handle(struct amd_emrdma_dev *dev,
 
     switch (event) {
     case NETDEV_REBOOT:
-        amd_emrdma_dispatch_event(dev, 1, IB_EVENT_PORT_ERR);
+        rocm_ernic_dispatch_event(dev, 1, IB_EVENT_PORT_ERR);
         break;
     case NETDEV_UNREGISTER:
         ib_device_set_netdev(&dev->ib_dev, NULL, 1);
@@ -764,39 +764,39 @@ static void amd_emrdma_netdevice_event_handle(struct amd_emrdma_dev *dev,
     }
 }
 
-static void amd_emrdma_netdevice_event_work(struct work_struct *work)
+static void rocm_ernic_netdevice_event_work(struct work_struct *work)
 {
-    struct amd_emrdma_netdevice_work *netdev_work;
-    struct amd_emrdma_dev *dev;
+    struct rocm_ernic_netdevice_work *netdev_work;
+    struct rocm_ernic_dev *dev;
 
-    netdev_work = container_of(work, struct amd_emrdma_netdevice_work, work);
+    netdev_work = container_of(work, struct rocm_ernic_netdevice_work, work);
 
-    mutex_lock(&amd_emrdma_device_list_lock);
-    list_for_each_entry(dev, &amd_emrdma_device_list, device_link)
+    mutex_lock(&rocm_ernic_device_list_lock);
+    list_for_each_entry(dev, &rocm_ernic_device_list, device_link)
     {
         if ((netdev_work->event == NETDEV_REGISTER) ||
             (dev->netdev == netdev_work->event_netdev)) {
-            amd_emrdma_netdevice_event_handle(dev, netdev_work->event_netdev,
+            rocm_ernic_netdevice_event_handle(dev, netdev_work->event_netdev,
                                               netdev_work->event);
             break;
         }
     }
-    mutex_unlock(&amd_emrdma_device_list_lock);
+    mutex_unlock(&rocm_ernic_device_list_lock);
 
     kfree(netdev_work);
 }
 
-static int amd_emrdma_netdevice_event(struct notifier_block *this,
+static int rocm_ernic_netdevice_event(struct notifier_block *this,
                                       unsigned long event, void *ptr)
 {
     struct net_device *event_netdev = netdev_notifier_info_to_dev(ptr);
-    struct amd_emrdma_netdevice_work *netdev_work;
+    struct rocm_ernic_netdevice_work *netdev_work;
 
     netdev_work = kmalloc(sizeof(*netdev_work), GFP_ATOMIC);
     if (!netdev_work)
         return NOTIFY_BAD;
 
-    INIT_WORK(&netdev_work->work, amd_emrdma_netdevice_event_work);
+    INIT_WORK(&netdev_work->work, rocm_ernic_netdevice_event_work);
     netdev_work->event_netdev = event_netdev;
     netdev_work->event = event;
     queue_work(event_wq, &netdev_work->work);
@@ -804,11 +804,11 @@ static int amd_emrdma_netdevice_event(struct notifier_block *this,
     return NOTIFY_DONE;
 }
 
-static int amd_emrdma_pci_probe(struct pci_dev *pdev,
+static int rocm_ernic_pci_probe(struct pci_dev *pdev,
                                 const struct pci_device_id *id)
 {
     struct pci_dev *pdev_net;
-    struct amd_emrdma_dev *dev;
+    struct rocm_ernic_dev *dev;
     int ret;
     unsigned long start;
     unsigned long len;
@@ -817,17 +817,17 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
     dev_dbg(&pdev->dev, "initializing driver %s\n", pci_name(pdev));
 
     /* Allocate zero-out device */
-    dev = ib_alloc_device(amd_emrdma_dev, ib_dev);
+    dev = ib_alloc_device(rocm_ernic_dev, ib_dev);
     if (!dev) {
         dev_err(&pdev->dev, "failed to allocate IB device\n");
         return -ENOMEM;
     }
 
-    mutex_lock(&amd_emrdma_device_list_lock);
-    list_add(&dev->device_link, &amd_emrdma_device_list);
-    mutex_unlock(&amd_emrdma_device_list_lock);
+    mutex_lock(&rocm_ernic_device_list_lock);
+    list_add(&dev->device_link, &rocm_ernic_device_list);
+    mutex_unlock(&rocm_ernic_device_list_lock);
 
-    ret = amd_emrdma_init_device(dev);
+    ret = rocm_ernic_init_device(dev);
     if (ret)
         goto err_free_device;
 
@@ -876,8 +876,8 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
     pci_set_master(pdev);
 
     /* Map register space */
-    start = pci_resource_start(dev->pdev, AMD_EMRDMA_PCI_RESOURCE_REG);
-    len = pci_resource_len(dev->pdev, AMD_EMRDMA_PCI_RESOURCE_REG);
+    start = pci_resource_start(dev->pdev, ROCM_ERNIC_PCI_RESOURCE_REG);
+    len = pci_resource_len(dev->pdev, ROCM_ERNIC_PCI_RESOURCE_REG);
     dev->regs = ioremap(start, len);
     if (!dev->regs) {
         dev_err(&pdev->dev, "register mapping failed\n");
@@ -888,7 +888,7 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
     /* Setup per-device UAR. */
     dev->driver_uar.index = 0;
     dev->driver_uar.pfn =
-        pci_resource_start(dev->pdev, AMD_EMRDMA_PCI_RESOURCE_UAR) >>
+        pci_resource_start(dev->pdev, ROCM_ERNIC_PCI_RESOURCE_UAR) >>
         PAGE_SHIFT;
     dev->driver_uar.map = ioremap(dev->driver_uar.pfn << PAGE_SHIFT, PAGE_SIZE);
     if (!dev->driver_uar.map) {
@@ -897,9 +897,9 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
         goto err_unmap_regs;
     }
 
-    dev->dsr_version = amd_emrdma_read_reg(dev, AMD_EMRDMA_REG_VERSION);
+    dev->dsr_version = rocm_ernic_read_reg(dev, ROCM_ERNIC_REG_VERSION);
     dev_info(&pdev->dev, "device version %d, driver version %d\n",
-             dev->dsr_version, AMD_EMRDMA_VERSION);
+             dev->dsr_version, ROCM_ERNIC_VERSION);
 
     dev->dsr = dma_alloc_coherent(&pdev->dev, sizeof(*dev->dsr), &dev->dsrbase,
                                   GFP_KERNEL);
@@ -910,13 +910,13 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
     }
 
     /* Setup the shared region */
-    dev->dsr->driver_version = AMD_EMRDMA_VERSION;
+    dev->dsr->driver_version = ROCM_ERNIC_VERSION;
     dev->dsr->gos_info.gos_bits =
-        sizeof(void *) == 4 ? AMD_EMRDMA_GOS_BITS_32 : AMD_EMRDMA_GOS_BITS_64;
-    dev->dsr->gos_info.gos_type = AMD_EMRDMA_GOS_TYPE_LINUX;
+        sizeof(void *) == 4 ? ROCM_ERNIC_GOS_BITS_32 : ROCM_ERNIC_GOS_BITS_64;
+    dev->dsr->gos_info.gos_type = ROCM_ERNIC_GOS_TYPE_LINUX;
     dev->dsr->gos_info.gos_ver = 1;
 
-    if (dev->dsr_version < AMD_EMRDMA_PPN64_VERSION)
+    if (dev->dsr_version < ROCM_ERNIC_PPN64_VERSION)
         dev->dsr->uar_pfn = dev->driver_uar.pfn;
     else
         dev->dsr->uar_pfn64 = dev->driver_uar.pfn;
@@ -942,8 +942,8 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
     dev->dsr->resp_slot_dma = (u64)slot_dma;
 
     /* Async event ring */
-    dev->dsr->async_ring_pages.num_pages = AMD_EMRDMA_NUM_RING_PAGES;
-    ret = amd_emrdma_page_dir_init(dev, &dev->async_pdir,
+    dev->dsr->async_ring_pages.num_pages = ROCM_ERNIC_NUM_RING_PAGES;
+    ret = rocm_ernic_page_dir_init(dev, &dev->async_pdir,
                                    dev->dsr->async_ring_pages.num_pages, true);
     if (ret)
         goto err_free_slots;
@@ -951,8 +951,8 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
     dev->dsr->async_ring_pages.pdir_dma = dev->async_pdir.dir_dma;
 
     /* CQ notification ring */
-    dev->dsr->cq_ring_pages.num_pages = AMD_EMRDMA_NUM_RING_PAGES;
-    ret = amd_emrdma_page_dir_init(dev, &dev->cq_pdir,
+    dev->dsr->cq_ring_pages.num_pages = ROCM_ERNIC_NUM_RING_PAGES;
+    ret = rocm_ernic_page_dir_init(dev, &dev->cq_pdir,
                                    dev->dsr->cq_ring_pages.num_pages, true);
     if (ret)
         goto err_free_async_ring;
@@ -965,8 +965,8 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
      * complete, the device will have filled out the capabilities.
      */
 
-    amd_emrdma_write_reg(dev, AMD_EMRDMA_REG_DSRLOW, (u32)dev->dsrbase);
-    amd_emrdma_write_reg(dev, AMD_EMRDMA_REG_DSRHIGH,
+    rocm_ernic_write_reg(dev, ROCM_ERNIC_REG_DSRLOW, (u32)dev->dsrbase);
+    rocm_ernic_write_reg(dev, ROCM_ERNIC_REG_DSRHIGH,
                          (u32)((u64)(dev->dsrbase) >> 32));
 
     /*
@@ -981,7 +981,7 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
 
         for (poll_count = 0; poll_count < 100; poll_count++) {
             mb();
-            if (AMD_EMRDMA_SUPPORTED(dev)) {
+            if (ROCM_ERNIC_SUPPORTED(dev)) {
                 dsr_ready = true;
                 dev_info(&pdev->dev, "DSR initialized after %d polls\n",
                          poll_count);
@@ -999,7 +999,7 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
     }
 
     /* The driver supports RoCE V1 and V2. */
-    if (!AMD_EMRDMA_SUPPORTED(dev)) {
+    if (!ROCM_ERNIC_SUPPORTED(dev)) {
         dev_err(&pdev->dev, "driver needs RoCE v1 or v2 support\n");
         ret = -EFAULT;
         goto err_free_cq_ring;
@@ -1053,7 +1053,7 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
     }
 
     /* Interrupt setup */
-    ret = amd_emrdma_alloc_intrs(dev);
+    ret = rocm_ernic_alloc_intrs(dev);
     if (ret) {
         dev_err(&pdev->dev, "failed to allocate interrupts\n");
         ret = -ENOMEM;
@@ -1061,7 +1061,7 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
     }
 
     /* Allocate UAR table. */
-    ret = amd_emrdma_uar_table_init(dev);
+    ret = rocm_ernic_uar_table_init(dev);
     if (ret) {
         dev_err(&pdev->dev, "failed to allocate UAR table\n");
         ret = -ENOMEM;
@@ -1077,17 +1077,17 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
     }
     dev_dbg(&pdev->dev, "gid table len %d\n", dev->dsr->caps.gid_tbl_len);
 
-    amd_emrdma_enable_intrs(dev);
+    rocm_ernic_enable_intrs(dev);
 
-    /* Activate amd_emrdma device */
-    amd_emrdma_write_reg(dev, AMD_EMRDMA_REG_CTL,
-                         AMD_EMRDMA_DEVICE_CTL_ACTIVATE);
+    /* Activate rocm_ernic device */
+    rocm_ernic_write_reg(dev, ROCM_ERNIC_REG_CTL,
+                         ROCM_ERNIC_DEVICE_CTL_ACTIVATE);
 
     /* Make sure the write is complete before reading status. */
     mb();
 
     /* Check if device was successfully activated */
-    ret = amd_emrdma_read_reg(dev, AMD_EMRDMA_REG_ERR);
+    ret = rocm_ernic_read_reg(dev, ROCM_ERNIC_REG_ERR);
     if (ret != 0) {
         dev_err(&pdev->dev, "failed to activate device\n");
         ret = -EFAULT;
@@ -1095,13 +1095,13 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
     }
 
     /* Register IB device */
-    ret = amd_emrdma_register_device(dev);
+    ret = rocm_ernic_register_device(dev);
     if (ret) {
         dev_err(&pdev->dev, "failed to register IB device\n");
         goto err_disable_intr;
     }
 
-    dev->nb_netdev.notifier_call = amd_emrdma_netdevice_event;
+    dev->nb_netdev.notifier_call = rocm_ernic_netdevice_event;
     ret = register_netdevice_notifier(&dev->nb_netdev);
     if (ret) {
         dev_err(&pdev->dev, "failed to register netdevice events\n");
@@ -1114,21 +1114,21 @@ static int amd_emrdma_pci_probe(struct pci_dev *pdev,
 err_unreg_ibdev:
     ib_unregister_device(&dev->ib_dev);
 err_disable_intr:
-    amd_emrdma_disable_intrs(dev);
+    rocm_ernic_disable_intrs(dev);
     kfree(dev->sgid_tbl);
 err_free_uar_table:
-    amd_emrdma_uar_table_cleanup(dev);
+    rocm_ernic_uar_table_cleanup(dev);
 err_free_intrs:
-    amd_emrdma_free_irq(dev);
+    rocm_ernic_free_irq(dev);
     pci_free_irq_vectors(pdev);
 err_free_cq_ring:
     dev_put(dev->netdev);
     dev->netdev = NULL;
-    amd_emrdma_page_dir_cleanup(dev, &dev->cq_pdir);
+    rocm_ernic_page_dir_cleanup(dev, &dev->cq_pdir);
 err_free_async_ring:
-    amd_emrdma_page_dir_cleanup(dev, &dev->async_pdir);
+    rocm_ernic_page_dir_cleanup(dev, &dev->async_pdir);
 err_free_slots:
-    amd_emrdma_free_slots(dev);
+    rocm_ernic_free_slots(dev);
 err_free_dsr:
     dma_free_coherent(&pdev->dev, sizeof(*dev->dsr), dev->dsr, dev->dsrbase);
 err_uar_unmap:
@@ -1141,16 +1141,16 @@ err_disable_pdev:
     pci_disable_device(pdev);
     pci_set_drvdata(pdev, NULL);
 err_free_device:
-    mutex_lock(&amd_emrdma_device_list_lock);
+    mutex_lock(&rocm_ernic_device_list_lock);
     list_del(&dev->device_link);
-    mutex_unlock(&amd_emrdma_device_list_lock);
+    mutex_unlock(&rocm_ernic_device_list_lock);
     ib_dealloc_device(&dev->ib_dev);
     return ret;
 }
 
-static void amd_emrdma_pci_remove(struct pci_dev *pdev)
+static void rocm_ernic_pci_remove(struct pci_dev *pdev)
 {
-    struct amd_emrdma_dev *dev = pci_get_drvdata(pdev);
+    struct rocm_ernic_dev *dev = pci_get_drvdata(pdev);
 
     if (!dev)
         return;
@@ -1168,19 +1168,19 @@ static void amd_emrdma_pci_remove(struct pci_dev *pdev)
     /* Unregister ib device */
     ib_unregister_device(&dev->ib_dev);
 
-    mutex_lock(&amd_emrdma_device_list_lock);
+    mutex_lock(&rocm_ernic_device_list_lock);
     list_del(&dev->device_link);
-    mutex_unlock(&amd_emrdma_device_list_lock);
+    mutex_unlock(&rocm_ernic_device_list_lock);
 
-    amd_emrdma_disable_intrs(dev);
-    amd_emrdma_free_irq(dev);
+    rocm_ernic_disable_intrs(dev);
+    rocm_ernic_free_irq(dev);
     pci_free_irq_vectors(pdev);
 
-    /* Deactivate amd_emrdma device */
-    amd_emrdma_write_reg(dev, AMD_EMRDMA_REG_CTL, AMD_EMRDMA_DEVICE_CTL_RESET);
-    amd_emrdma_page_dir_cleanup(dev, &dev->cq_pdir);
-    amd_emrdma_page_dir_cleanup(dev, &dev->async_pdir);
-    amd_emrdma_free_slots(dev);
+    /* Deactivate rocm_ernic device */
+    rocm_ernic_write_reg(dev, ROCM_ERNIC_REG_CTL, ROCM_ERNIC_DEVICE_CTL_RESET);
+    rocm_ernic_page_dir_cleanup(dev, &dev->cq_pdir);
+    rocm_ernic_page_dir_cleanup(dev, &dev->async_pdir);
+    rocm_ernic_free_slots(dev);
     dma_free_coherent(&pdev->dev, sizeof(*dev->dsr), dev->dsr, dev->dsrbase);
 
     iounmap(dev->regs);
@@ -1188,7 +1188,7 @@ static void amd_emrdma_pci_remove(struct pci_dev *pdev)
     kfree(dev->cq_tbl);
     kfree(dev->srq_tbl);
     kfree(dev->qp_tbl);
-    amd_emrdma_uar_table_cleanup(dev);
+    rocm_ernic_uar_table_cleanup(dev);
     iounmap(dev->driver_uar.map);
 
     ib_dealloc_device(&dev->ib_dev);
@@ -1200,49 +1200,49 @@ static void amd_emrdma_pci_remove(struct pci_dev *pdev)
 }
 
 /* AMD Emulated RDMA device (for vfio-user) */
-#define PCI_VENDOR_ID_AMD_EMRDMA 0x1022 /* AMD */
-#define PCI_DEVICE_ID_AMD_EMRDMA 0x1484 /* Emulated RDMA */
+#define PCI_VENDOR_ID_ROCM_ERNIC 0x1022 /* AMD */
+#define PCI_DEVICE_ID_ROCM_ERNIC 0x1484 /* Emulated RDMA */
 
-static const struct pci_device_id amd_emrdma_pci_table[] = {
+static const struct pci_device_id rocm_ernic_pci_table[] = {
     {
-        PCI_DEVICE(PCI_VENDOR_ID_AMD_EMRDMA, PCI_DEVICE_ID_AMD_EMRDMA),
+        PCI_DEVICE(PCI_VENDOR_ID_ROCM_ERNIC, PCI_DEVICE_ID_ROCM_ERNIC),
     },
     {0},
 };
 
-MODULE_DEVICE_TABLE(pci, amd_emrdma_pci_table);
+MODULE_DEVICE_TABLE(pci, rocm_ernic_pci_table);
 
-static struct pci_driver amd_emrdma_driver = {
+static struct pci_driver rocm_ernic_driver = {
     .name = DRV_NAME,
-    .id_table = amd_emrdma_pci_table,
-    .probe = amd_emrdma_pci_probe,
-    .remove = amd_emrdma_pci_remove,
+    .id_table = rocm_ernic_pci_table,
+    .probe = rocm_ernic_pci_probe,
+    .remove = rocm_ernic_pci_remove,
 };
 
-static int __init amd_emrdma_init(void)
+static int __init rocm_ernic_init(void)
 {
     int err;
 
-    event_wq = alloc_ordered_workqueue("amd_emrdma_event_wq", WQ_MEM_RECLAIM);
+    event_wq = alloc_ordered_workqueue("rocm_ernic_event_wq", WQ_MEM_RECLAIM);
     if (!event_wq)
         return -ENOMEM;
 
-    err = pci_register_driver(&amd_emrdma_driver);
+    err = pci_register_driver(&rocm_ernic_driver);
     if (err)
         destroy_workqueue(event_wq);
 
     return err;
 }
 
-static void __exit amd_emrdma_cleanup(void)
+static void __exit rocm_ernic_cleanup(void)
 {
-    pci_unregister_driver(&amd_emrdma_driver);
+    pci_unregister_driver(&rocm_ernic_driver);
 
     destroy_workqueue(event_wq);
 }
 
-module_init(amd_emrdma_init);
-module_exit(amd_emrdma_cleanup);
+module_init(rocm_ernic_init);
+module_exit(rocm_ernic_cleanup);
 
 MODULE_AUTHOR("Advanced Micro Devices, Inc");
 MODULE_DESCRIPTION("AMD ROCm ERNIC - Emulated RDMA NIC driver");

--- a/driver/rocm_ernic_misc.c
+++ b/driver/rocm_ernic_misc.c
@@ -49,8 +49,8 @@
 
 #include "rocm_ernic.h"
 
-int amd_emrdma_page_dir_init(struct amd_emrdma_dev *dev,
-                             struct amd_emrdma_page_dir *pdir, u64 npages,
+int rocm_ernic_page_dir_init(struct rocm_ernic_dev *dev,
+                             struct rocm_ernic_page_dir *pdir, u64 npages,
                              bool alloc_pages)
 {
     u64 i;
@@ -58,9 +58,9 @@ int amd_emrdma_page_dir_init(struct amd_emrdma_dev *dev,
     dev_info(&dev->pdev->dev, "page_dir_init: npages=%llu, alloc_pages=%d\n",
              npages, alloc_pages);
 
-    if (npages > AMD_EMRDMA_PAGE_DIR_MAX_PAGES) {
+    if (npages > ROCM_ERNIC_PAGE_DIR_MAX_PAGES) {
         dev_err(&dev->pdev->dev, "page_dir_init: npages > max (%llu > %d)\n",
-                npages, AMD_EMRDMA_PAGE_DIR_MAX_PAGES);
+                npages, ROCM_ERNIC_PAGE_DIR_MAX_PAGES);
         return -EINVAL;
     }
 
@@ -79,7 +79,7 @@ int amd_emrdma_page_dir_init(struct amd_emrdma_dev *dev,
              "page_dir_init: dir allocated at %p (dma=0x%llx)\n", pdir->dir,
              (unsigned long long)pdir->dir_dma);
 
-    pdir->ntables = AMD_EMRDMA_PAGE_DIR_TABLE(npages - 1) + 1;
+    pdir->ntables = ROCM_ERNIC_PAGE_DIR_TABLE(npages - 1) + 1;
     dev_info(&dev->pdev->dev, "page_dir_init: allocating %u tables\n",
              pdir->ntables);
     pdir->tables = kcalloc(pdir->ntables, sizeof(*pdir->tables), GFP_KERNEL);
@@ -118,37 +118,37 @@ int amd_emrdma_page_dir_init(struct amd_emrdma_dev *dev,
             if (!pdir->pages[i])
                 goto err;
 
-            amd_emrdma_page_dir_insert_dma(pdir, i, page_dma);
+            rocm_ernic_page_dir_insert_dma(pdir, i, page_dma);
         }
     }
 
     return 0;
 
 err:
-    amd_emrdma_page_dir_cleanup(dev, pdir);
+    rocm_ernic_page_dir_cleanup(dev, pdir);
 
     return -ENOMEM;
 }
 
-static u64 *amd_emrdma_page_dir_table(struct amd_emrdma_page_dir *pdir, u64 idx)
+static u64 *rocm_ernic_page_dir_table(struct rocm_ernic_page_dir *pdir, u64 idx)
 {
-    return pdir->tables[AMD_EMRDMA_PAGE_DIR_TABLE(idx)];
+    return pdir->tables[ROCM_ERNIC_PAGE_DIR_TABLE(idx)];
 }
 
-dma_addr_t amd_emrdma_page_dir_get_dma(struct amd_emrdma_page_dir *pdir,
+dma_addr_t rocm_ernic_page_dir_get_dma(struct rocm_ernic_page_dir *pdir,
                                        u64 idx)
 {
-    return amd_emrdma_page_dir_table(pdir, idx)[AMD_EMRDMA_PAGE_DIR_PAGE(idx)];
+    return rocm_ernic_page_dir_table(pdir, idx)[ROCM_ERNIC_PAGE_DIR_PAGE(idx)];
 }
 
-static void amd_emrdma_page_dir_cleanup_pages(struct amd_emrdma_dev *dev,
-                                              struct amd_emrdma_page_dir *pdir)
+static void rocm_ernic_page_dir_cleanup_pages(struct rocm_ernic_dev *dev,
+                                              struct rocm_ernic_page_dir *pdir)
 {
     if (pdir->pages) {
         u64 i;
 
         for (i = 0; i < pdir->npages && pdir->pages[i]; i++) {
-            dma_addr_t page_dma = amd_emrdma_page_dir_get_dma(pdir, i);
+            dma_addr_t page_dma = rocm_ernic_page_dir_get_dma(pdir, i);
 
             dma_free_coherent(&dev->pdev->dev, PAGE_SIZE, pdir->pages[i],
                               page_dma);
@@ -158,13 +158,13 @@ static void amd_emrdma_page_dir_cleanup_pages(struct amd_emrdma_dev *dev,
     }
 }
 
-static void amd_emrdma_page_dir_cleanup_tables(struct amd_emrdma_dev *dev,
-                                               struct amd_emrdma_page_dir *pdir)
+static void rocm_ernic_page_dir_cleanup_tables(struct rocm_ernic_dev *dev,
+                                               struct rocm_ernic_page_dir *pdir)
 {
     if (pdir->tables) {
         int i;
 
-        amd_emrdma_page_dir_cleanup_pages(dev, pdir);
+        rocm_ernic_page_dir_cleanup_pages(dev, pdir);
 
         for (i = 0; i < pdir->ntables; i++) {
             u64 *table = pdir->tables[i];
@@ -178,16 +178,16 @@ static void amd_emrdma_page_dir_cleanup_tables(struct amd_emrdma_dev *dev,
     }
 }
 
-void amd_emrdma_page_dir_cleanup(struct amd_emrdma_dev *dev,
-                                 struct amd_emrdma_page_dir *pdir)
+void rocm_ernic_page_dir_cleanup(struct rocm_ernic_dev *dev,
+                                 struct rocm_ernic_page_dir *pdir)
 {
     if (pdir->dir) {
-        amd_emrdma_page_dir_cleanup_tables(dev, pdir);
+        rocm_ernic_page_dir_cleanup_tables(dev, pdir);
         dma_free_coherent(&dev->pdev->dev, PAGE_SIZE, pdir->dir, pdir->dir_dma);
     }
 }
 
-int amd_emrdma_page_dir_insert_dma(struct amd_emrdma_page_dir *pdir, u64 idx,
+int rocm_ernic_page_dir_insert_dma(struct rocm_ernic_page_dir *pdir, u64 idx,
                                    dma_addr_t daddr)
 {
     u64 *table;
@@ -195,13 +195,13 @@ int amd_emrdma_page_dir_insert_dma(struct amd_emrdma_page_dir *pdir, u64 idx,
     if (idx >= pdir->npages)
         return -EINVAL;
 
-    table = amd_emrdma_page_dir_table(pdir, idx);
-    table[AMD_EMRDMA_PAGE_DIR_PAGE(idx)] = daddr;
+    table = rocm_ernic_page_dir_table(pdir, idx);
+    table[ROCM_ERNIC_PAGE_DIR_PAGE(idx)] = daddr;
 
     return 0;
 }
 
-int amd_emrdma_page_dir_insert_umem(struct amd_emrdma_page_dir *pdir,
+int rocm_ernic_page_dir_insert_umem(struct rocm_ernic_page_dir *pdir,
                                     struct ib_umem *umem, u64 offset)
 {
     struct ib_block_iter biter;
@@ -213,7 +213,7 @@ int amd_emrdma_page_dir_insert_umem(struct amd_emrdma_page_dir *pdir,
 
     rdma_umem_for_each_dma_block(umem, &biter, PAGE_SIZE)
     {
-        ret = amd_emrdma_page_dir_insert_dma(
+        ret = rocm_ernic_page_dir_insert_dma(
             pdir, i, rdma_block_iter_dma_address(&biter));
         if (ret)
             goto exit;
@@ -225,7 +225,7 @@ exit:
     return ret;
 }
 
-int amd_emrdma_page_dir_insert_page_list(struct amd_emrdma_page_dir *pdir,
+int rocm_ernic_page_dir_insert_page_list(struct rocm_ernic_page_dir *pdir,
                                          u64 *page_list, int num_pages)
 {
     int i;
@@ -235,7 +235,7 @@ int amd_emrdma_page_dir_insert_page_list(struct amd_emrdma_page_dir *pdir,
         return -EINVAL;
 
     for (i = 0; i < num_pages; i++) {
-        ret = amd_emrdma_page_dir_insert_dma(pdir, i, page_list[i]);
+        ret = rocm_ernic_page_dir_insert_dma(pdir, i, page_list[i]);
         if (ret)
             return ret;
     }
@@ -243,8 +243,8 @@ int amd_emrdma_page_dir_insert_page_list(struct amd_emrdma_page_dir *pdir,
     return 0;
 }
 
-void amd_emrdma_qp_cap_to_ib(struct ib_qp_cap *dst,
-                             const struct amd_emrdma_qp_cap *src)
+void rocm_ernic_qp_cap_to_ib(struct ib_qp_cap *dst,
+                             const struct rocm_ernic_qp_cap *src)
 {
     dst->max_send_wr = src->max_send_wr;
     dst->max_recv_wr = src->max_recv_wr;
@@ -253,7 +253,7 @@ void amd_emrdma_qp_cap_to_ib(struct ib_qp_cap *dst,
     dst->max_inline_data = src->max_inline_data;
 }
 
-void ib_qp_cap_to_amd_emrdma(struct amd_emrdma_qp_cap *dst,
+void ib_qp_cap_to_rocm_ernic(struct rocm_ernic_qp_cap *dst,
                              const struct ib_qp_cap *src)
 {
     dst->max_send_wr = src->max_send_wr;
@@ -263,43 +263,43 @@ void ib_qp_cap_to_amd_emrdma(struct amd_emrdma_qp_cap *dst,
     dst->max_inline_data = src->max_inline_data;
 }
 
-void amd_emrdma_gid_to_ib(union ib_gid *dst, const union amd_emrdma_gid *src)
+void rocm_ernic_gid_to_ib(union ib_gid *dst, const union rocm_ernic_gid *src)
 {
-    BUILD_BUG_ON(sizeof(union amd_emrdma_gid) != sizeof(union ib_gid));
+    BUILD_BUG_ON(sizeof(union rocm_ernic_gid) != sizeof(union ib_gid));
     memcpy(dst, src, sizeof(*src));
 }
 
-void ib_gid_to_amd_emrdma(union amd_emrdma_gid *dst, const union ib_gid *src)
+void ib_gid_to_rocm_ernic(union rocm_ernic_gid *dst, const union ib_gid *src)
 {
-    BUILD_BUG_ON(sizeof(union amd_emrdma_gid) != sizeof(union ib_gid));
+    BUILD_BUG_ON(sizeof(union rocm_ernic_gid) != sizeof(union ib_gid));
     memcpy(dst, src, sizeof(*src));
 }
 
-void amd_emrdma_global_route_to_ib(struct ib_global_route *dst,
-                                   const struct amd_emrdma_global_route *src)
+void rocm_ernic_global_route_to_ib(struct ib_global_route *dst,
+                                   const struct rocm_ernic_global_route *src)
 {
-    amd_emrdma_gid_to_ib(&dst->dgid, &src->dgid);
+    rocm_ernic_gid_to_ib(&dst->dgid, &src->dgid);
     dst->flow_label = src->flow_label;
     dst->sgid_index = src->sgid_index;
     dst->hop_limit = src->hop_limit;
     dst->traffic_class = src->traffic_class;
 }
 
-void ib_global_route_to_amd_emrdma(struct amd_emrdma_global_route *dst,
+void ib_global_route_to_rocm_ernic(struct rocm_ernic_global_route *dst,
                                    const struct ib_global_route *src)
 {
-    ib_gid_to_amd_emrdma(&dst->dgid, &src->dgid);
+    ib_gid_to_rocm_ernic(&dst->dgid, &src->dgid);
     dst->flow_label = src->flow_label;
     dst->sgid_index = src->sgid_index;
     dst->hop_limit = src->hop_limit;
     dst->traffic_class = src->traffic_class;
 }
 
-void amd_emrdma_ah_attr_to_rdma(struct rdma_ah_attr *dst,
-                                const struct amd_emrdma_ah_attr *src)
+void rocm_ernic_ah_attr_to_rdma(struct rdma_ah_attr *dst,
+                                const struct rocm_ernic_ah_attr *src)
 {
     dst->type = RDMA_AH_ATTR_TYPE_ROCE;
-    amd_emrdma_global_route_to_ib(rdma_ah_retrieve_grh(dst), &src->grh);
+    rocm_ernic_global_route_to_ib(rdma_ah_retrieve_grh(dst), &src->grh);
     rdma_ah_set_dlid(dst, src->dlid);
     rdma_ah_set_sl(dst, src->sl);
     rdma_ah_set_path_bits(dst, src->src_path_bits);
@@ -309,10 +309,10 @@ void amd_emrdma_ah_attr_to_rdma(struct rdma_ah_attr *dst,
     memcpy(dst->roce.dmac, &src->dmac, ETH_ALEN);
 }
 
-void rdma_ah_attr_to_amd_emrdma(struct amd_emrdma_ah_attr *dst,
+void rdma_ah_attr_to_rocm_ernic(struct rocm_ernic_ah_attr *dst,
                                 const struct rdma_ah_attr *src)
 {
-    ib_global_route_to_amd_emrdma(&dst->grh, rdma_ah_read_grh(src));
+    ib_global_route_to_rocm_ernic(&dst->grh, rdma_ah_read_grh(src));
     dst->dlid = rdma_ah_get_dlid(src);
     dst->sl = rdma_ah_get_sl(src);
     dst->src_path_bits = rdma_ah_get_path_bits(src);
@@ -322,9 +322,9 @@ void rdma_ah_attr_to_amd_emrdma(struct amd_emrdma_ah_attr *dst,
     memcpy(&dst->dmac, src->roce.dmac, sizeof(dst->dmac));
 }
 
-u8 ib_gid_type_to_amd_emrdma(enum ib_gid_type gid_type)
+u8 ib_gid_type_to_rocm_ernic(enum ib_gid_type gid_type)
 {
     return (gid_type == IB_GID_TYPE_ROCE_UDP_ENCAP)
-               ? AMD_EMRDMA_GID_TYPE_FLAG_ROCE_V2
-               : AMD_EMRDMA_GID_TYPE_FLAG_ROCE_V1;
+               ? ROCM_ERNIC_GID_TYPE_FLAG_ROCE_V2
+               : ROCM_ERNIC_GID_TYPE_FLAG_ROCE_V1;
 }

--- a/driver/rocm_ernic_mr.c
+++ b/driver/rocm_ernic_mr.c
@@ -49,20 +49,20 @@
 #include "rocm_ernic.h"
 
 /**
- * amd_emrdma_get_dma_mr - get a DMA memory region
+ * rocm_ernic_get_dma_mr - get a DMA memory region
  * @pd: protection domain
  * @acc: access flags
  *
  * @return: ib_mr pointer on success, otherwise returns an errno.
  */
-struct ib_mr *amd_emrdma_get_dma_mr(struct ib_pd *pd, int acc)
+struct ib_mr *rocm_ernic_get_dma_mr(struct ib_pd *pd, int acc)
 {
-    struct amd_emrdma_dev *dev = to_vdev(pd->device);
-    struct amd_emrdma_user_mr *mr;
-    union amd_emrdma_cmd_req req;
-    union amd_emrdma_cmd_resp rsp;
-    struct amd_emrdma_cmd_create_mr *cmd = &req.create_mr;
-    struct amd_emrdma_cmd_create_mr_resp *resp = &rsp.create_mr_resp;
+    struct rocm_ernic_dev *dev = to_vdev(pd->device);
+    struct rocm_ernic_user_mr *mr;
+    union rocm_ernic_cmd_req req;
+    union rocm_ernic_cmd_resp rsp;
+    struct rocm_ernic_cmd_create_mr *cmd = &req.create_mr;
+    struct rocm_ernic_cmd_create_mr_resp *resp = &rsp.create_mr_resp;
     int ret;
 
     /* Support only LOCAL_WRITE flag for DMA MRs */
@@ -76,12 +76,12 @@ struct ib_mr *amd_emrdma_get_dma_mr(struct ib_pd *pd, int acc)
         return ERR_PTR(-ENOMEM);
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_CREATE_MR;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_CREATE_MR;
     cmd->pd_handle = to_vpd(pd)->pd_handle;
     cmd->access_flags = acc;
-    cmd->flags = AMD_EMRDMA_MR_FLAG_DMA;
+    cmd->flags = ROCM_ERNIC_MR_FLAG_DMA;
 
-    ret = amd_emrdma_cmd_post(dev, &req, &rsp, AMD_EMRDMA_CMD_CREATE_MR_RESP);
+    ret = rocm_ernic_cmd_post(dev, &req, &rsp, ROCM_ERNIC_CMD_CREATE_MR_RESP);
     if (ret < 0) {
         dev_warn(&dev->pdev->dev, "could not get DMA mem region, error: %d\n",
                  ret);
@@ -97,7 +97,7 @@ struct ib_mr *amd_emrdma_get_dma_mr(struct ib_pd *pd, int acc)
 }
 
 /**
- * amd_emrdma_reg_user_mr - register a userspace memory region
+ * rocm_ernic_reg_user_mr - register a userspace memory region
  * @pd: protection domain
  * @start: starting address
  * @length: length of region
@@ -107,17 +107,17 @@ struct ib_mr *amd_emrdma_get_dma_mr(struct ib_pd *pd, int acc)
  *
  * @return: ib_mr pointer on success, otherwise returns an errno.
  */
-struct ib_mr *amd_emrdma_reg_user_mr(struct ib_pd *pd, u64 start, u64 length,
+struct ib_mr *rocm_ernic_reg_user_mr(struct ib_pd *pd, u64 start, u64 length,
                                      u64 virt_addr, int access_flags,
                                      struct ib_udata *udata)
 {
-    struct amd_emrdma_dev *dev = to_vdev(pd->device);
-    struct amd_emrdma_user_mr *mr = NULL;
+    struct rocm_ernic_dev *dev = to_vdev(pd->device);
+    struct rocm_ernic_user_mr *mr = NULL;
     struct ib_umem *umem;
-    union amd_emrdma_cmd_req req;
-    union amd_emrdma_cmd_resp rsp;
-    struct amd_emrdma_cmd_create_mr *cmd = &req.create_mr;
-    struct amd_emrdma_cmd_create_mr_resp *resp = &rsp.create_mr_resp;
+    union rocm_ernic_cmd_req req;
+    union rocm_ernic_cmd_resp rsp;
+    struct rocm_ernic_cmd_create_mr *cmd = &req.create_mr;
+    struct rocm_ernic_cmd_create_mr_resp *resp = &rsp.create_mr_resp;
     int ret, npages;
 
     if (length == 0 || length > dev->dsr->caps.max_mr_size) {
@@ -132,7 +132,7 @@ struct ib_mr *amd_emrdma_reg_user_mr(struct ib_pd *pd, u64 start, u64 length,
     }
 
     npages = ib_umem_num_dma_blocks(umem, PAGE_SIZE);
-    if (npages < 0 || npages > AMD_EMRDMA_PAGE_DIR_MAX_PAGES) {
+    if (npages < 0 || npages > ROCM_ERNIC_PAGE_DIR_MAX_PAGES) {
         dev_warn(&dev->pdev->dev, "overflow %d pages in mem region\n", npages);
         ret = -EINVAL;
         goto err_umem;
@@ -148,18 +148,18 @@ struct ib_mr *amd_emrdma_reg_user_mr(struct ib_pd *pd, u64 start, u64 length,
     mr->mmr.size = length;
     mr->umem = umem;
 
-    ret = amd_emrdma_page_dir_init(dev, &mr->pdir, npages, false);
+    ret = rocm_ernic_page_dir_init(dev, &mr->pdir, npages, false);
     if (ret) {
         dev_warn(&dev->pdev->dev, "could not allocate page directory\n");
         goto err_umem;
     }
 
-    ret = amd_emrdma_page_dir_insert_umem(&mr->pdir, mr->umem, 0);
+    ret = rocm_ernic_page_dir_insert_umem(&mr->pdir, mr->umem, 0);
     if (ret)
         goto err_pdir;
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_CREATE_MR;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_CREATE_MR;
     cmd->start = start;
     cmd->length = length;
     cmd->pd_handle = to_vpd(pd)->pd_handle;
@@ -167,7 +167,7 @@ struct ib_mr *amd_emrdma_reg_user_mr(struct ib_pd *pd, u64 start, u64 length,
     cmd->nchunks = npages;
     cmd->pdir_dma = mr->pdir.dir_dma;
 
-    ret = amd_emrdma_cmd_post(dev, &req, &rsp, AMD_EMRDMA_CMD_CREATE_MR_RESP);
+    ret = rocm_ernic_cmd_post(dev, &req, &rsp, ROCM_ERNIC_CMD_CREATE_MR_RESP);
     if (ret < 0) {
         dev_warn(&dev->pdev->dev, "could not register mem region, error: %d\n",
                  ret);
@@ -181,7 +181,7 @@ struct ib_mr *amd_emrdma_reg_user_mr(struct ib_pd *pd, u64 start, u64 length,
     return &mr->ibmr;
 
 err_pdir:
-    amd_emrdma_page_dir_cleanup(dev, &mr->pdir);
+    rocm_ernic_page_dir_cleanup(dev, &mr->pdir);
 err_umem:
     ib_umem_release(umem);
     kfree(mr);
@@ -190,27 +190,27 @@ err_umem:
 }
 
 /**
- * amd_emrdma_alloc_mr - allocate a memory region
+ * rocm_ernic_alloc_mr - allocate a memory region
  * @pd: protection domain
  * @mr_type: type of memory region
  * @max_num_sg: maximum number of pages
  *
  * @return: ib_mr pointer on success, otherwise returns an errno.
  */
-struct ib_mr *amd_emrdma_alloc_mr(struct ib_pd *pd, enum ib_mr_type mr_type,
+struct ib_mr *rocm_ernic_alloc_mr(struct ib_pd *pd, enum ib_mr_type mr_type,
                                   u32 max_num_sg)
 {
-    struct amd_emrdma_dev *dev = to_vdev(pd->device);
-    struct amd_emrdma_user_mr *mr;
-    union amd_emrdma_cmd_req req;
-    union amd_emrdma_cmd_resp rsp;
-    struct amd_emrdma_cmd_create_mr *cmd = &req.create_mr;
-    struct amd_emrdma_cmd_create_mr_resp *resp = &rsp.create_mr_resp;
+    struct rocm_ernic_dev *dev = to_vdev(pd->device);
+    struct rocm_ernic_user_mr *mr;
+    union rocm_ernic_cmd_req req;
+    union rocm_ernic_cmd_resp rsp;
+    struct rocm_ernic_cmd_create_mr *cmd = &req.create_mr;
+    struct rocm_ernic_cmd_create_mr_resp *resp = &rsp.create_mr_resp;
     int size = max_num_sg * sizeof(u64);
     int ret;
 
     if (mr_type != IB_MR_TYPE_MEM_REG ||
-        max_num_sg > AMD_EMRDMA_MAX_FAST_REG_PAGES)
+        max_num_sg > ROCM_ERNIC_MAX_FAST_REG_PAGES)
         return ERR_PTR(-EINVAL);
 
     mr = kzalloc(sizeof(*mr), GFP_KERNEL);
@@ -223,7 +223,7 @@ struct ib_mr *amd_emrdma_alloc_mr(struct ib_pd *pd, enum ib_mr_type mr_type,
         goto freemr;
     }
 
-    ret = amd_emrdma_page_dir_init(dev, &mr->pdir, max_num_sg, false);
+    ret = rocm_ernic_page_dir_init(dev, &mr->pdir, max_num_sg, false);
     if (ret) {
         dev_warn(&dev->pdev->dev, "failed to allocate page dir for mr\n");
         ret = -ENOMEM;
@@ -231,13 +231,13 @@ struct ib_mr *amd_emrdma_alloc_mr(struct ib_pd *pd, enum ib_mr_type mr_type,
     }
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_CREATE_MR;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_CREATE_MR;
     cmd->pd_handle = to_vpd(pd)->pd_handle;
     cmd->access_flags = 0;
-    cmd->flags = AMD_EMRDMA_MR_FLAG_FRMR;
+    cmd->flags = ROCM_ERNIC_MR_FLAG_FRMR;
     cmd->nchunks = max_num_sg;
 
-    ret = amd_emrdma_cmd_post(dev, &req, &rsp, AMD_EMRDMA_CMD_CREATE_MR_RESP);
+    ret = rocm_ernic_cmd_post(dev, &req, &rsp, ROCM_ERNIC_CMD_CREATE_MR_RESP);
     if (ret < 0) {
         dev_warn(&dev->pdev->dev, "could not create FR mem region, error: %d\n",
                  ret);
@@ -254,7 +254,7 @@ struct ib_mr *amd_emrdma_alloc_mr(struct ib_pd *pd, enum ib_mr_type mr_type,
     return &mr->ibmr;
 
 freepdir:
-    amd_emrdma_page_dir_cleanup(dev, &mr->pdir);
+    rocm_ernic_page_dir_cleanup(dev, &mr->pdir);
 freepages:
     kfree(mr->pages);
 freemr:
@@ -263,29 +263,29 @@ freemr:
 }
 
 /**
- * amd_emrdma_dereg_mr - deregister a memory region
+ * rocm_ernic_dereg_mr - deregister a memory region
  * @ibmr: memory region
  * @udata: pointer to user data
  *
  * @return: 0 on success.
  */
-int amd_emrdma_dereg_mr(struct ib_mr *ibmr, struct ib_udata *udata)
+int rocm_ernic_dereg_mr(struct ib_mr *ibmr, struct ib_udata *udata)
 {
-    struct amd_emrdma_user_mr *mr = to_vmr(ibmr);
-    struct amd_emrdma_dev *dev = to_vdev(ibmr->device);
-    union amd_emrdma_cmd_req req;
-    struct amd_emrdma_cmd_destroy_mr *cmd = &req.destroy_mr;
+    struct rocm_ernic_user_mr *mr = to_vmr(ibmr);
+    struct rocm_ernic_dev *dev = to_vdev(ibmr->device);
+    union rocm_ernic_cmd_req req;
+    struct rocm_ernic_cmd_destroy_mr *cmd = &req.destroy_mr;
     int ret;
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_DESTROY_MR;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_DESTROY_MR;
     cmd->mr_handle = mr->mmr.mr_handle;
-    ret = amd_emrdma_cmd_post(dev, &req, NULL, 0);
+    ret = rocm_ernic_cmd_post(dev, &req, NULL, 0);
     if (ret < 0)
         dev_warn(&dev->pdev->dev,
                  "could not deregister mem region, error: %d\n", ret);
 
-    amd_emrdma_page_dir_cleanup(dev, &mr->pdir);
+    rocm_ernic_page_dir_cleanup(dev, &mr->pdir);
     ib_umem_release(mr->umem);
 
     kfree(mr->pages);
@@ -294,9 +294,9 @@ int amd_emrdma_dereg_mr(struct ib_mr *ibmr, struct ib_udata *udata)
     return 0;
 }
 
-static int amd_emrdma_set_page(struct ib_mr *ibmr, u64 addr)
+static int rocm_ernic_set_page(struct ib_mr *ibmr, u64 addr)
 {
-    struct amd_emrdma_user_mr *mr = to_vmr(ibmr);
+    struct rocm_ernic_user_mr *mr = to_vmr(ibmr);
 
     if (mr->npages == mr->max_pages)
         return -ENOMEM;
@@ -305,16 +305,16 @@ static int amd_emrdma_set_page(struct ib_mr *ibmr, u64 addr)
     return 0;
 }
 
-int amd_emrdma_map_mr_sg(struct ib_mr *ibmr, struct scatterlist *sg,
+int rocm_ernic_map_mr_sg(struct ib_mr *ibmr, struct scatterlist *sg,
                          int sg_nents, unsigned int *sg_offset)
 {
-    struct amd_emrdma_user_mr *mr = to_vmr(ibmr);
-    struct amd_emrdma_dev *dev = to_vdev(ibmr->device);
+    struct rocm_ernic_user_mr *mr = to_vmr(ibmr);
+    struct rocm_ernic_dev *dev = to_vdev(ibmr->device);
     int ret;
 
     mr->npages = 0;
 
-    ret = ib_sg_to_pages(ibmr, sg, sg_nents, sg_offset, amd_emrdma_set_page);
+    ret = ib_sg_to_pages(ibmr, sg, sg_nents, sg_offset, rocm_ernic_set_page);
     if (ret < 0)
         dev_warn(&dev->pdev->dev, "could not map sg to pages\n");
 

--- a/driver/rocm_ernic_qp.c
+++ b/driver/rocm_ernic_qp.c
@@ -52,19 +52,19 @@
 
 #include "rocm_ernic.h"
 
-static void __amd_emrdma_destroy_qp(struct amd_emrdma_dev *dev,
-                                    struct amd_emrdma_qp *qp);
+static void __rocm_ernic_destroy_qp(struct rocm_ernic_dev *dev,
+                                    struct rocm_ernic_qp *qp);
 
-static inline void get_cqs(struct amd_emrdma_qp *qp,
-                           struct amd_emrdma_cq **send_cq,
-                           struct amd_emrdma_cq **recv_cq)
+static inline void get_cqs(struct rocm_ernic_qp *qp,
+                           struct rocm_ernic_cq **send_cq,
+                           struct rocm_ernic_cq **recv_cq)
 {
     *send_cq = to_vcq(qp->ibqp.send_cq);
     *recv_cq = to_vcq(qp->ibqp.recv_cq);
 }
 
-static void amd_emrdma_lock_cqs(struct amd_emrdma_cq *scq,
-                                struct amd_emrdma_cq *rcq,
+static void rocm_ernic_lock_cqs(struct rocm_ernic_cq *scq,
+                                struct rocm_ernic_cq *rcq,
                                 unsigned long *scq_flags,
                                 unsigned long *rcq_flags)
     __acquires(scq->cq_lock) __acquires(rcq->cq_lock)
@@ -83,8 +83,8 @@ static void amd_emrdma_lock_cqs(struct amd_emrdma_cq *scq,
     }
 }
 
-static void amd_emrdma_unlock_cqs(struct amd_emrdma_cq *scq,
-                                  struct amd_emrdma_cq *rcq,
+static void rocm_ernic_unlock_cqs(struct rocm_ernic_cq *scq,
+                                  struct rocm_ernic_cq *rcq,
                                   unsigned long *scq_flags,
                                   unsigned long *rcq_flags)
     __releases(scq->cq_lock) __releases(rcq->cq_lock)
@@ -101,20 +101,20 @@ static void amd_emrdma_unlock_cqs(struct amd_emrdma_cq *scq,
     }
 }
 
-static void amd_emrdma_reset_qp(struct amd_emrdma_qp *qp)
+static void rocm_ernic_reset_qp(struct rocm_ernic_qp *qp)
 {
-    struct amd_emrdma_cq *scq, *rcq;
+    struct rocm_ernic_cq *scq, *rcq;
     unsigned long scq_flags, rcq_flags;
 
     /* Clean up cqes */
     get_cqs(qp, &scq, &rcq);
-    amd_emrdma_lock_cqs(scq, rcq, &scq_flags, &rcq_flags);
+    rocm_ernic_lock_cqs(scq, rcq, &scq_flags, &rcq_flags);
 
-    _amd_emrdma_flush_cqe(qp, scq);
+    _rocm_ernic_flush_cqe(qp, scq);
     if (scq != rcq)
-        _amd_emrdma_flush_cqe(qp, rcq);
+        _rocm_ernic_flush_cqe(qp, rcq);
 
-    amd_emrdma_unlock_cqs(scq, rcq, &scq_flags, &rcq_flags);
+    rocm_ernic_unlock_cqs(scq, rcq, &scq_flags, &rcq_flags);
 
     /*
      * Reset queuepair. The checks are because usermode queuepairs won't
@@ -130,9 +130,9 @@ static void amd_emrdma_reset_qp(struct amd_emrdma_qp *qp)
     }
 }
 
-static int amd_emrdma_set_rq_size(struct amd_emrdma_dev *dev,
+static int rocm_ernic_set_rq_size(struct rocm_ernic_dev *dev,
                                   struct ib_qp_cap *req_cap,
-                                  struct amd_emrdma_qp *qp)
+                                  struct rocm_ernic_qp *qp)
 {
     if (req_cap->max_recv_wr > dev->dsr->caps.max_qp_wr ||
         req_cap->max_recv_sge > dev->dsr->caps.max_sge) {
@@ -148,17 +148,17 @@ static int amd_emrdma_set_rq_size(struct amd_emrdma_dev *dev,
     req_cap->max_recv_sge = qp->rq.max_sg;
 
     qp->rq.wqe_size =
-        roundup_pow_of_two(sizeof(struct amd_emrdma_rq_wqe_hdr) +
-                           sizeof(struct amd_emrdma_sge) * qp->rq.max_sg);
+        roundup_pow_of_two(sizeof(struct rocm_ernic_rq_wqe_hdr) +
+                           sizeof(struct rocm_ernic_sge) * qp->rq.max_sg);
     qp->npages_recv =
         (qp->rq.wqe_cnt * qp->rq.wqe_size + PAGE_SIZE - 1) / PAGE_SIZE;
 
     return 0;
 }
 
-static int amd_emrdma_set_sq_size(struct amd_emrdma_dev *dev,
+static int rocm_ernic_set_sq_size(struct rocm_ernic_dev *dev,
                                   struct ib_qp_cap *req_cap,
-                                  struct amd_emrdma_qp *qp)
+                                  struct rocm_ernic_qp *qp)
 {
     if (req_cap->max_send_wr > dev->dsr->caps.max_qp_wr ||
         req_cap->max_send_sge > dev->dsr->caps.max_sge) {
@@ -174,36 +174,36 @@ static int amd_emrdma_set_sq_size(struct amd_emrdma_dev *dev,
     req_cap->max_send_sge = qp->sq.max_sg;
 
     qp->sq.wqe_size =
-        roundup_pow_of_two(sizeof(struct amd_emrdma_sq_wqe_hdr) +
-                           sizeof(struct amd_emrdma_sge) * qp->sq.max_sg);
+        roundup_pow_of_two(sizeof(struct rocm_ernic_sq_wqe_hdr) +
+                           sizeof(struct rocm_ernic_sge) * qp->sq.max_sg);
     /* Note: one extra page for the header. */
     qp->npages_send =
-        AMD_EMRDMA_QP_NUM_HEADER_PAGES +
+        ROCM_ERNIC_QP_NUM_HEADER_PAGES +
         (qp->sq.wqe_cnt * qp->sq.wqe_size + PAGE_SIZE - 1) / PAGE_SIZE;
 
     return 0;
 }
 
 /**
- * amd_emrdma_create_qp - create queue pair
+ * rocm_ernic_create_qp - create queue pair
  * @ibqp: queue pair
  * @init_attr: queue pair attributes
  * @udata: user data
  *
  * @return: the 0 on success, otherwise returns an errno.
  */
-int amd_emrdma_create_qp(struct ib_qp *ibqp, struct ib_qp_init_attr *init_attr,
+int rocm_ernic_create_qp(struct ib_qp *ibqp, struct ib_qp_init_attr *init_attr,
                          struct ib_udata *udata)
 {
-    struct amd_emrdma_qp *qp = to_vqp(ibqp);
-    struct amd_emrdma_dev *dev = to_vdev(ibqp->device);
-    union amd_emrdma_cmd_req req;
-    union amd_emrdma_cmd_resp rsp;
-    struct amd_emrdma_cmd_create_qp *cmd = &req.create_qp;
-    struct amd_emrdma_cmd_create_qp_resp *resp = &rsp.create_qp_resp;
-    struct amd_emrdma_cmd_create_qp_resp_v2 *resp_v2 = &rsp.create_qp_resp_v2;
-    struct amd_emrdma_create_qp ucmd;
-    struct amd_emrdma_create_qp_resp qp_resp = {};
+    struct rocm_ernic_qp *qp = to_vqp(ibqp);
+    struct rocm_ernic_dev *dev = to_vdev(ibqp->device);
+    union rocm_ernic_cmd_req req;
+    union rocm_ernic_cmd_resp rsp;
+    struct rocm_ernic_cmd_create_qp *cmd = &req.create_qp;
+    struct rocm_ernic_cmd_create_qp_resp *resp = &rsp.create_qp_resp;
+    struct rocm_ernic_cmd_create_qp_resp_v2 *resp_v2 = &rsp.create_qp_resp_v2;
+    struct rocm_ernic_create_qp ucmd;
+    struct rocm_ernic_create_qp_resp qp_resp = {};
     unsigned long flags;
     int ret;
     bool is_srq = !!init_attr->srq;
@@ -258,7 +258,7 @@ int amd_emrdma_create_qp(struct ib_qp *ibqp, struct ib_qp_init_attr *init_attr,
             }
 
             /* Userspace supports qpn and qp handles? */
-            if (dev->dsr_version >= AMD_EMRDMA_QPHANDLE_VERSION &&
+            if (dev->dsr_version >= ROCM_ERNIC_QPHANDLE_VERSION &&
                 udata->outlen < sizeof(qp_resp)) {
                 dev_warn(&dev->pdev->dev, "create queuepair not supported\n");
                 ret = -EOPNOTSUPP;
@@ -295,12 +295,12 @@ int amd_emrdma_create_qp(struct ib_qp *ibqp, struct ib_qp_init_attr *init_attr,
                 qp->npages_recv = 0;
             qp->npages = qp->npages_send + qp->npages_recv;
         } else {
-            ret = amd_emrdma_set_sq_size(to_vdev(ibqp->device), &init_attr->cap,
+            ret = rocm_ernic_set_sq_size(to_vdev(ibqp->device), &init_attr->cap,
                                          qp);
             if (ret)
                 goto err_qp;
 
-            ret = amd_emrdma_set_rq_size(to_vdev(ibqp->device), &init_attr->cap,
+            ret = rocm_ernic_set_rq_size(to_vdev(ibqp->device), &init_attr->cap,
                                          qp);
             if (ret)
                 goto err_qp;
@@ -308,29 +308,29 @@ int amd_emrdma_create_qp(struct ib_qp *ibqp, struct ib_qp_init_attr *init_attr,
             qp->npages = qp->npages_send + qp->npages_recv;
 
             /* Skip header page. */
-            qp->sq.offset = AMD_EMRDMA_QP_NUM_HEADER_PAGES * PAGE_SIZE;
+            qp->sq.offset = ROCM_ERNIC_QP_NUM_HEADER_PAGES * PAGE_SIZE;
 
             /* Recv queue pages are after send pages. */
             qp->rq.offset = qp->npages_send * PAGE_SIZE;
         }
 
-        if (qp->npages < 0 || qp->npages > AMD_EMRDMA_PAGE_DIR_MAX_PAGES) {
+        if (qp->npages < 0 || qp->npages > ROCM_ERNIC_PAGE_DIR_MAX_PAGES) {
             dev_warn(&dev->pdev->dev, "overflow pages in queuepair\n");
             ret = -EINVAL;
             goto err_umem;
         }
 
         ret =
-            amd_emrdma_page_dir_init(dev, &qp->pdir, qp->npages, qp->is_kernel);
+            rocm_ernic_page_dir_init(dev, &qp->pdir, qp->npages, qp->is_kernel);
         if (ret) {
             dev_warn(&dev->pdev->dev, "could not allocate page directory\n");
             goto err_umem;
         }
 
         if (!qp->is_kernel) {
-            amd_emrdma_page_dir_insert_umem(&qp->pdir, qp->sumem, 0);
+            rocm_ernic_page_dir_insert_umem(&qp->pdir, qp->sumem, 0);
             if (!is_srq)
-                amd_emrdma_page_dir_insert_umem(&qp->pdir, qp->rumem,
+                rocm_ernic_page_dir_insert_umem(&qp->pdir, qp->rumem,
                                                 qp->npages_send);
         } else {
             /* Ring state is always the first page. */
@@ -347,7 +347,7 @@ int amd_emrdma_create_qp(struct ib_qp *ibqp, struct ib_qp_init_attr *init_attr,
     init_attr->cap.max_inline_data = 0;
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_CREATE_QP;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_CREATE_QP;
     cmd->pd_handle = to_vpd(ibqp->pd)->pd_handle;
     cmd->send_cq_handle = to_vcq(init_attr->send_cq)->cq_handle;
     cmd->recv_cq_handle = to_vcq(init_attr->recv_cq)->cq_handle;
@@ -361,19 +361,19 @@ int amd_emrdma_create_qp(struct ib_qp *ibqp, struct ib_qp_init_attr *init_attr,
     cmd->max_recv_sge = init_attr->cap.max_recv_sge;
     cmd->max_inline_data = init_attr->cap.max_inline_data;
     cmd->sq_sig_all = (init_attr->sq_sig_type == IB_SIGNAL_ALL_WR) ? 1 : 0;
-    cmd->qp_type = ib_qp_type_to_amd_emrdma(init_attr->qp_type);
+    cmd->qp_type = ib_qp_type_to_rocm_ernic(init_attr->qp_type);
     cmd->is_srq = is_srq;
     cmd->lkey = 0;
     cmd->access_flags = IB_ACCESS_LOCAL_WRITE;
     cmd->total_chunks = qp->npages;
-    cmd->send_chunks = qp->npages_send - AMD_EMRDMA_QP_NUM_HEADER_PAGES;
+    cmd->send_chunks = qp->npages_send - ROCM_ERNIC_QP_NUM_HEADER_PAGES;
     cmd->pdir_dma = qp->pdir.dir_dma;
 
     dev_dbg(&dev->pdev->dev, "create queuepair with %d, %d, %d, %d\n",
             cmd->max_send_wr, cmd->max_recv_wr, cmd->max_send_sge,
             cmd->max_recv_sge);
 
-    ret = amd_emrdma_cmd_post(dev, &req, &rsp, AMD_EMRDMA_CMD_CREATE_QP_RESP);
+    ret = rocm_ernic_cmd_post(dev, &req, &rsp, ROCM_ERNIC_CMD_CREATE_QP_RESP);
     if (ret < 0) {
         dev_warn(&dev->pdev->dev, "could not create queuepair, error: %d\n",
                  ret);
@@ -383,7 +383,7 @@ int amd_emrdma_create_qp(struct ib_qp *ibqp, struct ib_qp_init_attr *init_attr,
     /* max_send_wr/_recv_wr/_send_sge/_recv_sge/_inline_data */
     qp->port = init_attr->port_num;
 
-    if (dev->dsr_version >= AMD_EMRDMA_QPHANDLE_VERSION) {
+    if (dev->dsr_version >= ROCM_ERNIC_QPHANDLE_VERSION) {
         qp->ibqp.qp_num = resp_v2->qpn;
         qp->qp_handle = resp_v2->qp_handle;
     } else {
@@ -402,7 +402,7 @@ int amd_emrdma_create_qp(struct ib_qp *ibqp, struct ib_qp_init_attr *init_attr,
         if (ib_copy_to_udata(udata, &qp_resp,
                              min(udata->outlen, sizeof(qp_resp)))) {
             dev_warn(&dev->pdev->dev, "failed to copy back udata\n");
-            __amd_emrdma_destroy_qp(dev, qp);
+            __rocm_ernic_destroy_qp(dev, qp);
             return -EINVAL;
         }
     }
@@ -410,7 +410,7 @@ int amd_emrdma_create_qp(struct ib_qp *ibqp, struct ib_qp_init_attr *init_attr,
     return 0;
 
 err_pdir:
-    amd_emrdma_page_dir_cleanup(dev, &qp->pdir);
+    rocm_ernic_page_dir_cleanup(dev, &qp->pdir);
 err_umem:
     ib_umem_release(qp->rumem);
     ib_umem_release(qp->sumem);
@@ -419,10 +419,10 @@ err_qp:
     return ret;
 }
 
-static void _amd_emrdma_free_qp(struct amd_emrdma_qp *qp)
+static void _rocm_ernic_free_qp(struct rocm_ernic_qp *qp)
 {
     unsigned long flags;
-    struct amd_emrdma_dev *dev = to_vdev(qp->ibqp.device);
+    struct rocm_ernic_dev *dev = to_vdev(qp->ibqp.device);
 
     spin_lock_irqsave(&dev->qp_tbl_lock, flags);
     dev->qp_tbl[qp->qp_handle] = NULL;
@@ -435,77 +435,77 @@ static void _amd_emrdma_free_qp(struct amd_emrdma_qp *qp)
     ib_umem_release(qp->rumem);
     ib_umem_release(qp->sumem);
 
-    amd_emrdma_page_dir_cleanup(dev, &qp->pdir);
+    rocm_ernic_page_dir_cleanup(dev, &qp->pdir);
 
     atomic_dec(&dev->num_qps);
 }
 
-static void amd_emrdma_free_qp(struct amd_emrdma_qp *qp)
+static void rocm_ernic_free_qp(struct rocm_ernic_qp *qp)
 {
-    struct amd_emrdma_cq *scq;
-    struct amd_emrdma_cq *rcq;
+    struct rocm_ernic_cq *scq;
+    struct rocm_ernic_cq *rcq;
     unsigned long scq_flags, rcq_flags;
 
     /* In case cq is polling */
     get_cqs(qp, &scq, &rcq);
-    amd_emrdma_lock_cqs(scq, rcq, &scq_flags, &rcq_flags);
+    rocm_ernic_lock_cqs(scq, rcq, &scq_flags, &rcq_flags);
 
-    _amd_emrdma_flush_cqe(qp, scq);
+    _rocm_ernic_flush_cqe(qp, scq);
     if (scq != rcq)
-        _amd_emrdma_flush_cqe(qp, rcq);
+        _rocm_ernic_flush_cqe(qp, rcq);
 
     /*
      * We're now unlocking the CQs before clearing out the qp handle this
      * should still be safe. We have destroyed the backend QP and flushed
      * the CQEs so there should be no other completions for this QP.
      */
-    amd_emrdma_unlock_cqs(scq, rcq, &scq_flags, &rcq_flags);
+    rocm_ernic_unlock_cqs(scq, rcq, &scq_flags, &rcq_flags);
 
-    _amd_emrdma_free_qp(qp);
+    _rocm_ernic_free_qp(qp);
 }
 
-static inline void _amd_emrdma_destroy_qp_work(struct amd_emrdma_dev *dev,
+static inline void _rocm_ernic_destroy_qp_work(struct rocm_ernic_dev *dev,
                                                u32 qp_handle)
 {
-    union amd_emrdma_cmd_req req;
-    struct amd_emrdma_cmd_destroy_qp *cmd = &req.destroy_qp;
+    union rocm_ernic_cmd_req req;
+    struct rocm_ernic_cmd_destroy_qp *cmd = &req.destroy_qp;
     int ret;
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_DESTROY_QP;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_DESTROY_QP;
     cmd->qp_handle = qp_handle;
 
-    ret = amd_emrdma_cmd_post(dev, &req, NULL, 0);
+    ret = rocm_ernic_cmd_post(dev, &req, NULL, 0);
     if (ret < 0)
         dev_warn(&dev->pdev->dev, "destroy queuepair failed, error: %d\n", ret);
 }
 
 /**
- * amd_emrdma_destroy_qp - destroy a queue pair
+ * rocm_ernic_destroy_qp - destroy a queue pair
  * @qp: the queue pair to destroy
  * @udata: user data or null for kernel object
  *
  * @return: always 0.
  */
-int amd_emrdma_destroy_qp(struct ib_qp *qp, struct ib_udata *udata)
+int rocm_ernic_destroy_qp(struct ib_qp *qp, struct ib_udata *udata)
 {
-    struct amd_emrdma_qp *vqp = to_vqp(qp);
+    struct rocm_ernic_qp *vqp = to_vqp(qp);
 
-    _amd_emrdma_destroy_qp_work(to_vdev(qp->device), vqp->qp_handle);
-    amd_emrdma_free_qp(vqp);
+    _rocm_ernic_destroy_qp_work(to_vdev(qp->device), vqp->qp_handle);
+    rocm_ernic_free_qp(vqp);
 
     return 0;
 }
 
-static void __amd_emrdma_destroy_qp(struct amd_emrdma_dev *dev,
-                                    struct amd_emrdma_qp *qp)
+static void __rocm_ernic_destroy_qp(struct rocm_ernic_dev *dev,
+                                    struct rocm_ernic_qp *qp)
 {
-    _amd_emrdma_destroy_qp_work(dev, qp->qp_handle);
-    _amd_emrdma_free_qp(qp);
+    _rocm_ernic_destroy_qp_work(dev, qp->qp_handle);
+    _rocm_ernic_free_qp(qp);
 }
 
 /**
- * amd_emrdma_modify_qp - modify queue pair attributes
+ * rocm_ernic_modify_qp - modify queue pair attributes
  * @ibqp: the queue pair
  * @attr: the new queue pair's attributes
  * @attr_mask: attributes mask
@@ -513,14 +513,14 @@ static void __amd_emrdma_destroy_qp(struct amd_emrdma_dev *dev,
  *
  * @returns 0 on success, otherwise returns an errno.
  */
-int amd_emrdma_modify_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr,
+int rocm_ernic_modify_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr,
                          int attr_mask, struct ib_udata *udata)
 {
-    struct amd_emrdma_dev *dev = to_vdev(ibqp->device);
-    struct amd_emrdma_qp *qp = to_vqp(ibqp);
-    union amd_emrdma_cmd_req req;
-    union amd_emrdma_cmd_resp rsp;
-    struct amd_emrdma_cmd_modify_qp *cmd = &req.modify_qp;
+    struct rocm_ernic_dev *dev = to_vdev(ibqp->device);
+    struct rocm_ernic_qp *qp = to_vqp(ibqp);
+    union rocm_ernic_cmd_req req;
+    union rocm_ernic_cmd_resp rsp;
+    struct rocm_ernic_cmd_modify_qp *cmd = &req.modify_qp;
     enum ib_qp_state cur_state, next_state;
     int ret;
 
@@ -569,20 +569,20 @@ int amd_emrdma_modify_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr,
 
     qp->state = next_state;
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_MODIFY_QP;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_MODIFY_QP;
     cmd->qp_handle = qp->qp_handle;
-    cmd->attr_mask = ib_qp_attr_mask_to_amd_emrdma(attr_mask);
-    cmd->attrs.qp_state = ib_qp_state_to_amd_emrdma(attr->qp_state);
-    cmd->attrs.cur_qp_state = ib_qp_state_to_amd_emrdma(attr->cur_qp_state);
-    cmd->attrs.path_mtu = ib_mtu_to_amd_emrdma(attr->path_mtu);
+    cmd->attr_mask = ib_qp_attr_mask_to_rocm_ernic(attr_mask);
+    cmd->attrs.qp_state = ib_qp_state_to_rocm_ernic(attr->qp_state);
+    cmd->attrs.cur_qp_state = ib_qp_state_to_rocm_ernic(attr->cur_qp_state);
+    cmd->attrs.path_mtu = ib_mtu_to_rocm_ernic(attr->path_mtu);
     cmd->attrs.path_mig_state =
-        ib_mig_state_to_amd_emrdma(attr->path_mig_state);
+        ib_mig_state_to_rocm_ernic(attr->path_mig_state);
     cmd->attrs.qkey = attr->qkey;
     cmd->attrs.rq_psn = attr->rq_psn;
     cmd->attrs.sq_psn = attr->sq_psn;
     cmd->attrs.dest_qp_num = attr->dest_qp_num;
     cmd->attrs.qp_access_flags =
-        ib_access_flags_to_amd_emrdma(attr->qp_access_flags);
+        ib_access_flags_to_rocm_ernic(attr->qp_access_flags);
     cmd->attrs.pkey_index = attr->pkey_index;
     cmd->attrs.alt_pkey_index = attr->alt_pkey_index;
     cmd->attrs.en_sqd_async_notify = attr->en_sqd_async_notify;
@@ -596,11 +596,11 @@ int amd_emrdma_modify_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr,
     cmd->attrs.rnr_retry = attr->rnr_retry;
     cmd->attrs.alt_port_num = attr->alt_port_num;
     cmd->attrs.alt_timeout = attr->alt_timeout;
-    ib_qp_cap_to_amd_emrdma(&cmd->attrs.cap, &attr->cap);
-    rdma_ah_attr_to_amd_emrdma(&cmd->attrs.ah_attr, &attr->ah_attr);
-    rdma_ah_attr_to_amd_emrdma(&cmd->attrs.alt_ah_attr, &attr->alt_ah_attr);
+    ib_qp_cap_to_rocm_ernic(&cmd->attrs.cap, &attr->cap);
+    rdma_ah_attr_to_rocm_ernic(&cmd->attrs.ah_attr, &attr->ah_attr);
+    rdma_ah_attr_to_rocm_ernic(&cmd->attrs.alt_ah_attr, &attr->alt_ah_attr);
 
-    ret = amd_emrdma_cmd_post(dev, &req, &rsp, AMD_EMRDMA_CMD_MODIFY_QP_RESP);
+    ret = rocm_ernic_cmd_post(dev, &req, &rsp, ROCM_ERNIC_CMD_MODIFY_QP_RESP);
     if (ret < 0) {
         dev_warn(&dev->pdev->dev, "could not modify queuepair, error: %d\n",
                  ret);
@@ -611,7 +611,7 @@ int amd_emrdma_modify_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr,
     }
 
     if (ret == 0 && next_state == IB_QPS_RESET)
-        amd_emrdma_reset_qp(qp);
+        rocm_ernic_reset_qp(qp);
 
 out:
     mutex_unlock(&qp->mutex);
@@ -619,22 +619,22 @@ out:
     return ret;
 }
 
-static inline void *get_sq_wqe(struct amd_emrdma_qp *qp, unsigned int n)
+static inline void *get_sq_wqe(struct rocm_ernic_qp *qp, unsigned int n)
 {
-    return amd_emrdma_page_dir_get_ptr(&qp->pdir,
+    return rocm_ernic_page_dir_get_ptr(&qp->pdir,
                                        qp->sq.offset + n * qp->sq.wqe_size);
 }
 
-static inline void *get_rq_wqe(struct amd_emrdma_qp *qp, unsigned int n)
+static inline void *get_rq_wqe(struct rocm_ernic_qp *qp, unsigned int n)
 {
-    return amd_emrdma_page_dir_get_ptr(&qp->pdir,
+    return rocm_ernic_page_dir_get_ptr(&qp->pdir,
                                        qp->rq.offset + n * qp->rq.wqe_size);
 }
 
-static int set_reg_seg(struct amd_emrdma_sq_wqe_hdr *wqe_hdr,
+static int set_reg_seg(struct rocm_ernic_sq_wqe_hdr *wqe_hdr,
                        const struct ib_reg_wr *wr)
 {
-    struct amd_emrdma_user_mr *mr = to_vmr(wr->mr);
+    struct rocm_ernic_user_mr *mr = to_vmr(wr->mr);
 
     wqe_hdr->wr.fast_reg.iova_start = mr->ibmr.iova;
     wqe_hdr->wr.fast_reg.pl_pdir_dma = mr->pdir.dir_dma;
@@ -644,26 +644,26 @@ static int set_reg_seg(struct amd_emrdma_sq_wqe_hdr *wqe_hdr,
     wqe_hdr->wr.fast_reg.access_flags = wr->access;
     wqe_hdr->wr.fast_reg.rkey = wr->key;
 
-    return amd_emrdma_page_dir_insert_page_list(&mr->pdir, mr->pages,
+    return rocm_ernic_page_dir_insert_page_list(&mr->pdir, mr->pages,
                                                 mr->npages);
 }
 
 /**
- * amd_emrdma_post_send - post send work request entries on a QP
+ * rocm_ernic_post_send - post send work request entries on a QP
  * @ibqp: the QP
  * @wr: work request list to post
  * @bad_wr: the first bad WR returned
  *
  * @return: 0 on success, otherwise errno returned.
  */
-int amd_emrdma_post_send(struct ib_qp *ibqp, const struct ib_send_wr *wr,
+int rocm_ernic_post_send(struct ib_qp *ibqp, const struct ib_send_wr *wr,
                          const struct ib_send_wr **bad_wr)
 {
-    struct amd_emrdma_qp *qp = to_vqp(ibqp);
-    struct amd_emrdma_dev *dev = to_vdev(ibqp->device);
+    struct rocm_ernic_qp *qp = to_vqp(ibqp);
+    struct rocm_ernic_dev *dev = to_vdev(ibqp->device);
     unsigned long flags;
-    struct amd_emrdma_sq_wqe_hdr *wqe_hdr;
-    struct amd_emrdma_sge *sge;
+    struct rocm_ernic_sq_wqe_hdr *wqe_hdr;
+    struct rocm_ernic_sge *sge;
     int i, ret;
 
     /*
@@ -680,7 +680,7 @@ int amd_emrdma_post_send(struct ib_qp *ibqp, const struct ib_send_wr *wr,
     while (wr) {
         unsigned int tail = 0;
 
-        if (unlikely(!amd_emrdma_idx_ring_has_space(qp->sq.ring, qp->sq.wqe_cnt,
+        if (unlikely(!rocm_ernic_idx_ring_has_space(qp->sq.ring, qp->sq.wqe_cnt,
                                                     &tail))) {
             dev_warn_ratelimited(&dev->pdev->dev, "send queue is full\n");
             *bad_wr = wr;
@@ -730,17 +730,17 @@ int amd_emrdma_post_send(struct ib_qp *ibqp, const struct ib_send_wr *wr,
             }
         }
 
-        wqe_hdr = (struct amd_emrdma_sq_wqe_hdr *)get_sq_wqe(qp, tail);
+        wqe_hdr = (struct rocm_ernic_sq_wqe_hdr *)get_sq_wqe(qp, tail);
         memset(wqe_hdr, 0, sizeof(*wqe_hdr));
         wqe_hdr->wr_id = wr->wr_id;
         wqe_hdr->num_sge = wr->num_sge;
-        wqe_hdr->opcode = ib_wr_opcode_to_amd_emrdma(wr->opcode);
-        wqe_hdr->send_flags = ib_send_flags_to_amd_emrdma(wr->send_flags);
+        wqe_hdr->opcode = ib_wr_opcode_to_rocm_ernic(wr->opcode);
+        wqe_hdr->send_flags = ib_send_flags_to_rocm_ernic(wr->send_flags);
         if (wr->opcode == IB_WR_SEND_WITH_IMM ||
             wr->opcode == IB_WR_RDMA_WRITE_WITH_IMM)
             wqe_hdr->ex.imm_data = wr->ex.imm_data;
 
-        if (unlikely(wqe_hdr->opcode == AMD_EMRDMA_WR_ERROR)) {
+        if (unlikely(wqe_hdr->opcode == ROCM_ERNIC_WR_ERROR)) {
             *bad_wr = wr;
             ret = -EINVAL;
             goto out;
@@ -810,7 +810,7 @@ int amd_emrdma_post_send(struct ib_qp *ibqp, const struct ib_send_wr *wr,
             goto out;
         }
 
-        sge = (struct amd_emrdma_sge *)(wqe_hdr + 1);
+        sge = (struct rocm_ernic_sge *)(wqe_hdr + 1);
         for (i = 0; i < wr->num_sge; i++) {
             /* Need to check wqe_size 0 or max size */
             sge->addr = wr->sg_list[i].addr;
@@ -823,7 +823,7 @@ int amd_emrdma_post_send(struct ib_qp *ibqp, const struct ib_send_wr *wr,
         smp_wmb();
 
         /* Update shared sq ring */
-        amd_emrdma_idx_ring_inc(&qp->sq.ring->prod_tail, qp->sq.wqe_cnt);
+        rocm_ernic_idx_ring_inc(&qp->sq.ring->prod_tail, qp->sq.wqe_cnt);
 
         wr = wr->next;
     }
@@ -834,27 +834,27 @@ out:
     spin_unlock_irqrestore(&qp->sq.lock, flags);
 
     if (!ret)
-        amd_emrdma_write_uar_qp(dev, AMD_EMRDMA_UAR_QP_SEND | qp->qp_handle);
+        rocm_ernic_write_uar_qp(dev, ROCM_ERNIC_UAR_QP_SEND | qp->qp_handle);
 
     return ret;
 }
 
 /**
- * amd_emrdma_post_recv - post receive work request entries on a QP
+ * rocm_ernic_post_recv - post receive work request entries on a QP
  * @ibqp: the QP
  * @wr: the work request list to post
  * @bad_wr: the first bad WR returned
  *
  * @return: 0 on success, otherwise errno returned.
  */
-int amd_emrdma_post_recv(struct ib_qp *ibqp, const struct ib_recv_wr *wr,
+int rocm_ernic_post_recv(struct ib_qp *ibqp, const struct ib_recv_wr *wr,
                          const struct ib_recv_wr **bad_wr)
 {
-    struct amd_emrdma_dev *dev = to_vdev(ibqp->device);
+    struct rocm_ernic_dev *dev = to_vdev(ibqp->device);
     unsigned long flags;
-    struct amd_emrdma_qp *qp = to_vqp(ibqp);
-    struct amd_emrdma_rq_wqe_hdr *wqe_hdr;
-    struct amd_emrdma_sge *sge;
+    struct rocm_ernic_qp *qp = to_vqp(ibqp);
+    struct rocm_ernic_rq_wqe_hdr *wqe_hdr;
+    struct rocm_ernic_sge *sge;
     int ret = 0;
     int i;
 
@@ -885,7 +885,7 @@ int amd_emrdma_post_recv(struct ib_qp *ibqp, const struct ib_recv_wr *wr,
             goto out;
         }
 
-        if (unlikely(!amd_emrdma_idx_ring_has_space(qp->rq.ring, qp->rq.wqe_cnt,
+        if (unlikely(!rocm_ernic_idx_ring_has_space(qp->rq.ring, qp->rq.wqe_cnt,
                                                     &tail))) {
             ret = -ENOMEM;
             *bad_wr = wr;
@@ -893,12 +893,12 @@ int amd_emrdma_post_recv(struct ib_qp *ibqp, const struct ib_recv_wr *wr,
             goto out;
         }
 
-        wqe_hdr = (struct amd_emrdma_rq_wqe_hdr *)get_rq_wqe(qp, tail);
+        wqe_hdr = (struct rocm_ernic_rq_wqe_hdr *)get_rq_wqe(qp, tail);
         wqe_hdr->wr_id = wr->wr_id;
         wqe_hdr->num_sge = wr->num_sge;
         wqe_hdr->total_len = 0;
 
-        sge = (struct amd_emrdma_sge *)(wqe_hdr + 1);
+        sge = (struct rocm_ernic_sge *)(wqe_hdr + 1);
         for (i = 0; i < wr->num_sge; i++) {
             sge->addr = wr->sg_list[i].addr;
             sge->length = wr->sg_list[i].length;
@@ -910,14 +910,14 @@ int amd_emrdma_post_recv(struct ib_qp *ibqp, const struct ib_recv_wr *wr,
         smp_wmb();
 
         /* Update shared rq ring */
-        amd_emrdma_idx_ring_inc(&qp->rq.ring->prod_tail, qp->rq.wqe_cnt);
+        rocm_ernic_idx_ring_inc(&qp->rq.ring->prod_tail, qp->rq.wqe_cnt);
 
         wr = wr->next;
     }
 
     spin_unlock_irqrestore(&qp->rq.lock, flags);
 
-    amd_emrdma_write_uar_qp(dev, AMD_EMRDMA_UAR_QP_RECV | qp->qp_handle);
+    rocm_ernic_write_uar_qp(dev, ROCM_ERNIC_UAR_QP_RECV | qp->qp_handle);
 
     return ret;
 
@@ -928,7 +928,7 @@ out:
 }
 
 /**
- * amd_emrdma_query_qp - query a queue pair's attributes
+ * rocm_ernic_query_qp - query a queue pair's attributes
  * @ibqp: the queue pair to query
  * @attr: the queue pair's attributes
  * @attr_mask: attributes mask
@@ -936,15 +936,15 @@ out:
  *
  * @returns 0 on success, otherwise returns an errno.
  */
-int amd_emrdma_query_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr,
+int rocm_ernic_query_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr,
                         int attr_mask, struct ib_qp_init_attr *init_attr)
 {
-    struct amd_emrdma_dev *dev = to_vdev(ibqp->device);
-    struct amd_emrdma_qp *qp = to_vqp(ibqp);
-    union amd_emrdma_cmd_req req;
-    union amd_emrdma_cmd_resp rsp;
-    struct amd_emrdma_cmd_query_qp *cmd = &req.query_qp;
-    struct amd_emrdma_cmd_query_qp_resp *resp = &rsp.query_qp_resp;
+    struct rocm_ernic_dev *dev = to_vdev(ibqp->device);
+    struct rocm_ernic_qp *qp = to_vqp(ibqp);
+    union rocm_ernic_cmd_req req;
+    union rocm_ernic_cmd_resp rsp;
+    struct rocm_ernic_cmd_query_qp *cmd = &req.query_qp;
+    struct rocm_ernic_cmd_query_qp_resp *resp = &rsp.query_qp_resp;
     int ret = 0;
 
     mutex_lock(&qp->mutex);
@@ -955,28 +955,28 @@ int amd_emrdma_query_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr,
     }
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_QUERY_QP;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_QUERY_QP;
     cmd->qp_handle = qp->qp_handle;
-    cmd->attr_mask = ib_qp_attr_mask_to_amd_emrdma(attr_mask);
+    cmd->attr_mask = ib_qp_attr_mask_to_rocm_ernic(attr_mask);
 
-    ret = amd_emrdma_cmd_post(dev, &req, &rsp, AMD_EMRDMA_CMD_QUERY_QP_RESP);
+    ret = rocm_ernic_cmd_post(dev, &req, &rsp, ROCM_ERNIC_CMD_QUERY_QP_RESP);
     if (ret < 0) {
         dev_warn(&dev->pdev->dev, "could not query queuepair, error: %d\n",
                  ret);
         goto out;
     }
 
-    attr->qp_state = amd_emrdma_qp_state_to_ib(resp->attrs.qp_state);
-    attr->cur_qp_state = amd_emrdma_qp_state_to_ib(resp->attrs.cur_qp_state);
-    attr->path_mtu = amd_emrdma_mtu_to_ib(resp->attrs.path_mtu);
+    attr->qp_state = rocm_ernic_qp_state_to_ib(resp->attrs.qp_state);
+    attr->cur_qp_state = rocm_ernic_qp_state_to_ib(resp->attrs.cur_qp_state);
+    attr->path_mtu = rocm_ernic_mtu_to_ib(resp->attrs.path_mtu);
     attr->path_mig_state =
-        amd_emrdma_mig_state_to_ib(resp->attrs.path_mig_state);
+        rocm_ernic_mig_state_to_ib(resp->attrs.path_mig_state);
     attr->qkey = resp->attrs.qkey;
     attr->rq_psn = resp->attrs.rq_psn;
     attr->sq_psn = resp->attrs.sq_psn;
     attr->dest_qp_num = resp->attrs.dest_qp_num;
     attr->qp_access_flags =
-        amd_emrdma_access_flags_to_ib(resp->attrs.qp_access_flags);
+        rocm_ernic_access_flags_to_ib(resp->attrs.qp_access_flags);
     attr->pkey_index = resp->attrs.pkey_index;
     attr->alt_pkey_index = resp->attrs.alt_pkey_index;
     attr->en_sqd_async_notify = resp->attrs.en_sqd_async_notify;
@@ -990,9 +990,9 @@ int amd_emrdma_query_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr,
     attr->rnr_retry = resp->attrs.rnr_retry;
     attr->alt_port_num = resp->attrs.alt_port_num;
     attr->alt_timeout = resp->attrs.alt_timeout;
-    amd_emrdma_qp_cap_to_ib(&attr->cap, &resp->attrs.cap);
-    amd_emrdma_ah_attr_to_rdma(&attr->ah_attr, &resp->attrs.ah_attr);
-    amd_emrdma_ah_attr_to_rdma(&attr->alt_ah_attr, &resp->attrs.alt_ah_attr);
+    rocm_ernic_qp_cap_to_ib(&attr->cap, &resp->attrs.cap);
+    rocm_ernic_ah_attr_to_rdma(&attr->ah_attr, &resp->attrs.ah_attr);
+    rocm_ernic_ah_attr_to_rdma(&attr->alt_ah_attr, &resp->attrs.alt_ah_attr);
 
     qp->state = attr->qp_state;
 

--- a/driver/rocm_ernic_ring.h
+++ b/driver/rocm_ernic_ring.h
@@ -43,39 +43,39 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __AMD_EMRDMA_RING_H__
-#define __AMD_EMRDMA_RING_H__
+#ifndef __ROCM_ERNIC_RING_H__
+#define __ROCM_ERNIC_RING_H__
 
 #include <linux/types.h>
 
-#define AMD_EMRDMA_INVALID_IDX -1 /* Invalid index. */
+#define ROCM_ERNIC_INVALID_IDX -1 /* Invalid index. */
 
-struct amd_emrdma_ring {
+struct rocm_ernic_ring {
     atomic_t prod_tail; /* Producer tail. */
     atomic_t cons_head; /* Consumer head. */
 };
 
-struct amd_emrdma_ring_state {
-    struct amd_emrdma_ring tx; /* Tx ring. */
-    struct amd_emrdma_ring rx; /* Rx ring. */
+struct rocm_ernic_ring_state {
+    struct rocm_ernic_ring tx; /* Tx ring. */
+    struct rocm_ernic_ring rx; /* Rx ring. */
 };
 
-static inline int amd_emrdma_idx_valid(__u32 idx, __u32 max_elems)
+static inline int rocm_ernic_idx_valid(__u32 idx, __u32 max_elems)
 {
     /* Generates fewer instructions than a less-than. */
     return (idx & ~((max_elems << 1) - 1)) == 0;
 }
 
-static inline __s32 amd_emrdma_idx(atomic_t *var, __u32 max_elems)
+static inline __s32 rocm_ernic_idx(atomic_t *var, __u32 max_elems)
 {
     const unsigned int idx = atomic_read(var);
 
-    if (amd_emrdma_idx_valid(idx, max_elems))
+    if (rocm_ernic_idx_valid(idx, max_elems))
         return idx & (max_elems - 1);
-    return AMD_EMRDMA_INVALID_IDX;
+    return ROCM_ERNIC_INVALID_IDX;
 }
 
-static inline void amd_emrdma_idx_ring_inc(atomic_t *var, __u32 max_elems)
+static inline void rocm_ernic_idx_ring_inc(atomic_t *var, __u32 max_elems)
 {
     __u32 idx = atomic_read(var) + 1; /* Increment. */
 
@@ -83,32 +83,32 @@ static inline void amd_emrdma_idx_ring_inc(atomic_t *var, __u32 max_elems)
     atomic_set(var, idx);
 }
 
-static inline __s32 amd_emrdma_idx_ring_has_space(
-    const struct amd_emrdma_ring *r, __u32 max_elems, __u32 *out_tail)
+static inline __s32 rocm_ernic_idx_ring_has_space(
+    const struct rocm_ernic_ring *r, __u32 max_elems, __u32 *out_tail)
 {
     const __u32 tail = atomic_read(&r->prod_tail);
     const __u32 head = atomic_read(&r->cons_head);
 
-    if (amd_emrdma_idx_valid(tail, max_elems) &&
-        amd_emrdma_idx_valid(head, max_elems)) {
+    if (rocm_ernic_idx_valid(tail, max_elems) &&
+        rocm_ernic_idx_valid(head, max_elems)) {
         *out_tail = tail & (max_elems - 1);
         return tail != (head ^ max_elems);
     }
-    return AMD_EMRDMA_INVALID_IDX;
+    return ROCM_ERNIC_INVALID_IDX;
 }
 
-static inline __s32 amd_emrdma_idx_ring_has_data(
-    const struct amd_emrdma_ring *r, __u32 max_elems, __u32 *out_head)
+static inline __s32 rocm_ernic_idx_ring_has_data(
+    const struct rocm_ernic_ring *r, __u32 max_elems, __u32 *out_head)
 {
     const __u32 tail = atomic_read(&r->prod_tail);
     const __u32 head = atomic_read(&r->cons_head);
 
-    if (amd_emrdma_idx_valid(tail, max_elems) &&
-        amd_emrdma_idx_valid(head, max_elems)) {
+    if (rocm_ernic_idx_valid(tail, max_elems) &&
+        rocm_ernic_idx_valid(head, max_elems)) {
         *out_head = head & (max_elems - 1);
         return tail != head;
     }
-    return AMD_EMRDMA_INVALID_IDX;
+    return ROCM_ERNIC_INVALID_IDX;
 }
 
-#endif /* __AMD_EMRDMA_RING_H__ */
+#endif /* __ROCM_ERNIC_RING_H__ */

--- a/driver/rocm_ernic_srq.c
+++ b/driver/rocm_ernic_srq.c
@@ -53,27 +53,27 @@
 #include "rocm_ernic.h"
 
 /**
- * amd_emrdma_query_srq - query shared receive queue
+ * rocm_ernic_query_srq - query shared receive queue
  * @ibsrq: the shared receive queue to query
  * @srq_attr: attributes to query and return to client
  *
  * @return: 0 for success, otherwise returns an errno.
  */
-int amd_emrdma_query_srq(struct ib_srq *ibsrq, struct ib_srq_attr *srq_attr)
+int rocm_ernic_query_srq(struct ib_srq *ibsrq, struct ib_srq_attr *srq_attr)
 {
-    struct amd_emrdma_dev *dev = to_vdev(ibsrq->device);
-    struct amd_emrdma_srq *srq = to_vsrq(ibsrq);
-    union amd_emrdma_cmd_req req;
-    union amd_emrdma_cmd_resp rsp;
-    struct amd_emrdma_cmd_query_srq *cmd = &req.query_srq;
-    struct amd_emrdma_cmd_query_srq_resp *resp = &rsp.query_srq_resp;
+    struct rocm_ernic_dev *dev = to_vdev(ibsrq->device);
+    struct rocm_ernic_srq *srq = to_vsrq(ibsrq);
+    union rocm_ernic_cmd_req req;
+    union rocm_ernic_cmd_resp rsp;
+    struct rocm_ernic_cmd_query_srq *cmd = &req.query_srq;
+    struct rocm_ernic_cmd_query_srq_resp *resp = &rsp.query_srq_resp;
     int ret;
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_QUERY_SRQ;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_QUERY_SRQ;
     cmd->srq_handle = srq->srq_handle;
 
-    ret = amd_emrdma_cmd_post(dev, &req, &rsp, AMD_EMRDMA_CMD_QUERY_SRQ_RESP);
+    ret = rocm_ernic_cmd_post(dev, &req, &rsp, ROCM_ERNIC_CMD_QUERY_SRQ_RESP);
     if (ret < 0) {
         dev_warn(&dev->pdev->dev,
                  "could not query shared receive queue, error: %d\n", ret);
@@ -88,25 +88,25 @@ int amd_emrdma_query_srq(struct ib_srq *ibsrq, struct ib_srq_attr *srq_attr)
 }
 
 /**
- * amd_emrdma_create_srq - create shared receive queue
+ * rocm_ernic_create_srq - create shared receive queue
  * @ibsrq: the IB shared receive queue
  * @init_attr: shared receive queue attributes
  * @udata: user data
  *
  * @return: 0 on success, otherwise returns an errno.
  */
-int amd_emrdma_create_srq(struct ib_srq *ibsrq,
+int rocm_ernic_create_srq(struct ib_srq *ibsrq,
                           struct ib_srq_init_attr *init_attr,
                           struct ib_udata *udata)
 {
-    struct amd_emrdma_srq *srq = to_vsrq(ibsrq);
-    struct amd_emrdma_dev *dev = to_vdev(ibsrq->device);
-    union amd_emrdma_cmd_req req;
-    union amd_emrdma_cmd_resp rsp;
-    struct amd_emrdma_cmd_create_srq *cmd = &req.create_srq;
-    struct amd_emrdma_cmd_create_srq_resp *resp = &rsp.create_srq_resp;
-    struct amd_emrdma_create_srq_resp srq_resp = {};
-    struct amd_emrdma_create_srq ucmd;
+    struct rocm_ernic_srq *srq = to_vsrq(ibsrq);
+    struct rocm_ernic_dev *dev = to_vdev(ibsrq->device);
+    union rocm_ernic_cmd_req req;
+    union rocm_ernic_cmd_resp rsp;
+    struct rocm_ernic_cmd_create_srq *cmd = &req.create_srq;
+    struct rocm_ernic_cmd_create_srq_resp *resp = &rsp.create_srq_resp;
+    struct rocm_ernic_create_srq_resp srq_resp = {};
+    struct rocm_ernic_create_srq ucmd;
     unsigned long flags;
     int ret;
 
@@ -152,22 +152,22 @@ int amd_emrdma_create_srq(struct ib_srq *ibsrq,
 
     srq->npages = ib_umem_num_dma_blocks(srq->umem, PAGE_SIZE);
 
-    if (srq->npages < 0 || srq->npages > AMD_EMRDMA_PAGE_DIR_MAX_PAGES) {
+    if (srq->npages < 0 || srq->npages > ROCM_ERNIC_PAGE_DIR_MAX_PAGES) {
         dev_warn(&dev->pdev->dev, "overflow pages in shared receive queue\n");
         ret = -EINVAL;
         goto err_umem;
     }
 
-    ret = amd_emrdma_page_dir_init(dev, &srq->pdir, srq->npages, false);
+    ret = rocm_ernic_page_dir_init(dev, &srq->pdir, srq->npages, false);
     if (ret) {
         dev_warn(&dev->pdev->dev, "could not allocate page directory\n");
         goto err_umem;
     }
 
-    amd_emrdma_page_dir_insert_umem(&srq->pdir, srq->umem, 0);
+    rocm_ernic_page_dir_insert_umem(&srq->pdir, srq->umem, 0);
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_CREATE_SRQ;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_CREATE_SRQ;
     cmd->srq_type = init_attr->srq_type;
     cmd->nchunks = srq->npages;
     cmd->pd_handle = to_vpd(ibsrq->pd)->pd_handle;
@@ -176,7 +176,7 @@ int amd_emrdma_create_srq(struct ib_srq *ibsrq,
     cmd->attrs.srq_limit = init_attr->attr.srq_limit;
     cmd->pdir_dma = srq->pdir.dir_dma;
 
-    ret = amd_emrdma_cmd_post(dev, &req, &rsp, AMD_EMRDMA_CMD_CREATE_SRQ_RESP);
+    ret = rocm_ernic_cmd_post(dev, &req, &rsp, ROCM_ERNIC_CMD_CREATE_SRQ_RESP);
     if (ret < 0) {
         dev_warn(&dev->pdev->dev,
                  "could not create shared receive queue, error: %d\n", ret);
@@ -192,14 +192,14 @@ int amd_emrdma_create_srq(struct ib_srq *ibsrq,
     /* Copy udata back. */
     if (ib_copy_to_udata(udata, &srq_resp, sizeof(srq_resp))) {
         dev_warn(&dev->pdev->dev, "failed to copy back udata\n");
-        amd_emrdma_destroy_srq(&srq->ibsrq, udata);
+        rocm_ernic_destroy_srq(&srq->ibsrq, udata);
         return -EINVAL;
     }
 
     return 0;
 
 err_page_dir:
-    amd_emrdma_page_dir_cleanup(dev, &srq->pdir);
+    rocm_ernic_page_dir_cleanup(dev, &srq->pdir);
 err_umem:
     ib_umem_release(srq->umem);
 err_srq:
@@ -208,8 +208,8 @@ err_srq:
     return ret;
 }
 
-static void amd_emrdma_free_srq(struct amd_emrdma_dev *dev,
-                                struct amd_emrdma_srq *srq)
+static void rocm_ernic_free_srq(struct rocm_ernic_dev *dev,
+                                struct rocm_ernic_srq *srq)
 {
     unsigned long flags;
 
@@ -224,41 +224,41 @@ static void amd_emrdma_free_srq(struct amd_emrdma_dev *dev,
     /* There is no support for kernel clients, so this is safe. */
     ib_umem_release(srq->umem);
 
-    amd_emrdma_page_dir_cleanup(dev, &srq->pdir);
+    rocm_ernic_page_dir_cleanup(dev, &srq->pdir);
 
     atomic_dec(&dev->num_srqs);
 }
 
 /**
- * amd_emrdma_destroy_srq - destroy shared receive queue
+ * rocm_ernic_destroy_srq - destroy shared receive queue
  * @srq: the shared receive queue to destroy
  * @udata: user data or null for kernel object
  *
  * @return: 0 for success.
  */
-int amd_emrdma_destroy_srq(struct ib_srq *srq, struct ib_udata *udata)
+int rocm_ernic_destroy_srq(struct ib_srq *srq, struct ib_udata *udata)
 {
-    struct amd_emrdma_srq *vsrq = to_vsrq(srq);
-    union amd_emrdma_cmd_req req;
-    struct amd_emrdma_cmd_destroy_srq *cmd = &req.destroy_srq;
-    struct amd_emrdma_dev *dev = to_vdev(srq->device);
+    struct rocm_ernic_srq *vsrq = to_vsrq(srq);
+    union rocm_ernic_cmd_req req;
+    struct rocm_ernic_cmd_destroy_srq *cmd = &req.destroy_srq;
+    struct rocm_ernic_dev *dev = to_vdev(srq->device);
     int ret;
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_DESTROY_SRQ;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_DESTROY_SRQ;
     cmd->srq_handle = vsrq->srq_handle;
 
-    ret = amd_emrdma_cmd_post(dev, &req, NULL, 0);
+    ret = rocm_ernic_cmd_post(dev, &req, NULL, 0);
     if (ret < 0)
         dev_warn(&dev->pdev->dev,
                  "destroy shared receive queue failed, error: %d\n", ret);
 
-    amd_emrdma_free_srq(dev, vsrq);
+    rocm_ernic_free_srq(dev, vsrq);
     return 0;
 }
 
 /**
- * amd_emrdma_modify_srq - modify shared receive queue attributes
+ * rocm_ernic_modify_srq - modify shared receive queue attributes
  * @ibsrq: the shared receive queue to modify
  * @attr: the shared receive queue's new attributes
  * @attr_mask: attributes mask
@@ -266,14 +266,14 @@ int amd_emrdma_destroy_srq(struct ib_srq *srq, struct ib_udata *udata)
  *
  * @returns 0 on success, otherwise returns an errno.
  */
-int amd_emrdma_modify_srq(struct ib_srq *ibsrq, struct ib_srq_attr *attr,
+int rocm_ernic_modify_srq(struct ib_srq *ibsrq, struct ib_srq_attr *attr,
                           enum ib_srq_attr_mask attr_mask,
                           struct ib_udata *udata)
 {
-    struct amd_emrdma_srq *vsrq = to_vsrq(ibsrq);
-    union amd_emrdma_cmd_req req;
-    struct amd_emrdma_cmd_modify_srq *cmd = &req.modify_srq;
-    struct amd_emrdma_dev *dev = to_vdev(ibsrq->device);
+    struct rocm_ernic_srq *vsrq = to_vsrq(ibsrq);
+    union rocm_ernic_cmd_req req;
+    struct rocm_ernic_cmd_modify_srq *cmd = &req.modify_srq;
+    struct rocm_ernic_dev *dev = to_vdev(ibsrq->device);
     int ret;
 
     /* Only support SRQ limit. */
@@ -281,12 +281,12 @@ int amd_emrdma_modify_srq(struct ib_srq *ibsrq, struct ib_srq_attr *attr,
         return -EINVAL;
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_MODIFY_SRQ;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_MODIFY_SRQ;
     cmd->srq_handle = vsrq->srq_handle;
     cmd->attrs.srq_limit = attr->srq_limit;
     cmd->attr_mask = attr_mask;
 
-    ret = amd_emrdma_cmd_post(dev, &req, NULL, 0);
+    ret = rocm_ernic_cmd_post(dev, &req, NULL, 0);
     if (ret < 0) {
         dev_warn(&dev->pdev->dev,
                  "could not modify shared receive queue, error: %d\n", ret);

--- a/driver/rocm_ernic_verbs.c
+++ b/driver/rocm_ernic_verbs.c
@@ -55,17 +55,17 @@
 #include "rocm_ernic.h"
 
 /**
- * amd_emrdma_query_device - query device
+ * rocm_ernic_query_device - query device
  * @ibdev: the device to query
  * @props: the device properties
  * @uhw: user data
  *
  * @return: 0 on success, otherwise negative errno
  */
-int amd_emrdma_query_device(struct ib_device *ibdev,
+int rocm_ernic_query_device(struct ib_device *ibdev,
                             struct ib_device_attr *props, struct ib_udata *uhw)
 {
-    struct amd_emrdma_dev *dev = to_vdev(ibdev);
+    struct rocm_ernic_dev *dev = to_vdev(ibdev);
 
     if (uhw->inlen || uhw->outlen)
         return -EINVAL;
@@ -82,7 +82,7 @@ int amd_emrdma_query_device(struct ib_device *ibdev,
     props->device_cap_flags = dev->dsr->caps.device_cap_flags;
     props->max_send_sge = dev->dsr->caps.max_sge;
     props->max_recv_sge = dev->dsr->caps.max_sge;
-    props->max_sge_rd = AMD_EMRDMA_GET_CAP(dev, dev->dsr->caps.max_sge,
+    props->max_sge_rd = ROCM_ERNIC_GET_CAP(dev, dev->dsr->caps.max_sge,
                                            dev->dsr->caps.max_sge_rd);
     props->max_srq = dev->dsr->caps.max_srq;
     props->max_srq_wr = dev->dsr->caps.max_srq_wr;
@@ -94,20 +94,20 @@ int amd_emrdma_query_device(struct ib_device *ibdev,
     props->max_qp_rd_atom = dev->dsr->caps.max_qp_rd_atom;
     props->max_qp_init_rd_atom = dev->dsr->caps.max_qp_init_rd_atom;
     props->atomic_cap =
-        dev->dsr->caps.atomic_ops & (AMD_EMRDMA_ATOMIC_OP_COMP_SWAP |
-                                     AMD_EMRDMA_ATOMIC_OP_FETCH_ADD)
+        dev->dsr->caps.atomic_ops & (ROCM_ERNIC_ATOMIC_OP_COMP_SWAP |
+                                     ROCM_ERNIC_ATOMIC_OP_FETCH_ADD)
             ? IB_ATOMIC_HCA
             : IB_ATOMIC_NONE;
     props->masked_atomic_cap = props->atomic_cap;
     props->max_ah = dev->dsr->caps.max_ah;
     props->max_pkeys = dev->dsr->caps.max_pkeys;
     props->local_ca_ack_delay = dev->dsr->caps.local_ca_ack_delay;
-    if ((dev->dsr->caps.bmme_flags & AMD_EMRDMA_BMME_FLAG_LOCAL_INV) &&
-        (dev->dsr->caps.bmme_flags & AMD_EMRDMA_BMME_FLAG_REMOTE_INV) &&
-        (dev->dsr->caps.bmme_flags & AMD_EMRDMA_BMME_FLAG_FAST_REG_WR)) {
+    if ((dev->dsr->caps.bmme_flags & ROCM_ERNIC_BMME_FLAG_LOCAL_INV) &&
+        (dev->dsr->caps.bmme_flags & ROCM_ERNIC_BMME_FLAG_REMOTE_INV) &&
+        (dev->dsr->caps.bmme_flags & ROCM_ERNIC_BMME_FLAG_FAST_REG_WR)) {
         props->device_cap_flags |= IB_DEVICE_MEM_MGT_EXTENSIONS;
         props->max_fast_reg_page_list_len =
-            AMD_EMRDMA_GET_CAP(dev, AMD_EMRDMA_MAX_FAST_REG_PAGES,
+            ROCM_ERNIC_GET_CAP(dev, ROCM_ERNIC_MAX_FAST_REG_PAGES,
                                dev->dsr->caps.max_fast_reg_page_list_len);
     }
 
@@ -118,28 +118,28 @@ int amd_emrdma_query_device(struct ib_device *ibdev,
 }
 
 /**
- * amd_emrdma_query_port - query device port attributes
+ * rocm_ernic_query_port - query device port attributes
  * @ibdev: the device to query
  * @port: the port number
  * @props: the device properties
  *
  * @return: 0 on success, otherwise negative errno
  */
-int amd_emrdma_query_port(struct ib_device *ibdev, u32 port,
+int rocm_ernic_query_port(struct ib_device *ibdev, u32 port,
                           struct ib_port_attr *props)
 {
-    struct amd_emrdma_dev *dev = to_vdev(ibdev);
-    union amd_emrdma_cmd_req req;
-    union amd_emrdma_cmd_resp rsp;
-    struct amd_emrdma_cmd_query_port *cmd = &req.query_port;
-    struct amd_emrdma_cmd_query_port_resp *resp = &rsp.query_port_resp;
+    struct rocm_ernic_dev *dev = to_vdev(ibdev);
+    union rocm_ernic_cmd_req req;
+    union rocm_ernic_cmd_resp rsp;
+    struct rocm_ernic_cmd_query_port *cmd = &req.query_port;
+    struct rocm_ernic_cmd_query_port_resp *resp = &rsp.query_port_resp;
     int err;
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_QUERY_PORT;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_QUERY_PORT;
     cmd->port_num = port;
 
-    err = amd_emrdma_cmd_post(dev, &req, &rsp, AMD_EMRDMA_CMD_QUERY_PORT_RESP);
+    err = rocm_ernic_cmd_post(dev, &req, &rsp, ROCM_ERNIC_CMD_QUERY_PORT_RESP);
     if (err < 0) {
         dev_warn(&dev->pdev->dev, "could not query port, error: %d\n", err);
         return err;
@@ -147,12 +147,12 @@ int amd_emrdma_query_port(struct ib_device *ibdev, u32 port,
 
     /* props being zeroed by the caller, avoid zeroing it here */
 
-    props->state = amd_emrdma_port_state_to_ib(resp->attrs.state);
-    props->max_mtu = amd_emrdma_mtu_to_ib(resp->attrs.max_mtu);
-    props->active_mtu = amd_emrdma_mtu_to_ib(resp->attrs.active_mtu);
+    props->state = rocm_ernic_port_state_to_ib(resp->attrs.state);
+    props->max_mtu = rocm_ernic_mtu_to_ib(resp->attrs.max_mtu);
+    props->active_mtu = rocm_ernic_mtu_to_ib(resp->attrs.active_mtu);
     props->gid_tbl_len = resp->attrs.gid_tbl_len;
     props->port_cap_flags =
-        amd_emrdma_port_cap_flags_to_ib(resp->attrs.port_cap_flags);
+        rocm_ernic_port_cap_flags_to_ib(resp->attrs.port_cap_flags);
     props->port_cap_flags |= IB_PORT_CM_SUP;
     props->ip_gids = true;
 
@@ -169,15 +169,15 @@ int amd_emrdma_query_port(struct ib_device *ibdev, u32 port,
     props->sm_sl = resp->attrs.sm_sl;
     props->subnet_timeout = resp->attrs.subnet_timeout;
     props->init_type_reply = resp->attrs.init_type_reply;
-    props->active_width = amd_emrdma_port_width_to_ib(resp->attrs.active_width);
-    props->active_speed = amd_emrdma_port_speed_to_ib(resp->attrs.active_speed);
+    props->active_width = rocm_ernic_port_width_to_ib(resp->attrs.active_width);
+    props->active_speed = rocm_ernic_port_speed_to_ib(resp->attrs.active_speed);
     props->phys_state = resp->attrs.phys_state;
 
     return 0;
 }
 
 /**
- * amd_emrdma_query_gid - query device gid
+ * rocm_ernic_query_gid - query device gid
  * @ibdev: the device to query
  * @port: the port number
  * @index: the index
@@ -185,10 +185,10 @@ int amd_emrdma_query_port(struct ib_device *ibdev, u32 port,
  *
  * @return: 0 on success, otherwise negative errno
  */
-int amd_emrdma_query_gid(struct ib_device *ibdev, u32 port, int index,
+int rocm_ernic_query_gid(struct ib_device *ibdev, u32 port, int index,
                          union ib_gid *gid)
 {
-    struct amd_emrdma_dev *dev = to_vdev(ibdev);
+    struct rocm_ernic_dev *dev = to_vdev(ibdev);
 
     if (index >= dev->dsr->caps.gid_tbl_len)
         return -EINVAL;
@@ -211,7 +211,7 @@ int amd_emrdma_query_gid(struct ib_device *ibdev, u32 port, int index,
 }
 
 /**
- * amd_emrdma_query_pkey - query device port's P_Key table
+ * rocm_ernic_query_pkey - query device port's P_Key table
  * @ibdev: the device to query
  * @port: the port number
  * @index: the index
@@ -219,21 +219,21 @@ int amd_emrdma_query_gid(struct ib_device *ibdev, u32 port, int index,
  *
  * @return: 0 on success, otherwise negative errno
  */
-int amd_emrdma_query_pkey(struct ib_device *ibdev, u32 port, u16 index,
+int rocm_ernic_query_pkey(struct ib_device *ibdev, u32 port, u16 index,
                           u16 *pkey)
 {
     int err = 0;
-    union amd_emrdma_cmd_req req;
-    union amd_emrdma_cmd_resp rsp;
-    struct amd_emrdma_cmd_query_pkey *cmd = &req.query_pkey;
+    union rocm_ernic_cmd_req req;
+    union rocm_ernic_cmd_resp rsp;
+    struct rocm_ernic_cmd_query_pkey *cmd = &req.query_pkey;
 
     memset(cmd, 0, sizeof(*cmd));
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_QUERY_PKEY;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_QUERY_PKEY;
     cmd->port_num = port;
     cmd->index = index;
 
-    err = amd_emrdma_cmd_post(to_vdev(ibdev), &req, &rsp,
-                              AMD_EMRDMA_CMD_QUERY_PKEY_RESP);
+    err = rocm_ernic_cmd_post(to_vdev(ibdev), &req, &rsp,
+                              ROCM_ERNIC_CMD_QUERY_PKEY_RESP);
     if (err < 0) {
         dev_warn(&to_vdev(ibdev)->pdev->dev,
                  "could not query pkey, error: %d\n", err);
@@ -245,7 +245,7 @@ int amd_emrdma_query_pkey(struct ib_device *ibdev, u32 port, u16 index,
     return 0;
 }
 
-enum rdma_link_layer amd_emrdma_port_link_layer(struct ib_device *ibdev,
+enum rdma_link_layer rocm_ernic_port_link_layer(struct ib_device *ibdev,
                                                 u32 port)
 {
     /* Always report as Ethernet/RoCE to enable proper GID management */
@@ -253,7 +253,7 @@ enum rdma_link_layer amd_emrdma_port_link_layer(struct ib_device *ibdev,
 }
 
 /**
- * amd_emrdma_modify_port - modify device port attributes
+ * rocm_ernic_modify_port - modify device port attributes
  * @ibdev: the device to modify
  * @port: the port number
  * @mask: attributes to modify
@@ -261,11 +261,11 @@ enum rdma_link_layer amd_emrdma_port_link_layer(struct ib_device *ibdev,
  *
  * @return: 0 on success, otherwise negative errno
  */
-int amd_emrdma_modify_port(struct ib_device *ibdev, u32 port, int mask,
+int rocm_ernic_modify_port(struct ib_device *ibdev, u32 port, int mask,
                            struct ib_port_modify *props)
 {
     struct ib_port_attr attr;
-    struct amd_emrdma_dev *vdev = to_vdev(ibdev);
+    struct rocm_ernic_dev *vdev = to_vdev(ibdev);
     int ret;
 
     if (mask & ~IB_PORT_SHUTDOWN) {
@@ -290,40 +290,40 @@ out:
 }
 
 /**
- * amd_emrdma_alloc_ucontext - allocate ucontext
+ * rocm_ernic_alloc_ucontext - allocate ucontext
  * @uctx: the uverbs countext
  * @udata: user data
  *
  * @return:  zero on success, otherwise errno.
  */
-int amd_emrdma_alloc_ucontext(struct ib_ucontext *uctx, struct ib_udata *udata)
+int rocm_ernic_alloc_ucontext(struct ib_ucontext *uctx, struct ib_udata *udata)
 {
     struct ib_device *ibdev = uctx->device;
-    struct amd_emrdma_dev *vdev = to_vdev(ibdev);
-    struct amd_emrdma_ucontext *context = to_vucontext(uctx);
-    union amd_emrdma_cmd_req req = {};
-    union amd_emrdma_cmd_resp rsp = {};
-    struct amd_emrdma_cmd_create_uc *cmd = &req.create_uc;
-    struct amd_emrdma_cmd_create_uc_resp *resp = &rsp.create_uc_resp;
-    struct amd_emrdma_alloc_ucontext_resp uresp = {};
+    struct rocm_ernic_dev *vdev = to_vdev(ibdev);
+    struct rocm_ernic_ucontext *context = to_vucontext(uctx);
+    union rocm_ernic_cmd_req req = {};
+    union rocm_ernic_cmd_resp rsp = {};
+    struct rocm_ernic_cmd_create_uc *cmd = &req.create_uc;
+    struct rocm_ernic_cmd_create_uc_resp *resp = &rsp.create_uc_resp;
+    struct rocm_ernic_alloc_ucontext_resp uresp = {};
     int ret;
 
     if (!vdev->ib_active)
         return -EAGAIN;
 
     context->dev = vdev;
-    ret = amd_emrdma_uar_alloc(vdev, &context->uar);
+    ret = rocm_ernic_uar_alloc(vdev, &context->uar);
     if (ret)
         return -ENOMEM;
 
     /* get ctx_handle from host */
-    if (vdev->dsr_version < AMD_EMRDMA_PPN64_VERSION)
+    if (vdev->dsr_version < ROCM_ERNIC_PPN64_VERSION)
         cmd->pfn = context->uar.pfn;
     else
         cmd->pfn64 = context->uar.pfn;
 
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_CREATE_UC;
-    ret = amd_emrdma_cmd_post(vdev, &req, &rsp, AMD_EMRDMA_CMD_CREATE_UC_RESP);
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_CREATE_UC;
+    ret = rocm_ernic_cmd_post(vdev, &req, &rsp, ROCM_ERNIC_CMD_CREATE_UC_RESP);
     if (ret < 0) {
         dev_warn(&vdev->pdev->dev, "could not create ucontext, error: %d\n",
                  ret);
@@ -336,51 +336,51 @@ int amd_emrdma_alloc_ucontext(struct ib_ucontext *uctx, struct ib_udata *udata)
     uresp.qp_tab_size = vdev->dsr->caps.max_qp;
     ret = ib_copy_to_udata(udata, &uresp, sizeof(uresp));
     if (ret) {
-        amd_emrdma_uar_free(vdev, &context->uar);
-        amd_emrdma_dealloc_ucontext(&context->ibucontext);
+        rocm_ernic_uar_free(vdev, &context->uar);
+        rocm_ernic_dealloc_ucontext(&context->ibucontext);
         return -EFAULT;
     }
 
     return 0;
 
 err:
-    amd_emrdma_uar_free(vdev, &context->uar);
+    rocm_ernic_uar_free(vdev, &context->uar);
     return ret;
 }
 
 /**
- * amd_emrdma_dealloc_ucontext - deallocate ucontext
+ * rocm_ernic_dealloc_ucontext - deallocate ucontext
  * @ibcontext: the ucontext
  */
-void amd_emrdma_dealloc_ucontext(struct ib_ucontext *ibcontext)
+void rocm_ernic_dealloc_ucontext(struct ib_ucontext *ibcontext)
 {
-    struct amd_emrdma_ucontext *context = to_vucontext(ibcontext);
-    union amd_emrdma_cmd_req req = {};
-    struct amd_emrdma_cmd_destroy_uc *cmd = &req.destroy_uc;
+    struct rocm_ernic_ucontext *context = to_vucontext(ibcontext);
+    union rocm_ernic_cmd_req req = {};
+    struct rocm_ernic_cmd_destroy_uc *cmd = &req.destroy_uc;
     int ret;
 
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_DESTROY_UC;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_DESTROY_UC;
     cmd->ctx_handle = context->ctx_handle;
 
-    ret = amd_emrdma_cmd_post(context->dev, &req, NULL, 0);
+    ret = rocm_ernic_cmd_post(context->dev, &req, NULL, 0);
     if (ret < 0)
         dev_warn(&context->dev->pdev->dev,
                  "destroy ucontext failed, error: %d\n", ret);
 
     /* Free the UAR even if the device command failed */
-    amd_emrdma_uar_free(to_vdev(ibcontext->device), &context->uar);
+    rocm_ernic_uar_free(to_vdev(ibcontext->device), &context->uar);
 }
 
 /**
- * amd_emrdma_mmap - create mmap region
+ * rocm_ernic_mmap - create mmap region
  * @ibcontext: the user context
  * @vma: the VMA
  *
  * @return: 0 on success, otherwise errno.
  */
-int amd_emrdma_mmap(struct ib_ucontext *ibcontext, struct vm_area_struct *vma)
+int rocm_ernic_mmap(struct ib_ucontext *ibcontext, struct vm_area_struct *vma)
 {
-    struct amd_emrdma_ucontext *context = to_vucontext(ibcontext);
+    struct rocm_ernic_ucontext *context = to_vucontext(ibcontext);
     unsigned long start = vma->vm_start;
     unsigned long size = vma->vm_end - vma->vm_start;
     unsigned long offset = vma->vm_pgoff << PAGE_SHIFT;
@@ -403,33 +403,33 @@ int amd_emrdma_mmap(struct ib_ucontext *ibcontext, struct vm_area_struct *vma)
 }
 
 /**
- * amd_emrdma_alloc_pd - allocate protection domain
+ * rocm_ernic_alloc_pd - allocate protection domain
  * @ibpd: PD pointer
  * @udata: user data
  *
  * @return: the ib_pd protection domain pointer on success, otherwise errno.
  */
-int amd_emrdma_alloc_pd(struct ib_pd *ibpd, struct ib_udata *udata)
+int rocm_ernic_alloc_pd(struct ib_pd *ibpd, struct ib_udata *udata)
 {
     struct ib_device *ibdev = ibpd->device;
-    struct amd_emrdma_pd *pd = to_vpd(ibpd);
-    struct amd_emrdma_dev *dev = to_vdev(ibdev);
-    union amd_emrdma_cmd_req req = {};
-    union amd_emrdma_cmd_resp rsp = {};
-    struct amd_emrdma_cmd_create_pd *cmd = &req.create_pd;
-    struct amd_emrdma_cmd_create_pd_resp *resp = &rsp.create_pd_resp;
-    struct amd_emrdma_alloc_pd_resp pd_resp = {0};
+    struct rocm_ernic_pd *pd = to_vpd(ibpd);
+    struct rocm_ernic_dev *dev = to_vdev(ibdev);
+    union rocm_ernic_cmd_req req = {};
+    union rocm_ernic_cmd_resp rsp = {};
+    struct rocm_ernic_cmd_create_pd *cmd = &req.create_pd;
+    struct rocm_ernic_cmd_create_pd_resp *resp = &rsp.create_pd_resp;
+    struct rocm_ernic_alloc_pd_resp pd_resp = {0};
     int ret;
-    struct amd_emrdma_ucontext *context = rdma_udata_to_drv_context(
-        udata, struct amd_emrdma_ucontext, ibucontext);
+    struct rocm_ernic_ucontext *context = rdma_udata_to_drv_context(
+        udata, struct rocm_ernic_ucontext, ibucontext);
 
     /* Check allowed max pds */
     if (!atomic_add_unless(&dev->num_pds, 1, dev->dsr->caps.max_pd))
         return -ENOMEM;
 
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_CREATE_PD;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_CREATE_PD;
     cmd->ctx_handle = context ? context->ctx_handle : 0;
-    ret = amd_emrdma_cmd_post(dev, &req, &rsp, AMD_EMRDMA_CMD_CREATE_PD_RESP);
+    ret = rocm_ernic_cmd_post(dev, &req, &rsp, ROCM_ERNIC_CMD_CREATE_PD_RESP);
     if (ret < 0) {
         dev_warn(&dev->pdev->dev,
                  "failed to allocate protection domain, error: %d\n", ret);
@@ -445,7 +445,7 @@ int amd_emrdma_alloc_pd(struct ib_pd *ibpd, struct ib_udata *udata)
         if (ib_copy_to_udata(udata, &pd_resp, sizeof(pd_resp))) {
             dev_warn(&dev->pdev->dev,
                      "failed to copy back protection domain\n");
-            amd_emrdma_dealloc_pd(&pd->ibpd, udata);
+            rocm_ernic_dealloc_pd(&pd->ibpd, udata);
             return -EFAULT;
         }
     }
@@ -459,23 +459,23 @@ err:
 }
 
 /**
- * amd_emrdma_dealloc_pd - deallocate protection domain
+ * rocm_ernic_dealloc_pd - deallocate protection domain
  * @pd: the protection domain to be released
  * @udata: user data or null for kernel object
  *
  * @return: Always 0
  */
-int amd_emrdma_dealloc_pd(struct ib_pd *pd, struct ib_udata *udata)
+int rocm_ernic_dealloc_pd(struct ib_pd *pd, struct ib_udata *udata)
 {
-    struct amd_emrdma_dev *dev = to_vdev(pd->device);
-    union amd_emrdma_cmd_req req = {};
-    struct amd_emrdma_cmd_destroy_pd *cmd = &req.destroy_pd;
+    struct rocm_ernic_dev *dev = to_vdev(pd->device);
+    union rocm_ernic_cmd_req req = {};
+    struct rocm_ernic_cmd_destroy_pd *cmd = &req.destroy_pd;
     int ret;
 
-    cmd->hdr.cmd = AMD_EMRDMA_CMD_DESTROY_PD;
+    cmd->hdr.cmd = ROCM_ERNIC_CMD_DESTROY_PD;
     cmd->pd_handle = to_vpd(pd)->pd_handle;
 
-    ret = amd_emrdma_cmd_post(dev, &req, NULL, 0);
+    ret = rocm_ernic_cmd_post(dev, &req, NULL, 0);
     if (ret)
         dev_warn(&dev->pdev->dev,
                  "could not dealloc protection domain, error: %d\n", ret);
@@ -485,20 +485,20 @@ int amd_emrdma_dealloc_pd(struct ib_pd *pd, struct ib_udata *udata)
 }
 
 /**
- * amd_emrdma_create_ah - create an address handle
+ * rocm_ernic_create_ah - create an address handle
  * @ibah: the IB address handle
  * @init_attr: the attributes of the AH
  * @udata: pointer to user data
  *
  * @return: 0 on success, otherwise errno.
  */
-int amd_emrdma_create_ah(struct ib_ah *ibah,
+int rocm_ernic_create_ah(struct ib_ah *ibah,
                          struct rdma_ah_init_attr *init_attr,
                          struct ib_udata *udata)
 {
     struct rdma_ah_attr *ah_attr = init_attr->ah_attr;
-    struct amd_emrdma_dev *dev = to_vdev(ibah->device);
-    struct amd_emrdma_ah *ah = to_vah(ibah);
+    struct rocm_ernic_dev *dev = to_vdev(ibah->device);
+    struct rocm_ernic_ah *ah = to_vah(ibah);
     const struct ib_global_route *grh;
     u32 port_num = rdma_ah_get_port_num(ah_attr);
 
@@ -526,14 +526,14 @@ int amd_emrdma_create_ah(struct ib_ah *ibah,
 }
 
 /**
- * amd_emrdma_destroy_ah - destroy an address handle
+ * rocm_ernic_destroy_ah - destroy an address handle
  * @ah: the address handle to destroyed
  * @flags: destroy address handle flags (see enum rdma_destroy_ah_flags)
  *
  */
-int amd_emrdma_destroy_ah(struct ib_ah *ah, u32 flags)
+int rocm_ernic_destroy_ah(struct ib_ah *ah, u32 flags)
 {
-    struct amd_emrdma_dev *dev = to_vdev(ah->device);
+    struct rocm_ernic_dev *dev = to_vdev(ah->device);
 
     atomic_dec(&dev->num_ahs);
     return 0;

--- a/driver/rocm_ernic_verbs.h
+++ b/driver/rocm_ernic_verbs.h
@@ -43,13 +43,13 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __AMD_EMRDMA_VERBS_H__
-#define __AMD_EMRDMA_VERBS_H__
+#ifndef __ROCM_ERNIC_VERBS_H__
+#define __ROCM_ERNIC_VERBS_H__
 
 #include <linux/version.h>
 #include <linux/types.h>
 
-union amd_emrdma_gid {
+union rocm_ernic_gid {
     u8 raw[16];
     struct {
         __be64 subnet_prefix;
@@ -57,77 +57,77 @@ union amd_emrdma_gid {
     } global;
 };
 
-enum amd_emrdma_link_layer {
-    AMD_EMRDMA_LINK_LAYER_UNSPECIFIED,
-    AMD_EMRDMA_LINK_LAYER_INFINIBAND,
-    AMD_EMRDMA_LINK_LAYER_ETHERNET,
+enum rocm_ernic_link_layer {
+    ROCM_ERNIC_LINK_LAYER_UNSPECIFIED,
+    ROCM_ERNIC_LINK_LAYER_INFINIBAND,
+    ROCM_ERNIC_LINK_LAYER_ETHERNET,
 };
 
-enum amd_emrdma_mtu {
-    AMD_EMRDMA_MTU_256 = 1,
-    AMD_EMRDMA_MTU_512 = 2,
-    AMD_EMRDMA_MTU_1024 = 3,
-    AMD_EMRDMA_MTU_2048 = 4,
-    AMD_EMRDMA_MTU_4096 = 5,
+enum rocm_ernic_mtu {
+    ROCM_ERNIC_MTU_256 = 1,
+    ROCM_ERNIC_MTU_512 = 2,
+    ROCM_ERNIC_MTU_1024 = 3,
+    ROCM_ERNIC_MTU_2048 = 4,
+    ROCM_ERNIC_MTU_4096 = 5,
 };
 
-enum amd_emrdma_port_state {
-    AMD_EMRDMA_PORT_NOP = 0,
-    AMD_EMRDMA_PORT_DOWN = 1,
-    AMD_EMRDMA_PORT_INIT = 2,
-    AMD_EMRDMA_PORT_ARMED = 3,
-    AMD_EMRDMA_PORT_ACTIVE = 4,
-    AMD_EMRDMA_PORT_ACTIVE_DEFER = 5,
+enum rocm_ernic_port_state {
+    ROCM_ERNIC_PORT_NOP = 0,
+    ROCM_ERNIC_PORT_DOWN = 1,
+    ROCM_ERNIC_PORT_INIT = 2,
+    ROCM_ERNIC_PORT_ARMED = 3,
+    ROCM_ERNIC_PORT_ACTIVE = 4,
+    ROCM_ERNIC_PORT_ACTIVE_DEFER = 5,
 };
 
-enum amd_emrdma_port_cap_flags {
-    AMD_EMRDMA_PORT_SM = 1 << 1,
-    AMD_EMRDMA_PORT_NOTICE_SUP = 1 << 2,
-    AMD_EMRDMA_PORT_TRAP_SUP = 1 << 3,
-    AMD_EMRDMA_PORT_OPT_IPD_SUP = 1 << 4,
-    AMD_EMRDMA_PORT_AUTO_MIGR_SUP = 1 << 5,
-    AMD_EMRDMA_PORT_SL_MAP_SUP = 1 << 6,
-    AMD_EMRDMA_PORT_MKEY_NVRAM = 1 << 7,
-    AMD_EMRDMA_PORT_PKEY_NVRAM = 1 << 8,
-    AMD_EMRDMA_PORT_LED_INFO_SUP = 1 << 9,
-    AMD_EMRDMA_PORT_SM_DISABLED = 1 << 10,
-    AMD_EMRDMA_PORT_SYS_IMAGE_GUID_SUP = 1 << 11,
-    AMD_EMRDMA_PORT_PKEY_SW_EXT_PORT_TRAP_SUP = 1 << 12,
-    AMD_EMRDMA_PORT_EXTENDED_SPEEDS_SUP = 1 << 14,
-    AMD_EMRDMA_PORT_CM_SUP = 1 << 16,
-    AMD_EMRDMA_PORT_SNMP_TUNNEL_SUP = 1 << 17,
-    AMD_EMRDMA_PORT_REINIT_SUP = 1 << 18,
-    AMD_EMRDMA_PORT_DEVICE_MGMT_SUP = 1 << 19,
-    AMD_EMRDMA_PORT_VENDOR_CLASS_SUP = 1 << 20,
-    AMD_EMRDMA_PORT_DR_NOTICE_SUP = 1 << 21,
-    AMD_EMRDMA_PORT_CAP_MASK_NOTICE_SUP = 1 << 22,
-    AMD_EMRDMA_PORT_BOOT_MGMT_SUP = 1 << 23,
-    AMD_EMRDMA_PORT_LINK_LATENCY_SUP = 1 << 24,
-    AMD_EMRDMA_PORT_CLIENT_REG_SUP = 1 << 25,
-    AMD_EMRDMA_PORT_IP_BASED_GIDS = 1 << 26,
-    AMD_EMRDMA_PORT_CAP_FLAGS_MAX = AMD_EMRDMA_PORT_IP_BASED_GIDS,
+enum rocm_ernic_port_cap_flags {
+    ROCM_ERNIC_PORT_SM = 1 << 1,
+    ROCM_ERNIC_PORT_NOTICE_SUP = 1 << 2,
+    ROCM_ERNIC_PORT_TRAP_SUP = 1 << 3,
+    ROCM_ERNIC_PORT_OPT_IPD_SUP = 1 << 4,
+    ROCM_ERNIC_PORT_AUTO_MIGR_SUP = 1 << 5,
+    ROCM_ERNIC_PORT_SL_MAP_SUP = 1 << 6,
+    ROCM_ERNIC_PORT_MKEY_NVRAM = 1 << 7,
+    ROCM_ERNIC_PORT_PKEY_NVRAM = 1 << 8,
+    ROCM_ERNIC_PORT_LED_INFO_SUP = 1 << 9,
+    ROCM_ERNIC_PORT_SM_DISABLED = 1 << 10,
+    ROCM_ERNIC_PORT_SYS_IMAGE_GUID_SUP = 1 << 11,
+    ROCM_ERNIC_PORT_PKEY_SW_EXT_PORT_TRAP_SUP = 1 << 12,
+    ROCM_ERNIC_PORT_EXTENDED_SPEEDS_SUP = 1 << 14,
+    ROCM_ERNIC_PORT_CM_SUP = 1 << 16,
+    ROCM_ERNIC_PORT_SNMP_TUNNEL_SUP = 1 << 17,
+    ROCM_ERNIC_PORT_REINIT_SUP = 1 << 18,
+    ROCM_ERNIC_PORT_DEVICE_MGMT_SUP = 1 << 19,
+    ROCM_ERNIC_PORT_VENDOR_CLASS_SUP = 1 << 20,
+    ROCM_ERNIC_PORT_DR_NOTICE_SUP = 1 << 21,
+    ROCM_ERNIC_PORT_CAP_MASK_NOTICE_SUP = 1 << 22,
+    ROCM_ERNIC_PORT_BOOT_MGMT_SUP = 1 << 23,
+    ROCM_ERNIC_PORT_LINK_LATENCY_SUP = 1 << 24,
+    ROCM_ERNIC_PORT_CLIENT_REG_SUP = 1 << 25,
+    ROCM_ERNIC_PORT_IP_BASED_GIDS = 1 << 26,
+    ROCM_ERNIC_PORT_CAP_FLAGS_MAX = ROCM_ERNIC_PORT_IP_BASED_GIDS,
 };
 
-enum amd_emrdma_port_width {
-    AMD_EMRDMA_WIDTH_1X = 1,
-    AMD_EMRDMA_WIDTH_4X = 2,
-    AMD_EMRDMA_WIDTH_8X = 4,
-    AMD_EMRDMA_WIDTH_12X = 8,
+enum rocm_ernic_port_width {
+    ROCM_ERNIC_WIDTH_1X = 1,
+    ROCM_ERNIC_WIDTH_4X = 2,
+    ROCM_ERNIC_WIDTH_8X = 4,
+    ROCM_ERNIC_WIDTH_12X = 8,
 };
 
-enum amd_emrdma_port_speed {
-    AMD_EMRDMA_SPEED_SDR = 1,
-    AMD_EMRDMA_SPEED_DDR = 2,
-    AMD_EMRDMA_SPEED_QDR = 4,
-    AMD_EMRDMA_SPEED_FDR10 = 8,
-    AMD_EMRDMA_SPEED_FDR = 16,
-    AMD_EMRDMA_SPEED_EDR = 32,
+enum rocm_ernic_port_speed {
+    ROCM_ERNIC_SPEED_SDR = 1,
+    ROCM_ERNIC_SPEED_DDR = 2,
+    ROCM_ERNIC_SPEED_QDR = 4,
+    ROCM_ERNIC_SPEED_FDR10 = 8,
+    ROCM_ERNIC_SPEED_FDR = 16,
+    ROCM_ERNIC_SPEED_EDR = 32,
 };
 
-struct amd_emrdma_port_attr {
-    enum amd_emrdma_port_state state;
-    enum amd_emrdma_mtu max_mtu;
-    enum amd_emrdma_mtu active_mtu;
+struct rocm_ernic_port_attr {
+    enum rocm_ernic_port_state state;
+    enum rocm_ernic_mtu max_mtu;
+    enum rocm_ernic_mtu active_mtu;
     u32 gid_tbl_len;
     u32 port_cap_flags;
     u32 max_msg_sz;
@@ -147,8 +147,8 @@ struct amd_emrdma_port_attr {
     u8 reserved[2];
 };
 
-struct amd_emrdma_global_route {
-    union amd_emrdma_gid dgid;
+struct rocm_ernic_global_route {
+    union rocm_ernic_gid dgid;
     u32 flow_label;
     u8 sgid_index;
     u8 hop_limit;
@@ -156,42 +156,42 @@ struct amd_emrdma_global_route {
     u8 reserved;
 };
 
-struct amd_emrdma_grh {
+struct rocm_ernic_grh {
     __be32 version_tclass_flow;
     __be16 paylen;
     u8 next_hdr;
     u8 hop_limit;
-    union amd_emrdma_gid sgid;
-    union amd_emrdma_gid dgid;
+    union rocm_ernic_gid sgid;
+    union rocm_ernic_gid dgid;
 };
 
-enum amd_emrdma_ah_flags {
-    AMD_EMRDMA_AH_GRH = 1,
+enum rocm_ernic_ah_flags {
+    ROCM_ERNIC_AH_GRH = 1,
 };
 
-enum amd_emrdma_rate {
-    AMD_EMRDMA_RATE_PORT_CURRENT = 0,
-    AMD_EMRDMA_RATE_2_5_GBPS = 2,
-    AMD_EMRDMA_RATE_5_GBPS = 5,
-    AMD_EMRDMA_RATE_10_GBPS = 3,
-    AMD_EMRDMA_RATE_20_GBPS = 6,
-    AMD_EMRDMA_RATE_30_GBPS = 4,
-    AMD_EMRDMA_RATE_40_GBPS = 7,
-    AMD_EMRDMA_RATE_60_GBPS = 8,
-    AMD_EMRDMA_RATE_80_GBPS = 9,
-    AMD_EMRDMA_RATE_120_GBPS = 10,
-    AMD_EMRDMA_RATE_14_GBPS = 11,
-    AMD_EMRDMA_RATE_56_GBPS = 12,
-    AMD_EMRDMA_RATE_112_GBPS = 13,
-    AMD_EMRDMA_RATE_168_GBPS = 14,
-    AMD_EMRDMA_RATE_25_GBPS = 15,
-    AMD_EMRDMA_RATE_100_GBPS = 16,
-    AMD_EMRDMA_RATE_200_GBPS = 17,
-    AMD_EMRDMA_RATE_300_GBPS = 18,
+enum rocm_ernic_rate {
+    ROCM_ERNIC_RATE_PORT_CURRENT = 0,
+    ROCM_ERNIC_RATE_2_5_GBPS = 2,
+    ROCM_ERNIC_RATE_5_GBPS = 5,
+    ROCM_ERNIC_RATE_10_GBPS = 3,
+    ROCM_ERNIC_RATE_20_GBPS = 6,
+    ROCM_ERNIC_RATE_30_GBPS = 4,
+    ROCM_ERNIC_RATE_40_GBPS = 7,
+    ROCM_ERNIC_RATE_60_GBPS = 8,
+    ROCM_ERNIC_RATE_80_GBPS = 9,
+    ROCM_ERNIC_RATE_120_GBPS = 10,
+    ROCM_ERNIC_RATE_14_GBPS = 11,
+    ROCM_ERNIC_RATE_56_GBPS = 12,
+    ROCM_ERNIC_RATE_112_GBPS = 13,
+    ROCM_ERNIC_RATE_168_GBPS = 14,
+    ROCM_ERNIC_RATE_25_GBPS = 15,
+    ROCM_ERNIC_RATE_100_GBPS = 16,
+    ROCM_ERNIC_RATE_200_GBPS = 17,
+    ROCM_ERNIC_RATE_300_GBPS = 18,
 };
 
-struct amd_emrdma_ah_attr {
-    struct amd_emrdma_global_route grh;
+struct rocm_ernic_ah_attr {
+    struct rocm_ernic_global_route grh;
     u16 dlid;
     u16 vlan_id;
     u8 sl;
@@ -203,15 +203,15 @@ struct amd_emrdma_ah_attr {
     u8 reserved;
 };
 
-enum amd_emrdma_cq_notify_flags {
-    AMD_EMRDMA_CQ_SOLICITED = 1 << 0,
-    AMD_EMRDMA_CQ_NEXT_COMP = 1 << 1,
-    AMD_EMRDMA_CQ_SOLICITED_MASK =
-        AMD_EMRDMA_CQ_SOLICITED | AMD_EMRDMA_CQ_NEXT_COMP,
-    AMD_EMRDMA_CQ_REPORT_MISSED_EVENTS = 1 << 2,
+enum rocm_ernic_cq_notify_flags {
+    ROCM_ERNIC_CQ_SOLICITED = 1 << 0,
+    ROCM_ERNIC_CQ_NEXT_COMP = 1 << 1,
+    ROCM_ERNIC_CQ_SOLICITED_MASK =
+        ROCM_ERNIC_CQ_SOLICITED | ROCM_ERNIC_CQ_NEXT_COMP,
+    ROCM_ERNIC_CQ_REPORT_MISSED_EVENTS = 1 << 2,
 };
 
-struct amd_emrdma_qp_cap {
+struct rocm_ernic_qp_cap {
     u32 max_send_wr;
     u32 max_recv_wr;
     u32 max_send_sge;
@@ -220,88 +220,88 @@ struct amd_emrdma_qp_cap {
     u32 reserved;
 };
 
-enum amd_emrdma_sig_type {
-    AMD_EMRDMA_SIGNAL_ALL_WR,
-    AMD_EMRDMA_SIGNAL_REQ_WR,
+enum rocm_ernic_sig_type {
+    ROCM_ERNIC_SIGNAL_ALL_WR,
+    ROCM_ERNIC_SIGNAL_REQ_WR,
 };
 
-enum amd_emrdma_qp_type {
-    AMD_EMRDMA_QPT_SMI,
-    AMD_EMRDMA_QPT_GSI,
-    AMD_EMRDMA_QPT_RC,
-    AMD_EMRDMA_QPT_UC,
-    AMD_EMRDMA_QPT_UD,
-    AMD_EMRDMA_QPT_RAW_IPV6,
-    AMD_EMRDMA_QPT_RAW_ETHERTYPE,
-    AMD_EMRDMA_QPT_RAW_PACKET = 8,
-    AMD_EMRDMA_QPT_XRC_INI = 9,
-    AMD_EMRDMA_QPT_XRC_TGT,
-    AMD_EMRDMA_QPT_MAX,
+enum rocm_ernic_qp_type {
+    ROCM_ERNIC_QPT_SMI,
+    ROCM_ERNIC_QPT_GSI,
+    ROCM_ERNIC_QPT_RC,
+    ROCM_ERNIC_QPT_UC,
+    ROCM_ERNIC_QPT_UD,
+    ROCM_ERNIC_QPT_RAW_IPV6,
+    ROCM_ERNIC_QPT_RAW_ETHERTYPE,
+    ROCM_ERNIC_QPT_RAW_PACKET = 8,
+    ROCM_ERNIC_QPT_XRC_INI = 9,
+    ROCM_ERNIC_QPT_XRC_TGT,
+    ROCM_ERNIC_QPT_MAX,
 };
 
-enum amd_emrdma_qp_create_flags {
-    AMD_EMRDMA_QP_CREATE_IPOAMD_EMRDMA_UD_LSO = 1 << 0,
-    AMD_EMRDMA_QP_CREATE_BLOCK_MULTICAST_LOOPBACK = 1 << 1,
+enum rocm_ernic_qp_create_flags {
+    ROCM_ERNIC_QP_CREATE_IPOROCM_ERNIC_UD_LSO = 1 << 0,
+    ROCM_ERNIC_QP_CREATE_BLOCK_MULTICAST_LOOPBACK = 1 << 1,
 };
 
-enum amd_emrdma_qp_attr_mask {
-    AMD_EMRDMA_QP_STATE = 1 << 0,
-    AMD_EMRDMA_QP_CUR_STATE = 1 << 1,
-    AMD_EMRDMA_QP_EN_SQD_ASYNC_NOTIFY = 1 << 2,
-    AMD_EMRDMA_QP_ACCESS_FLAGS = 1 << 3,
-    AMD_EMRDMA_QP_PKEY_INDEX = 1 << 4,
-    AMD_EMRDMA_QP_PORT = 1 << 5,
-    AMD_EMRDMA_QP_QKEY = 1 << 6,
-    AMD_EMRDMA_QP_AV = 1 << 7,
-    AMD_EMRDMA_QP_PATH_MTU = 1 << 8,
-    AMD_EMRDMA_QP_TIMEOUT = 1 << 9,
-    AMD_EMRDMA_QP_RETRY_CNT = 1 << 10,
-    AMD_EMRDMA_QP_RNR_RETRY = 1 << 11,
-    AMD_EMRDMA_QP_RQ_PSN = 1 << 12,
-    AMD_EMRDMA_QP_MAX_QP_RD_ATOMIC = 1 << 13,
-    AMD_EMRDMA_QP_ALT_PATH = 1 << 14,
-    AMD_EMRDMA_QP_MIN_RNR_TIMER = 1 << 15,
-    AMD_EMRDMA_QP_SQ_PSN = 1 << 16,
-    AMD_EMRDMA_QP_MAX_DEST_RD_ATOMIC = 1 << 17,
-    AMD_EMRDMA_QP_PATH_MIG_STATE = 1 << 18,
-    AMD_EMRDMA_QP_CAP = 1 << 19,
-    AMD_EMRDMA_QP_DEST_QPN = 1 << 20,
-    AMD_EMRDMA_QP_ATTR_MASK_MAX = AMD_EMRDMA_QP_DEST_QPN,
+enum rocm_ernic_qp_attr_mask {
+    ROCM_ERNIC_QP_STATE = 1 << 0,
+    ROCM_ERNIC_QP_CUR_STATE = 1 << 1,
+    ROCM_ERNIC_QP_EN_SQD_ASYNC_NOTIFY = 1 << 2,
+    ROCM_ERNIC_QP_ACCESS_FLAGS = 1 << 3,
+    ROCM_ERNIC_QP_PKEY_INDEX = 1 << 4,
+    ROCM_ERNIC_QP_PORT = 1 << 5,
+    ROCM_ERNIC_QP_QKEY = 1 << 6,
+    ROCM_ERNIC_QP_AV = 1 << 7,
+    ROCM_ERNIC_QP_PATH_MTU = 1 << 8,
+    ROCM_ERNIC_QP_TIMEOUT = 1 << 9,
+    ROCM_ERNIC_QP_RETRY_CNT = 1 << 10,
+    ROCM_ERNIC_QP_RNR_RETRY = 1 << 11,
+    ROCM_ERNIC_QP_RQ_PSN = 1 << 12,
+    ROCM_ERNIC_QP_MAX_QP_RD_ATOMIC = 1 << 13,
+    ROCM_ERNIC_QP_ALT_PATH = 1 << 14,
+    ROCM_ERNIC_QP_MIN_RNR_TIMER = 1 << 15,
+    ROCM_ERNIC_QP_SQ_PSN = 1 << 16,
+    ROCM_ERNIC_QP_MAX_DEST_RD_ATOMIC = 1 << 17,
+    ROCM_ERNIC_QP_PATH_MIG_STATE = 1 << 18,
+    ROCM_ERNIC_QP_CAP = 1 << 19,
+    ROCM_ERNIC_QP_DEST_QPN = 1 << 20,
+    ROCM_ERNIC_QP_ATTR_MASK_MAX = ROCM_ERNIC_QP_DEST_QPN,
 };
 
-enum amd_emrdma_qp_state {
-    AMD_EMRDMA_QPS_RESET,
-    AMD_EMRDMA_QPS_INIT,
-    AMD_EMRDMA_QPS_RTR,
-    AMD_EMRDMA_QPS_RTS,
-    AMD_EMRDMA_QPS_SQD,
-    AMD_EMRDMA_QPS_SQE,
-    AMD_EMRDMA_QPS_ERR,
+enum rocm_ernic_qp_state {
+    ROCM_ERNIC_QPS_RESET,
+    ROCM_ERNIC_QPS_INIT,
+    ROCM_ERNIC_QPS_RTR,
+    ROCM_ERNIC_QPS_RTS,
+    ROCM_ERNIC_QPS_SQD,
+    ROCM_ERNIC_QPS_SQE,
+    ROCM_ERNIC_QPS_ERR,
 };
 
-enum amd_emrdma_mig_state {
-    AMD_EMRDMA_MIG_MIGRATED,
-    AMD_EMRDMA_MIG_REARM,
-    AMD_EMRDMA_MIG_ARMED,
+enum rocm_ernic_mig_state {
+    ROCM_ERNIC_MIG_MIGRATED,
+    ROCM_ERNIC_MIG_REARM,
+    ROCM_ERNIC_MIG_ARMED,
 };
 
-enum amd_emrdma_mw_type {
-    AMD_EMRDMA_MW_TYPE_1 = 1,
-    AMD_EMRDMA_MW_TYPE_2 = 2,
+enum rocm_ernic_mw_type {
+    ROCM_ERNIC_MW_TYPE_1 = 1,
+    ROCM_ERNIC_MW_TYPE_2 = 2,
 };
 
-struct amd_emrdma_srq_attr {
+struct rocm_ernic_srq_attr {
     u32 max_wr;
     u32 max_sge;
     u32 srq_limit;
     u32 reserved;
 };
 
-struct amd_emrdma_qp_attr {
-    enum amd_emrdma_qp_state qp_state;
-    enum amd_emrdma_qp_state cur_qp_state;
-    enum amd_emrdma_mtu path_mtu;
-    enum amd_emrdma_mig_state path_mig_state;
+struct rocm_ernic_qp_attr {
+    enum rocm_ernic_qp_state qp_state;
+    enum rocm_ernic_qp_state cur_qp_state;
+    enum rocm_ernic_mtu path_mtu;
+    enum rocm_ernic_mig_state path_mig_state;
     u32 qkey;
     u32 rq_psn;
     u32 sq_psn;
@@ -321,90 +321,90 @@ struct amd_emrdma_qp_attr {
     u8 alt_port_num;
     u8 alt_timeout;
     u8 reserved[5];
-    struct amd_emrdma_qp_cap cap;
-    struct amd_emrdma_ah_attr ah_attr;
-    struct amd_emrdma_ah_attr alt_ah_attr;
+    struct rocm_ernic_qp_cap cap;
+    struct rocm_ernic_ah_attr ah_attr;
+    struct rocm_ernic_ah_attr alt_ah_attr;
 };
 
-enum amd_emrdma_send_flags {
-    AMD_EMRDMA_SEND_FENCE = 1 << 0,
-    AMD_EMRDMA_SEND_SIGNALED = 1 << 1,
-    AMD_EMRDMA_SEND_SOLICITED = 1 << 2,
-    AMD_EMRDMA_SEND_INLINE = 1 << 3,
-    AMD_EMRDMA_SEND_IP_CSUM = 1 << 4,
-    AMD_EMRDMA_SEND_FLAGS_MAX = AMD_EMRDMA_SEND_IP_CSUM,
+enum rocm_ernic_send_flags {
+    ROCM_ERNIC_SEND_FENCE = 1 << 0,
+    ROCM_ERNIC_SEND_SIGNALED = 1 << 1,
+    ROCM_ERNIC_SEND_SOLICITED = 1 << 2,
+    ROCM_ERNIC_SEND_INLINE = 1 << 3,
+    ROCM_ERNIC_SEND_IP_CSUM = 1 << 4,
+    ROCM_ERNIC_SEND_FLAGS_MAX = ROCM_ERNIC_SEND_IP_CSUM,
 };
 
-enum amd_emrdma_access_flags {
-    AMD_EMRDMA_ACCESS_LOCAL_WRITE = 1 << 0,
-    AMD_EMRDMA_ACCESS_REMOTE_WRITE = 1 << 1,
-    AMD_EMRDMA_ACCESS_REMOTE_READ = 1 << 2,
-    AMD_EMRDMA_ACCESS_REMOTE_ATOMIC = 1 << 3,
-    AMD_EMRDMA_ACCESS_MW_BIND = 1 << 4,
-    AMD_EMRDMA_ZERO_BASED = 1 << 5,
-    AMD_EMRDMA_ACCESS_ON_DEMAND = 1 << 6,
-    AMD_EMRDMA_ACCESS_FLAGS_MAX = AMD_EMRDMA_ACCESS_ON_DEMAND,
+enum rocm_ernic_access_flags {
+    ROCM_ERNIC_ACCESS_LOCAL_WRITE = 1 << 0,
+    ROCM_ERNIC_ACCESS_REMOTE_WRITE = 1 << 1,
+    ROCM_ERNIC_ACCESS_REMOTE_READ = 1 << 2,
+    ROCM_ERNIC_ACCESS_REMOTE_ATOMIC = 1 << 3,
+    ROCM_ERNIC_ACCESS_MW_BIND = 1 << 4,
+    ROCM_ERNIC_ZERO_BASED = 1 << 5,
+    ROCM_ERNIC_ACCESS_ON_DEMAND = 1 << 6,
+    ROCM_ERNIC_ACCESS_FLAGS_MAX = ROCM_ERNIC_ACCESS_ON_DEMAND,
 };
 
-int amd_emrdma_query_device(struct ib_device *ibdev,
+int rocm_ernic_query_device(struct ib_device *ibdev,
                             struct ib_device_attr *props,
                             struct ib_udata *udata);
-int amd_emrdma_query_port(struct ib_device *ibdev, u32 port,
+int rocm_ernic_query_port(struct ib_device *ibdev, u32 port,
                           struct ib_port_attr *props);
-int amd_emrdma_query_gid(struct ib_device *ibdev, u32 port, int index,
+int rocm_ernic_query_gid(struct ib_device *ibdev, u32 port, int index,
                          union ib_gid *gid);
-int amd_emrdma_query_pkey(struct ib_device *ibdev, u32 port, u16 index,
+int rocm_ernic_query_pkey(struct ib_device *ibdev, u32 port, u16 index,
                           u16 *pkey);
-enum rdma_link_layer amd_emrdma_port_link_layer(struct ib_device *ibdev,
+enum rdma_link_layer rocm_ernic_port_link_layer(struct ib_device *ibdev,
                                                 u32 port);
-int amd_emrdma_modify_port(struct ib_device *ibdev, u32 port, int mask,
+int rocm_ernic_modify_port(struct ib_device *ibdev, u32 port, int mask,
                            struct ib_port_modify *props);
-int amd_emrdma_mmap(struct ib_ucontext *context, struct vm_area_struct *vma);
-int amd_emrdma_alloc_ucontext(struct ib_ucontext *uctx, struct ib_udata *udata);
-void amd_emrdma_dealloc_ucontext(struct ib_ucontext *context);
-int amd_emrdma_alloc_pd(struct ib_pd *pd, struct ib_udata *udata);
-int amd_emrdma_dealloc_pd(struct ib_pd *ibpd, struct ib_udata *udata);
-struct ib_mr *amd_emrdma_get_dma_mr(struct ib_pd *pd, int acc);
-struct ib_mr *amd_emrdma_reg_user_mr(struct ib_pd *pd, u64 start, u64 length,
+int rocm_ernic_mmap(struct ib_ucontext *context, struct vm_area_struct *vma);
+int rocm_ernic_alloc_ucontext(struct ib_ucontext *uctx, struct ib_udata *udata);
+void rocm_ernic_dealloc_ucontext(struct ib_ucontext *context);
+int rocm_ernic_alloc_pd(struct ib_pd *pd, struct ib_udata *udata);
+int rocm_ernic_dealloc_pd(struct ib_pd *ibpd, struct ib_udata *udata);
+struct ib_mr *rocm_ernic_get_dma_mr(struct ib_pd *pd, int acc);
+struct ib_mr *rocm_ernic_reg_user_mr(struct ib_pd *pd, u64 start, u64 length,
                                      u64 virt_addr, int access_flags,
                                      struct ib_udata *udata);
-int amd_emrdma_dereg_mr(struct ib_mr *mr, struct ib_udata *udata);
-struct ib_mr *amd_emrdma_alloc_mr(struct ib_pd *pd, enum ib_mr_type mr_type,
+int rocm_ernic_dereg_mr(struct ib_mr *mr, struct ib_udata *udata);
+struct ib_mr *rocm_ernic_alloc_mr(struct ib_pd *pd, enum ib_mr_type mr_type,
                                   u32 max_num_sg);
-int amd_emrdma_map_mr_sg(struct ib_mr *ibmr, struct scatterlist *sg,
+int rocm_ernic_map_mr_sg(struct ib_mr *ibmr, struct scatterlist *sg,
                          int sg_nents, unsigned int *sg_offset);
-int amd_emrdma_create_cq(struct ib_cq *ibcq, const struct ib_cq_init_attr *attr,
+int rocm_ernic_create_cq(struct ib_cq *ibcq, const struct ib_cq_init_attr *attr,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
                          struct uverbs_attr_bundle *attrs);
 #else
                          struct ib_udata *udata);
 #endif
-int amd_emrdma_destroy_cq(struct ib_cq *cq, struct ib_udata *udata);
-int amd_emrdma_poll_cq(struct ib_cq *ibcq, int num_entries, struct ib_wc *wc);
-int amd_emrdma_req_notify_cq(struct ib_cq *cq, enum ib_cq_notify_flags flags);
-int amd_emrdma_create_ah(struct ib_ah *ah, struct rdma_ah_init_attr *init_attr,
+int rocm_ernic_destroy_cq(struct ib_cq *cq, struct ib_udata *udata);
+int rocm_ernic_poll_cq(struct ib_cq *ibcq, int num_entries, struct ib_wc *wc);
+int rocm_ernic_req_notify_cq(struct ib_cq *cq, enum ib_cq_notify_flags flags);
+int rocm_ernic_create_ah(struct ib_ah *ah, struct rdma_ah_init_attr *init_attr,
                          struct ib_udata *udata);
-int amd_emrdma_destroy_ah(struct ib_ah *ah, u32 flags);
+int rocm_ernic_destroy_ah(struct ib_ah *ah, u32 flags);
 
-int amd_emrdma_create_srq(struct ib_srq *srq,
+int rocm_ernic_create_srq(struct ib_srq *srq,
                           struct ib_srq_init_attr *init_attr,
                           struct ib_udata *udata);
-int amd_emrdma_modify_srq(struct ib_srq *ibsrq, struct ib_srq_attr *attr,
+int rocm_ernic_modify_srq(struct ib_srq *ibsrq, struct ib_srq_attr *attr,
                           enum ib_srq_attr_mask attr_mask,
                           struct ib_udata *udata);
-int amd_emrdma_query_srq(struct ib_srq *srq, struct ib_srq_attr *srq_attr);
-int amd_emrdma_destroy_srq(struct ib_srq *srq, struct ib_udata *udata);
+int rocm_ernic_query_srq(struct ib_srq *srq, struct ib_srq_attr *srq_attr);
+int rocm_ernic_destroy_srq(struct ib_srq *srq, struct ib_udata *udata);
 
-int amd_emrdma_create_qp(struct ib_qp *qp, struct ib_qp_init_attr *init_attr,
+int rocm_ernic_create_qp(struct ib_qp *qp, struct ib_qp_init_attr *init_attr,
                          struct ib_udata *udata);
-int amd_emrdma_modify_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr,
+int rocm_ernic_modify_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr,
                          int attr_mask, struct ib_udata *udata);
-int amd_emrdma_query_qp(struct ib_qp *ibqp, struct ib_qp_attr *qp_attr,
+int rocm_ernic_query_qp(struct ib_qp *ibqp, struct ib_qp_attr *qp_attr,
                         int qp_attr_mask, struct ib_qp_init_attr *qp_init_attr);
-int amd_emrdma_destroy_qp(struct ib_qp *qp, struct ib_udata *udata);
-int amd_emrdma_post_send(struct ib_qp *ibqp, const struct ib_send_wr *wr,
+int rocm_ernic_destroy_qp(struct ib_qp *qp, struct ib_udata *udata);
+int rocm_ernic_post_send(struct ib_qp *ibqp, const struct ib_send_wr *wr,
                          const struct ib_send_wr **bad_wr);
-int amd_emrdma_post_recv(struct ib_qp *ibqp, const struct ib_recv_wr *wr,
+int rocm_ernic_post_recv(struct ib_qp *ibqp, const struct ib_recv_wr *wr,
                          const struct ib_recv_wr **bad_wr);
 
-#endif /* __AMD_EMRDMA_VERBS_H__ */
+#endif /* __ROCM_ERNIC_VERBS_H__ */

--- a/scripts/local-vm-test.sh
+++ b/scripts/local-vm-test.sh
@@ -244,11 +244,11 @@ echo ""
 echo "=== Building Driver ==="
 cd /tmp/driver
 make
-ls -lh amd_emrdma.ko
+ls -lh rocm_ernic.ko
 
 echo ""
 echo "=== Loading Driver ==="
-sudo insmod ./amd_emrdma.ko || {
+sudo insmod ./rocm_ernic.ko || {
     echo "Failed to load driver"
     sudo dmesg | tail -30
     exit 1
@@ -256,11 +256,11 @@ sudo insmod ./amd_emrdma.ko || {
 
 echo ""
 echo "=== Verifying Driver Loaded ==="
-lsmod | grep amd_emrdma
+lsmod | grep rocm_ernic
 
 echo ""
 echo "=== Kernel Messages ==="
-sudo dmesg | grep -i "amd_emrdma" | tail -20 || echo "No amd_emrdma messages"
+sudo dmesg | grep -i "rocm_ernic" | tail -20 || echo "No rocm_ernic messages"
 
 echo ""
 echo "=== RDMA Devices ==="
@@ -268,7 +268,7 @@ ibv_devices || echo "No RDMA devices found"
 
 echo ""
 echo "=== Device Info ==="
-# Check for device (driver name is amd_emrdma, device name is rocep*)
+# Check for device (driver name is rocm_ernic, device name is rocep*)
 if ibv_devices | tail -n +3 | grep -q -E "rocep|mlx|qedr|rxe"; then
     DEVICE_NAME=$(ibv_devices | tail -n +3 | grep -v "^$" | head -1 | awk '{print $1}')
     echo "Found RDMA device: $DEVICE_NAME"

--- a/src/rocm_ernic_server.c
+++ b/src/rocm_ernic_server.c
@@ -35,9 +35,9 @@
 #include "rocm_ernic_internal.h"
 #include "rocm_ernic_compat.h"
 
-/* AMD Emulated RDMA device IDs (for vfio-user) */
+/* AMD ROCm ERNIC device IDs (for vfio-user) */
 #define PCI_VENDOR_ID_AMD        0x1022
-#define PCI_DEVICE_ID_AMD_EMRDMA 0x1484
+#define PCI_DEVICE_ID_ROCM_ERNIC 0x1484
 
 /* PCI Class Codes (from linux/pci_ids.h) */
 #define PCI_BASE_CLASS_NETWORK 0x02
@@ -317,9 +317,9 @@ static int setup_pci_config(vfu_ctx_t *vfu_ctx, rocm_ernic_dev_t *dev)
 
     /* Set vendor/device IDs */
     vfu_pci_set_id(vfu_ctx, PCI_VENDOR_ID_AMD, /* Vendor ID */
-                   PCI_DEVICE_ID_AMD_EMRDMA,   /* Device ID */
+                   PCI_DEVICE_ID_ROCM_ERNIC,   /* Device ID */
                    PCI_VENDOR_ID_AMD,          /* Subsystem Vendor ID */
-                   PCI_DEVICE_ID_AMD_EMRDMA);  /* Subsystem ID */
+                   PCI_DEVICE_ID_ROCM_ERNIC);  /* Subsystem ID */
 
     /* Set PCI class code: Network Controller - Other */
     vfu_pci_set_class(vfu_ctx, PCI_BASE_CLASS_NETWORK, /* Base class */
@@ -327,7 +327,7 @@ static int setup_pci_config(vfu_ctx_t *vfu_ctx, rocm_ernic_dev_t *dev)
                       0x00); /* Programming interface */
 
     vfu_log(vfu_ctx, LOG_INFO, "PCI device configured: vendor=%#x device=%#x",
-            PCI_VENDOR_ID_AMD, PCI_DEVICE_ID_AMD_EMRDMA);
+            PCI_VENDOR_ID_AMD, PCI_DEVICE_ID_ROCM_ERNIC);
 
     return 0;
 }


### PR DESCRIPTION
This commit completes the renaming of the driver from AMD_EMRDMA to ROCM_ERNIC across all source files, build system, CI workflows, and documentation.

Driver Changes:
- Kconfig: INFINIBAND_AMD_EMRDMA → INFINIBAND_ROCM_ERNIC
- Makefile: Module name amd_emrdma → rocm_ernic
- All driver source files: Updated constants, structs, and functions
  - AMD_EMRDMA_* → ROCM_ERNIC_*
  - amd_emrdma_* → rocm_ernic_*
- Module init/exit: rocm_ernic_init(), rocm_ernic_cleanup()
- DRV_NAME: "rocm_ernic"
- Module file: amd_emrdma.ko → rocm_ernic.ko

Server Changes:
- PCI device ID: PCI_DEVICE_ID_AMD_EMRDMA → PCI_DEVICE_ID_ROCM_ERNIC
- Updated all PCI device ID references in server code

CI Workflow Updates:
- integration-test.yml: Updated module name references
- driver-build.yml: Updated build verification and artifact names

Documentation Updates:
- README.md: Updated PCI device IDs (15ad:0820 → 1022:1484)
- README.md: Updated driver loading instructions
- driver/README.md: Updated module name references

Script Updates:
- scripts/local-vm-test.sh: Updated module name references

This refactoring ensures consistent naming throughout the codebase, aligning with the ROCm ERNIC project branding. The driver module name change requires users to update their modprobe/insmod commands from 'amd_emrdma' to 'rocm_ernic'.

Breaking Change: Module name changed from amd_emrdma.ko to rocm_ernic.ko

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
