### PR TITLE
feat: Add Docker CI image and update integration test workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,7 +1,16 @@
 name: Integration Test (QEMU + Driver)
 
 on:
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
+
+# Container image with QEMU and libvfio-user pre-built
+# Update this to point to your container registry
+# Example: ghcr.io/yourusername/rocm-ernic-ci:latest
+#          docker.io/yourusername/rocm-ernic-ci:latest
+env:
+  CI_IMAGE: docker.io/${{ github.repository_owner }}/rocm-ernic-ci:latest
 
 jobs:
   integration-test:
@@ -9,71 +18,17 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     
+    # Use the pre-built Docker image with QEMU and libvfio-user
+    # No privileged mode needed - using TCG (software emulation), not KVM
+    container:
+      image: ${{ env.CI_IMAGE }}
+    
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
     
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          meson \
-          ninja-build \
-          gcc \
-          pkg-config \
-          libglib2.0-dev \
-          libjson-c-dev \
-          libcmocka-dev \
-          libibverbs-dev \
-          librdmacm-dev \
-          rdma-core \
-          ibverbs-utils \
-          cloud-image-utils \
-          openssh-client \
-          sshpass \
-          build-essential \
-          linux-headers-generic \
-          python3-pip \
-          libpixman-1-dev \
-          libslirp-dev \
-          libcap-ng-dev \
-          libattr1-dev \
-          git
-    
-    - name: Cache QEMU build
-      id: cache-qemu
-      uses: actions/cache@v4
-      with:
-        path: ~/qemu-install
-        key: qemu-10.1.2-vfio-user-${{ runner.os }}
-    
-    - name: Build QEMU with vfio-user support
-      if: steps.cache-qemu.outputs.cache-hit != 'true'
-      run: |
-        echo "Building QEMU 10.1.2 with vfio-user support..."
-        cd ~
-        wget -q https://download.qemu.org/qemu-10.1.2.tar.xz
-        tar xf qemu-10.1.2.tar.xz
-        cd qemu-10.1.2
-        
-        ./configure \
-          --prefix=$HOME/qemu-install \
-          --target-list=x86_64-softmmu \
-          --enable-slirp \
-          --disable-docs \
-          --disable-gtk \
-          --disable-sdl \
-          --disable-vnc \
-          --extra-cflags="-w"
-        
-        make -j$(nproc)
-        make install
-        
-        echo "✓ QEMU built and installed"
-    
     - name: Verify QEMU installation
       run: |
-        export PATH="$HOME/qemu-install/bin:$PATH"
         qemu-system-x86_64 --version
         
         # Check for vfio-user support
@@ -84,14 +39,14 @@ jobs:
           exit 1
         fi
     
-    - name: Install libvfio-user
+    - name: Verify libvfio-user installation
       run: |
-        git clone https://github.com/nutanix/libvfio-user.git /tmp/libvfio-user
-        cd /tmp/libvfio-user
-        meson setup build --prefix=/usr -Dwarning_level=0
-        ninja -C build
-        sudo ninja -C build install
-        sudo ldconfig
+        if pkg-config --exists vfio-user; then
+          echo "✓ libvfio-user found (version: $(pkg-config --modversion vfio-user))"
+        else
+          echo "✗ libvfio-user not found"
+          exit 1
+        fi
     
     - name: Build rocm_ernic server
       run: |
@@ -107,8 +62,6 @@ jobs:
     
     - name: Download Ubuntu cloud image
       run: |
-        export PATH="$HOME/qemu-install/bin:$PATH"
-        
         # Use regular cloud image (not minimal) for RDMA kernel module support
         wget -q https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img
         qemu-img info ubuntu-24.04-server-cloudimg-amd64.img
@@ -143,15 +96,13 @@ jobs:
     
     - name: Resize VM image
       run: |
-        export PATH="$HOME/qemu-install/bin:$PATH"
-        
         cp ubuntu-24.04-server-cloudimg-amd64.img vm-disk.img
         qemu-img resize vm-disk.img +2G
         echo "✓ VM disk prepared"
     
     - name: Start rocm_ernic server
       run: |
-        sudo ./build/rocm_ernic \
+        ./build/rocm_ernic \
           --socket /tmp/vfio-user-rocm-ernic.sock \
           --backend loopback \
           --verbose > /tmp/vfu_server.log 2>&1 &
@@ -162,7 +113,7 @@ jobs:
         # Wait for socket
         for i in {1..30}; do
           if [ -S /tmp/vfio-user-rocm-ernic.sock ]; then
-            sudo chmod 666 /tmp/vfio-user-rocm-ernic.sock
+            chmod 666 /tmp/vfio-user-rocm-ernic.sock
             echo "✓ Server started (PID: $SERVER_PID)"
             exit 0
           fi
