### PR TITLE
ci: remove cppcheck from lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,39 +53,6 @@ jobs:
 
           echo "✅ All files are properly formatted!"
 
-  cppcheck:
-    name: cppcheck
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Install cppcheck
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cppcheck
-
-      - name: Run cppcheck
-        run: |
-          cppcheck --enable=warning,style,performance,portability \
-            --error-exitcode=1 \
-            --suppress=missingIncludeSystem \
-            --suppress=unusedFunction \
-            --suppress=unmatchedSuppression \
-            --suppress=unknownMacro \
-            --suppress=knownConditionTrueFalse \
-            --suppress=constVariablePointer \
-            --suppress=constParameter \
-            --suppress=variableScope \
-            --suppress=unreadVariable \
-            --suppress=arithOperationsOnVoidPointer \
-            --suppress=invalidPrintfArgType_sint \
-            --suppress=invalidPrintfArgType_uint \
-            -I src/from-qemu/include \
-            -I src \
-            src/rocm_ernic_*.c \
-            tests/*.c
-
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove cppcheck static analysis from CI as it provides minimal value compared to the overhead it adds.

Rationale:
- cppcheck currently finds 0 issues in the codebase
- Only checks 4 files (src/rocm_ernic_*.c and tests/*.c), not comprehensive
- Requires 11 suppressions due to false positives with QEMU code
- Compiler warnings already catch similar issues during build
- Adds ~30-60 seconds to CI runtime without providing actionable feedback

What remains:
- clang-format: Code formatting checks (complementary to cppcheck's style checks, but more focused and actionable)
- shellcheck: Shell script linting
- Compiler warnings: Build-time static analysis via GCC/Clang

This simplifies the CI pipeline while maintaining code quality checks through formatting and compiler warnings.