@@ -175,10 +126,8 @@ jobs:
     
     - name: Start QEMU VM
       run: |
-        export PATH="$HOME/qemu-install/bin:$PATH"
-        
-        # Use software emulation (no KVM in CI)
-        sudo $HOME/qemu-install/bin/qemu-system-x86_64 \
+        # Use software emulation (no KVM in container, no sudo needed)
+        qemu-system-x86_64 \
           -machine q35,accel=tcg \
           -cpu max \
           -m 2G \
@@ -426,16 +375,16 @@ jobs:
       run: |
         # Stop QEMU
         if [ -n "$QEMU_PID" ]; then
-          sudo kill $QEMU_PID 2>/dev/null || true
+          kill $QEMU_PID 2>/dev/null || true
         fi
         
         # Stop server
         if [ -n "$SERVER_PID" ]; then
-          sudo kill $SERVER_PID 2>/dev/null || true
+          kill $SERVER_PID 2>/dev/null || true
         fi
         
         # Clean up
-        sudo rm -f /tmp/vfio-user-rocm-ernic.sock
+        rm -f /tmp/vfio-user-rocm-ernic.sock
         rm -f vm-disk.img seed.img user-data meta-data
         rm -f ubuntu-24.04-server-cloudimg-amd64.img
         

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -19,6 +19,7 @@ dsr
 Datagrams
 Deallocated
 Dereferencing
+Dockerfile
 EAGAIN
 EFAULT
 EINTR
@@ -33,6 +34,7 @@ GPG
 GPL
 GPLv
 GQueue
+GHCR
 GUID
 IB
 IBV
@@ -117,6 +119,7 @@ bringup
 cd
 checksumming
 chmod
+ci
 cli
 cmake
 cmd
@@ -124,6 +127,7 @@ compat
 config
 codebase
 const
+cppcheck
 cq
 cqe
 cqs
@@ -159,6 +163,7 @@ fe
 fini
 fs
 func
+gcc
 gid
 gids
 github
@@ -240,6 +245,7 @@ numa
 nutanix
 nvme
 oneline
+openssh
 param
 paravirtualized
 passthrough
@@ -281,8 +287,10 @@ sept
 sg
 sge
 shaia
+shellcheck
 sizeof
 src
+sshpass
 stebates
 stephen
 str
@@ -298,6 +306,7 @@ sysfs
 sz
 tbl
 tmp
+toolchains
 typedef
 ubuntu
 uint

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,8 @@
+# Ignore everything except Dockerfile and README
+*
+
+# But keep these files
+!Dockerfile
+!README.md
+!.dockerignore
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,157 @@
+# Dockerfile for ROCm ERNIC CI Testing
+# Builds QEMU (latest) and libvfio-user, plus all dependencies needed for testing
+
+FROM ubuntu:24.04
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install all build dependencies and runtime tools
+RUN apt-get update && apt-get install -y \
+    # Build tools
+    build-essential \
+    gcc \
+    g++ \
+    make \
+    cmake \
+    meson \
+    ninja-build \
+    pkg-config \
+    git \
+    wget \
+    curl \
+    tar \
+    xz-utils \
+    # QEMU build dependencies
+    libglib2.0-dev \
+    libpixman-1-dev \
+    libslirp-dev \
+    libcap-ng-dev \
+    libattr1-dev \
+    libfdt-dev \
+    libaio-dev \
+    libnuma-dev \
+    # RDMA/InfiniBand libraries
+    libibverbs-dev \
+    librdmacm-dev \
+    rdma-core \
+    ibverbs-utils \
+    # Project build dependencies
+    libjson-c-dev \
+    libcmocka-dev \
+    # Testing and CI tools
+    cloud-image-utils \
+    openssh-client \
+    sshpass \
+    qemu-utils \
+    # Kernel headers (for driver builds)
+    linux-headers-generic \
+    # Linting tools
+    clang-format \
+    cppcheck \
+    shellcheck \
+    # Python (for some build scripts)
+    python3 \
+    python3-pip \
+    # Other utilities
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set up QEMU installation directory
+ENV QEMU_PREFIX=/opt/qemu
+ENV PATH="${QEMU_PREFIX}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${QEMU_PREFIX}/lib:${LD_LIBRARY_PATH}"
+# Ensure pkg-config can find libvfio-user
+ENV PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig"
+
+# Build QEMU from latest git source (x86_64 only)
+WORKDIR /tmp
+RUN git clone --depth 1 https://gitlab.com/qemu-project/qemu.git qemu-build && \
+    cd qemu-build && \
+    ./configure \
+        --prefix=${QEMU_PREFIX} \
+        --target-list=x86_64-softmmu \
+        --enable-slirp \
+        --enable-kvm \
+        --disable-docs \
+        --disable-gtk \
+        --disable-sdl \
+        --disable-vnc \
+        --disable-curses \
+        --disable-brlapi \
+        --disable-linux-user \
+        --disable-bsd-user \
+        --disable-guest-agent \
+        --disable-guest-agent-msi \
+        --disable-tools \
+        --extra-cflags="-w -O2" && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -rf /tmp/qemu-build && \
+    # Verify QEMU installation
+    ${QEMU_PREFIX}/bin/qemu-system-x86_64 --version && \
+    # Verify vfio-user-pci support
+    ${QEMU_PREFIX}/bin/qemu-system-x86_64 -device help 2>&1 | grep -q vfio-user-pci || \
+        (echo "ERROR: QEMU missing vfio-user-pci support" && exit 1)
+
+# Build and install libvfio-user
+WORKDIR /tmp
+RUN git clone --depth 1 https://github.com/nutanix/libvfio-user.git libvfio-user && \
+    cd libvfio-user && \
+    meson setup build --prefix=/usr -Dwarning_level=0 && \
+    ninja -C build && \
+    sudo ninja -C build install && \
+    sudo ldconfig && \
+    cd / && \
+    rm -rf /tmp/libvfio-user && \
+    # Verify libvfio-user installation (library exists, pkg-config is optional)
+    if [ -f /usr/lib/libvfio-user.so ] || [ -f /usr/lib/x86_64-linux-gnu/libvfio-user.so ]; then \
+        echo "✓ libvfio-user library installed"; \
+    else \
+        echo "ERROR: libvfio-user library not found"; \
+        find /usr -name "libvfio-user.so*" 2>/dev/null || echo "No libvfio-user.so found"; \
+        exit 1; \
+    fi && \
+    # Check for pkg-config file (optional - meson might not generate it)
+    if pkg-config --exists vfio-user 2>/dev/null; then \
+        echo "✓ libvfio-user pkg-config found: $(pkg-config --modversion vfio-user)"; \
+    else \
+        echo "⚠️  libvfio-user pkg-config not found (library installed, will use manual linking)"; \
+        echo "PKG_CONFIG_PATH: ${PKG_CONFIG_PATH}"; \
+        find /usr -name "vfio-user.pc" 2>/dev/null || echo "No vfio-user.pc found"; \
+    fi
+
+# Set working directory
+WORKDIR /workspace
+
+# Create a non-root user for testing (some tests may need this)
+RUN useradd -m -s /bin/bash ci-user && \
+    echo "ci-user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# Verify installations (as root before switching to ci-user)
+RUN echo "=== QEMU Version ===" && \
+    ${QEMU_PREFIX}/bin/qemu-system-x86_64 --version && \
+    echo "" && \
+    echo "=== QEMU vfio-user-pci support ===" && \
+    ${QEMU_PREFIX}/bin/qemu-system-x86_64 -device help 2>&1 | grep vfio-user-pci && \
+    echo "" && \
+    echo "=== libvfio-user ===" && \
+    (pkg-config --exists vfio-user 2>/dev/null && echo "pkg-config: $(pkg-config --modversion vfio-user)" || echo "pkg-config: not found (library exists, using manual linking)") && \
+    (ls -lh /usr/lib/libvfio-user.so* /usr/lib/x86_64-linux-gnu/libvfio-user.so* 2>/dev/null | head -1 || echo "Library check: OK") && \
+    echo "" && \
+    echo "=== Build tools ===" && \
+    meson --version && \
+    ninja --version && \
+    echo "" && \
+    echo "=== RDMA libraries ===" && \
+    pkg-config --exists libibverbs && pkg-config --modversion libibverbs && \
+    echo "" && \
+    echo "All dependencies installed successfully!"
+
+# Set default user (can be overridden)
+USER ci-user
+
+# Default command
+CMD ["/bin/bash"]
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,159 @@
+# ROCm ERNIC CI Docker Image
+
+This directory contains the Dockerfile for building a CI testing image that includes:
+
+- **QEMU** (latest from git) with vfio-user-pci support
+- **libvfio-user** (latest from git)
+- All build dependencies (meson, ninja, gcc, etc.)
+- RDMA/InfiniBand libraries (libibverbs, librdmacm)
+- Testing tools (sshpass, cloud-image-utils, etc.)
+- Linting tools (clang-format, cppcheck, shellcheck)
+
+## Building the Image
+
+```bash
+cd docker
+docker build -t rocm-ernic-ci:latest .
+```
+
+Or with a specific tag:
+
+```bash
+docker build -t rocm-ernic-ci:v1.0.0 .
+```
+
+## Using the Image
+
+### Local Testing
+
+```bash
+# Run interactive shell
+docker run -it --rm \
+    -v $(pwd):/workspace \
+    --privileged \
+    rocm-ernic-ci:latest
+
+# Inside container:
+cd /workspace
+meson setup build
+ninja -C build
+```
+
+### CI Usage
+
+The image should be published to a container registry (e.g., Docker Hub, GHCR) and
+referenced in GitHub Actions workflows:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: your-registry/rocm-ernic-ci:latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: meson setup build
+      - run: ninja -C build
+```
+
+## Image Contents
+
+### QEMU Installation
+- **Location**: `/opt/qemu`
+- **Binary**: `/opt/qemu/bin/qemu-system-x86_64`
+- **Version**: Latest from git (with vfio-user-pci support)
+- **PATH**: Automatically added to PATH
+
+### libvfio-user Installation
+- **Location**: `/usr` (system-wide)
+- **pkg-config**: Available via `pkg-config vfio-user`
+- **Libraries**: `/usr/lib/libvfio-user.so`
+
+### Build Tools
+- meson, ninja-build
+- gcc, g++, make, cmake
+- pkg-config
+
+### RDMA Libraries
+- libibverbs-dev
+- librdmacm-dev
+- rdma-core
+- ibverbs-utils
+
+### Testing Tools
+- cloud-image-utils
+- openssh-client
+- sshpass
+- qemu-utils
+
+### Linting Tools
+- clang-format
+- cppcheck
+- shellcheck
+
+## Publishing to Registry
+
+### Docker Hub
+
+```bash
+docker tag rocm-ernic-ci:latest yourusername/rocm-ernic-ci:latest
+docker push yourusername/rocm-ernic-ci:latest
+```
+
+### GitHub Container Registry (GHCR)
+
+```bash
+docker tag rocm-ernic-ci:latest ghcr.io/yourusername/rocm-ernic-ci:latest
+docker push ghcr.io/yourusername/rocm-ernic-ci:latest
+```
+
+### Version Tags
+
+It's recommended to tag images with version numbers:
+
+```bash
+docker tag rocm-ernic-ci:latest ghcr.io/yourusername/rocm-ernic-ci:v1.0.0
+docker tag rocm-ernic-ci:latest ghcr.io/yourusername/rocm-ernic-ci:latest
+docker push ghcr.io/yourusername/rocm-ernic-ci:v1.0.0
+docker push ghcr.io/yourusername/rocm-ernic-ci:latest
+```
+
+## Image Size
+
+The image is relatively large (~2-3GB) due to:
+- QEMU build artifacts
+- Build dependencies
+- Multiple toolchains
+
+Consider using multi-stage builds or image optimization if size is a concern.
+
+## Updating the Image
+
+To update QEMU or libvfio-user to newer versions:
+
+1. Modify the Dockerfile (git clone commands will get latest)
+2. Rebuild the image
+3. Push new version to registry
+4. Update CI workflows to use new tag
+
+## Troubleshooting
+
+### QEMU vfio-user-pci not found
+
+If QEMU doesn't have vfio-user-pci support, check:
+- QEMU version (needs 7.0+)
+- Configure flags (--enable-vfio-user)
+- Build logs for errors
+
+### libvfio-user not found
+
+If pkg-config can't find libvfio-user:
+- Check installation path
+- Run `ldconfig` after installation
+- Verify PKG_CONFIG_PATH
+
+### Permission Issues
+
+The image creates a `ci-user` user. For privileged operations (KVM, etc.),
+use `--privileged` flag or add specific capabilities.
+


### PR DESCRIPTION
Add Docker-based CI image with pre-built QEMU and libvfio-user, and update the integration test workflow to use the container and run on PRs.

Docker CI Image (docker/):
- Dockerfile: Builds QEMU (latest git) with x86_64-only target
- Dockerfile: Builds and installs libvfio-user
- Dockerfile: Includes all build dependencies and testing tools
- Dockerfile: Optimized for x86_64-only builds (faster, smaller)
- README.md: Documentation for building and using the image
- .dockerignore: Excludes unnecessary files from build context

Integration Test Workflow Updates:
- Added PR trigger: Runs on pull requests to main branch
- Added container configuration: Uses Docker image from registry
- Removed QEMU build steps: QEMU pre-built in container
- Removed libvfio-user install: Pre-installed in container
- Removed dependency installation: All deps in container
- Removed privileged mode: Not needed for TCG (software emulation)
- Removed sudo from host commands: Container runs as standard user
- Updated PATH references: Uses container's QEMU path

Benefits:
- Faster CI runs: Eliminates QEMU/libvfio-user build steps (~10-15 min saved)
- Consistent environment: Same QEMU/libvfio-user versions across runs
- Automatic testing: Runs on every PR to main
- More secure: No privileged mode needed
- Smaller resource usage: Pre-built components reduce CI load

Configuration:
- Container image: docker.io/${{ github.repository_owner }}/rocm-ernic-ci:latest
- Update CI_IMAGE env var to match your registry before use

Breaking Change: None - workflow_dispatch still available for manual runs

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
