### PR TITLE
docs: add Sphinx + Breathe + Doxygen documentation pipeline

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,49 @@
+name: docs-check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'src/**/*.h'
+      - 'driver/**/*.h'
+      - 'README.md'
+      - 'requirements.txt'
+      - '.github/workflows/docs-check.yml'
+
+jobs:
+  sphinx:
+    name: sphinx-build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake doxygen
+
+    - name: Configure docs-only build
+      run: |
+        cmake -S . -B build \
+          -DERNIC_DOCS_ONLY=ON \
+          -DERNIC_BUILD_DOCS=ON
+
+    - name: Build documentation
+      run: cmake --build build --target sphinx-html
+
+  rst-lint:
+    name: rst-lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Install doc8
+      run: pip install doc8
+
+    - name: Lint RST files
+      run: doc8 docs/ --max-line-length 80

--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,6 @@ modules.order
 Module.symvers
 .cursor/
 setup-docs/
-docs/
 setup-scripts/
 
 # Ignore nohup.out

--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -17,3 +17,17 @@ matrix:
   - '**/*.md'
   default_encoding: utf-8
 
+- name: reStructuredText
+  aspell:
+    lang: en
+  sources:
+  - 'docs/**/*.rst'
+  pipeline:
+  - pyspelling.filters.text
+  dictionary:
+    wordlists:
+    - .wordlist.txt
+    output: wordlist.dic
+    encoding: utf-8
+  default_encoding: utf-8
+

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -7,6 +7,7 @@ Async
 BARs
 Backend
 Backends
+Breathe
 CMake
 CONFIG
 CTest
@@ -26,6 +27,7 @@ Deallocated
 Dereferencing
 DCMAKE
 Dockerfile
+Doxygen
 EAGAIN
 EFAULT
 EINTR
@@ -80,6 +82,7 @@ RDMA
 README
 ROCm
 RTR
+RST
 RTS
 RdmaBackendDev
 RdmaBackendLoopback
@@ -98,6 +101,7 @@ SPDK
 SRQ
 SRQs
 Shaia
+Sphinx
 TCP
 TODO
 TSAN
@@ -132,6 +136,7 @@ attrs
 backend
 backends
 bool
+breathe
 bringup
 cd
 checksumming
@@ -144,6 +149,7 @@ ctest
 cmd
 codebase
 compat
+conf
 config
 const
 cppcheck
@@ -163,6 +169,10 @@ dir
 dma
 dmesg
 doorbell
+doorbells
+doxyfile
+doxygen
+doxygenfile
 dsr
 elmail
 emrdma
@@ -240,6 +250,7 @@ lsmod
 lspci
 malloc
 marcel
+maxdepth
 md
 memfd
 memset
@@ -317,6 +328,7 @@ sge
 shaia
 shellcheck
 sizeof
+sphinx
 src
 sshpass
 stdin
@@ -335,6 +347,7 @@ sysfs
 sz
 tbl
 tcp
+toctree
 txt
 tmp
 toolchains

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,17 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
 # Add cmake/ to the module search path
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
+# Docs-only mode: build documentation without requiring
+# libvfio-user, glib, or libibverbs.
+option(ERNIC_DOCS_ONLY
+  "Only configure documentation targets"
+  OFF)
+
+if(ERNIC_DOCS_ONLY)
+    include(ErnicDocumentation)
+    return()
+endif()
+
 # Enable CTest (automatically calls enable_testing())
 include(CTest)
 
@@ -228,6 +239,11 @@ add_subdirectory(tests)
 include(ErnicInstall)
 
 # ---------------------------------------------------------------
+# Documentation (optional, requires -DERNIC_BUILD_DOCS=ON)
+# ---------------------------------------------------------------
+include(ErnicDocumentation)
+
+# ---------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------
 message("")
@@ -253,4 +269,7 @@ message("")
 message("  Sanitizers:")
 message("    ASAN/LSAN/UBSAN : ${ERNIC_USE_SANITIZERS}")
 message("    TSAN            : ${ERNIC_USE_THREAD_SANITIZER}")
+message("")
+message("  Documentation:")
+message("    Build docs : ${ERNIC_BUILD_DOCS}")
 message("")

--- a/cmake/ErnicDocumentation.cmake
+++ b/cmake/ErnicDocumentation.cmake
@@ -1,0 +1,109 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# ErnicDocumentation.cmake
+# Sphinx + Breathe + Doxygen documentation pipeline
+# (following ROCm best practices)
+#
+# A Python venv is created automatically in the build tree
+# and populated from requirements.txt.
+
+option(ERNIC_BUILD_DOCS
+  "Build documentation with Sphinx + Breathe + Doxygen"
+  OFF)
+
+if(ERNIC_BUILD_DOCS)
+    find_package(Doxygen REQUIRED)
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+    # ── Python venv with Sphinx + Breathe ──────────────
+    set(ERNIC_DOCS_VENV "${CMAKE_BINARY_DIR}/docs-venv")
+    set(ERNIC_DOCS_VENV_STAMP
+      "${ERNIC_DOCS_VENV}/stamp")
+    set(ERNIC_DOCS_REQUIREMENTS
+      "${CMAKE_SOURCE_DIR}/requirements.txt")
+
+    if(WIN32)
+        set(ERNIC_VENV_BIN
+          "${ERNIC_DOCS_VENV}/Scripts")
+    else()
+        set(ERNIC_VENV_BIN
+          "${ERNIC_DOCS_VENV}/bin")
+    endif()
+
+    set(SPHINX_BUILD "${ERNIC_VENV_BIN}/sphinx-build")
+
+    add_custom_command(
+      OUTPUT ${ERNIC_DOCS_VENV_STAMP}
+      COMMAND ${Python3_EXECUTABLE} -m venv
+        ${ERNIC_DOCS_VENV}
+      COMMAND ${ERNIC_VENV_BIN}/pip install
+        --quiet --upgrade pip
+      COMMAND ${ERNIC_VENV_BIN}/pip install
+        --quiet -r ${ERNIC_DOCS_REQUIREMENTS}
+      COMMAND ${CMAKE_COMMAND} -E touch
+        ${ERNIC_DOCS_VENV_STAMP}
+      DEPENDS ${ERNIC_DOCS_REQUIREMENTS}
+      COMMENT "Creating docs venv and installing deps"
+      VERBATIM
+    )
+
+    add_custom_target(docs-venv
+      DEPENDS ${ERNIC_DOCS_VENV_STAMP}
+      COMMENT "Ensure docs Python venv is up to date"
+    )
+
+    # ── Paths ──────────────────────────────────────────
+    set(ERNIC_DOC_PATH "${CMAKE_BINARY_DIR}/docs")
+    set(BREATHE_DOC_XML_DIR
+      "${ERNIC_DOC_PATH}/xml")
+
+    set(ERNIC_DOXYFILE_INPUT
+      "${CMAKE_SOURCE_DIR}/src/rocm_ernic_internal.h \
+       ${CMAKE_SOURCE_DIR}/src/rocm_ernic_compat.h \
+       ${CMAKE_SOURCE_DIR}/src/rocm_ernic_eth.h \
+       ${CMAKE_SOURCE_DIR}/driver/rocm_ernic_dev_api.h \
+       ${CMAKE_SOURCE_DIR}/driver/rocm_ernic-abi.h \
+       ${CMAKE_SOURCE_DIR}/driver/rocm_ernic_verbs.h \
+       ${CMAKE_SOURCE_DIR}/driver/rocm_ernic_pci_ids.h \
+       ${CMAKE_SOURCE_DIR}/driver/rocm_ernic.h \
+       ${CMAKE_SOURCE_DIR}/driver/rocm_ernic_ring.h"
+    )
+
+    # Configure Doxyfile (substitutes @VARIABLES@)
+    configure_file(
+      ${CMAKE_SOURCE_DIR}/docs/Doxyfile.in
+      ${CMAKE_BINARY_DIR}/Doxyfile
+      @ONLY
+    )
+
+    # Configure conf.py (substitutes Breathe XML path)
+    configure_file(
+      ${CMAKE_SOURCE_DIR}/docs/conf.py
+      ${CMAKE_BINARY_DIR}/docs-sphinx/conf.py
+      @ONLY
+    )
+
+    # ── Doxygen target: source headers -> XML ──────────
+    add_custom_target(doxygen
+      COMMAND ${DOXYGEN_EXECUTABLE}
+        ${CMAKE_BINARY_DIR}/Doxyfile
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      COMMENT "Generating Doxygen XML"
+      VERBATIM
+    )
+
+    # ── Sphinx target: RST + Doxygen XML -> HTML ───────
+    add_custom_target(sphinx-html
+      COMMAND ${SPHINX_BUILD}
+        -b html
+        -c ${CMAKE_BINARY_DIR}/docs-sphinx
+        ${CMAKE_SOURCE_DIR}/docs
+        ${ERNIC_DOC_PATH}/html
+      DEPENDS doxygen docs-venv
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      COMMENT "Building Sphinx HTML documentation"
+      VERBATIM
+    )
+endif()

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,0 +1,63 @@
+# Doxyfile for rocm-ernic
+# Generated from docs/Doxyfile.in by CMake
+#
+# Doxygen generates XML consumed by Breathe; Sphinx
+# produces the final HTML output.
+
+PROJECT_NAME           = "@PROJECT_NAME@"
+PROJECT_NUMBER         = "@PROJECT_VERSION@"
+PROJECT_BRIEF          = "Emulated RDMA NIC for Virtual Machines"
+
+OUTPUT_DIRECTORY       = @ERNIC_DOC_PATH@
+INPUT                  = @ERNIC_DOXYFILE_INPUT@
+RECURSIVE              = YES
+FILE_PATTERNS          = *.h
+
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = YES
+
+# Exclude QEMU-derived code (not our public API)
+EXCLUDE_PATTERNS       = */from-qemu/*
+
+# XML output for Breathe (Sphinx integration)
+GENERATE_HTML          = NO
+GENERATE_LATEX         = NO
+GENERATE_XML           = YES
+XML_OUTPUT             = xml
+XML_PROGRAMLISTING     = YES
+
+# Warning settings
+QUIET                  = YES
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = NO
+WARN_IF_DOC_ERROR      = YES
+# Kernel driver headers use Linux kernel-doc style
+# (@param_name) which Doxygen treats as unknown commands.
+# Disable fatal warnings to tolerate both conventions.
+WARN_AS_ERROR          = NO
+WARN_NO_PARAMDOC       = NO
+
+# C-only project
+OPTIMIZE_OUTPUT_FOR_C  = YES
+
+# Preprocessing
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+PREDEFINED             = __attribute__(x)=
+
+# Source browsing (available via Breathe)
+SOURCE_BROWSER         = YES
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+
+# Diagrams
+HAVE_DOT               = NO
+
+# Sorting
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = YES
+
+# Miscellaneous
+TYPEDEF_HIDES_STRUCT   = NO
+SHOW_INCLUDE_FILES     = YES

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,46 @@
+API Reference
+=============
+
+This page documents the rocm-ernic C API, extracted from
+annotated source headers by Doxygen and rendered via Breathe.
+
+Userspace Server API
+--------------------
+
+Device Structure
+^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: rocm_ernic_internal.h
+
+Compatibility Bridge
+^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: rocm_ernic_compat.h
+
+Ethernet Registers (Userspace)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: src/rocm_ernic_eth.h
+
+Kernel Driver API
+-----------------
+
+Device API
+^^^^^^^^^^
+
+.. doxygenfile:: rocm_ernic_dev_api.h
+
+ABI Definitions
+^^^^^^^^^^^^^^^
+
+.. doxygenfile:: rocm_ernic-abi.h
+
+Verbs Structures
+^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: rocm_ernic_verbs.h
+
+PCI Identifiers
+^^^^^^^^^^^^^^^
+
+.. doxygenfile:: rocm_ernic_pci_ids.h

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,0 +1,127 @@
+Architecture
+============
+
+rocm-ernic emulates a complete PCIe RDMA device in userspace
+using the VFIO-User protocol. A companion kernel driver inside
+the guest VM communicates with the emulated device, providing
+standard InfiniBand verbs to applications.
+
+High-Level Overview
+-------------------
+
+::
+
+  ┌──────────────────────────────────────────────┐
+  │          Virtual Machine (Guest)             │
+  │  ┌────────────────────────────────────┐      │
+  │  │   Linux Kernel rocm_ernic Driver   │      │
+  │  └─────────────┬──────────────────────┘      │
+  │                │ PCI Interface               │
+  └────────────────┼─────────────────────────────┘
+                   │ VFIO-User Protocol
+  ┌────────────────┼─────────────────────────────┐
+  │                ▼                             │
+  │  ┌──────────────────────────────────────┐    │
+  │  │    rocm_ernic Server                 │    │
+  │  │  ┌───────────────────────┐           │    │
+  │  │  │  RDMA Device Logic    │           │    │
+  │  │  │  (adapted from QEMU)  │           │    │
+  │  │  └──────────┬────────────┘           │    │
+  │  │    ┌────────┴────────┬──────┐        │    │
+  │  │    ▼                 ▼      ▼        │    │
+  │  │  ┌──────┐  ┌──────────┐  ┌──────┐   │    │
+  │  │  │Loop- │  │ TCP/IP   │  │RDMA/ │   │    │
+  │  │  │back  │  │ Backend  │  │Verbs │   │    │
+  │  │  └──────┘  └────┬─────┘  └──┬───┘   │    │
+  │  └─────────────────┼───────────┼────────┘    │
+  │                    │           │             │
+  │         ┌──────────┘           │             │
+  │         ▼                      ▼             │
+  │  ┌──────────────┐    ┌──────────────┐        │
+  │  │Another       │    │  libibverbs  │        │
+  │  │rocm_ernic    │    └──────┬───────┘        │
+  │  │Server        │           ▼                │
+  │  └──────────────┘    ┌──────────────┐        │
+  │                      │ InfiniBand   │        │
+  │                      │ Hardware     │        │
+  │                      └──────────────┘        │
+  └──────────────────────────────────────────────┘
+
+Components
+----------
+
+Server (``rocm_ernic_server.c``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The main entry point. It creates the libvfio-user context,
+sets up the three PCI BARs, registers MSI-X vectors, and
+enters the server loop waiting for a QEMU client to connect.
+
+Compatibility Bridge (``rocm_ernic_compat.c``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An isolation layer between the QEMU-derived RDMA device logic
+and the libvfio-user transport. The bridge exposes a clean
+C API (``pvrdma_device_create``, ``pvrdma_regs_write``, etc.)
+so that the server never includes QEMU headers directly.
+
+RDMA Device Logic (``src/from-qemu/``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Adapted from the QEMU PVRDMA device implementation. This code
+handles the command ring, doorbell processing, queue-pair
+management, and completion-queue posting. It is intentionally
+kept close to the upstream QEMU source to simplify future
+synchronization.
+
+PCI BARs
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 25 65
+
+   * - BAR
+     - Size
+     - Purpose
+   * - BAR 0
+     - 16 KB
+     - MSI-X table and Pending Bit Array (PBA)
+   * - BAR 1
+     - 256 B (64 DWORDs)
+     - Device registers (version, DSR, control,
+       interrupt cause/mask, MAC address, Ethernet)
+   * - BAR 2
+     - 2 MB (512 x 4 KB pages)
+     - User Access Region (UAR) doorbells
+
+Backends
+--------
+
+Loopback
+^^^^^^^^
+
+In-memory emulation with no external dependencies. Send and
+receive operations complete immediately within the same
+process. Ideal for driver development and CI testing.
+
+TCP/IP
+^^^^^^
+
+Connects two rocm-ernic server instances over a TCP socket.
+The protocol serializes RDMA work requests and completions
+across the network. Useful for multi-VM testing without
+RDMA hardware.
+
+RDMA / Verbs
+^^^^^^^^^^^^^
+
+Forwards operations to a real InfiniBand HCA via libibverbs.
+Requires an RDMA-capable NIC on the host (for example,
+``mlx5_0``).
+
+None
+^^^^
+
+Minimal stubs that accept but do not process work requests.
+Suitable for PCI enumeration and basic driver bring-up tests.

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -1,0 +1,97 @@
+Building and Installing
+=======================
+
+Dependencies
+------------
+
+Install the required packages on Ubuntu/Debian:
+
+.. code-block:: bash
+
+   sudo apt install cmake meson ninja-build pkg-config \
+     libibverbs-dev librdmacm-dev libglib2.0-dev
+
+Build and install ``libvfio-user`` if it is not already
+available on your system:
+
+.. code-block:: bash
+
+   cd /path/to/libvfio-user
+   meson setup build --prefix=/usr
+   ninja -C build
+   sudo ninja -C build install
+   sudo ldconfig
+
+Compilation
+-----------
+
+From the project root directory:
+
+.. code-block:: bash
+
+   cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+   cmake --build build
+
+The executable is produced at ``build/rocm-ernic``.
+
+Installation
+------------
+
+.. code-block:: bash
+
+   sudo cmake --install build
+
+By default the binary installs to ``/usr/local/bin/rocm-ernic``.
+Override the destination with ``-DCMAKE_INSTALL_PREFIX=<path>``.
+
+Build Options
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 10 60
+
+   * - Option
+     - Default
+     - Description
+   * - ``CMAKE_BUILD_TYPE``
+     - ``Debug``
+     - Build type (Debug, Release, RelWithDebInfo, etc.)
+   * - ``ERNIC_USE_SANITIZERS``
+     - ``OFF``
+     - Enable ASAN / LSAN / UBSAN
+   * - ``ERNIC_USE_THREAD_SANITIZER``
+     - ``OFF``
+     - Enable TSAN (mutually exclusive with above)
+   * - ``ERNIC_BUILD_DOCS``
+     - ``OFF``
+     - Build Sphinx + Breathe + Doxygen documentation
+   * - ``ERNIC_DOCS_ONLY``
+     - ``OFF``
+     - Configure only documentation targets (no library
+       dependencies required)
+   * - ``CMAKE_INSTALL_PREFIX``
+     - ``/usr/local``
+     - Installation prefix
+
+Building Documentation
+----------------------
+
+Documentation requires Doxygen and Python 3. A Python virtual
+environment is created automatically in the build tree.
+
+.. code-block:: bash
+
+   cmake -B build -G Ninja -DERNIC_BUILD_DOCS=ON
+   cmake --build build --target sphinx-html
+
+The generated HTML is written to ``build/docs/html/``.
+
+To build documentation without needing the project's library
+dependencies (libvfio-user, glib, libibverbs):
+
+.. code-block:: bash
+
+   cmake -B build -DERNIC_DOCS_ONLY=ON \
+     -DERNIC_BUILD_DOCS=ON
+   cmake --build build --target sphinx-html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,54 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+"""Sphinx configuration for rocm-ernic documentation."""
+
+project = "rocm-ernic"
+author = "Advanced Micro Devices, Inc."
+copyright = (
+    "2025-2026 Advanced Micro Devices, Inc. "
+    "All rights reserved."
+)
+
+version = "0.2.0"
+release = version
+
+# -- Extensions --------------------------------------------------
+
+extensions = [
+    "breathe",
+]
+
+# -- Breathe (Doxygen XML import) --------------------------------
+
+breathe_projects = {
+    "rocm-ernic": "@BREATHE_DOC_XML_DIR@",
+}
+breathe_default_project = "rocm-ernic"
+breathe_default_members = ("members",)
+
+# -- General -----------------------------------------------------
+
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+templates_path = []
+
+# Kernel driver headers reuse type names across files and
+# use anonymous unions that Breathe cannot fully parse.
+suppress_warnings = [
+    "cpp.duplicate_declaration",
+    "c.duplicate_declaration",
+]
+
+# -- HTML output -------------------------------------------------
+
+html_theme = "sphinx_book_theme"
+html_theme_options = {
+    "repository_url": (
+        "https://github.com/ROCm/rocm-ernic"
+    ),
+    "use_repository_button": True,
+    "show_toc_level": 2,
+}
+html_title = f"rocm-ernic {version}"
+html_static_path = []

--- a/docs/driver.rst
+++ b/docs/driver.rst
@@ -1,0 +1,82 @@
+Kernel Driver
+=============
+
+The ``rocm_ernic`` Linux kernel module is the guest-side
+companion to the userspace server. It registers an InfiniBand
+device so that standard RDMA applications (libibverbs, librdmacm)
+work inside the virtual machine.
+
+Building the Driver
+-------------------
+
+.. code-block:: bash
+
+   cd driver/
+
+   # Build against the running kernel (KDIR is optional)
+   make -C $KDIR M=$(pwd) modules
+
+   # Install the module (optional)
+   sudo make -C $KDIR M=$(pwd) modules_install
+   sudo depmod -a
+
+Loading the Driver
+------------------
+
+.. code-block:: bash
+
+   sudo modprobe rocm_ernic
+
+   # Verify with dmesg
+   dmesg | grep rocm_ernic
+
+Expected output when the device is detected:
+
+::
+
+   [  xxx] rocm_ernic 0000:00:04.0: device version 17, \
+   driver version 20
+   [  xxx] rocm_ernic 0000:00:04.0: DSR initialized \
+   after N polls
+   [  xxx] rocm_ernic 0000:00:04.0: running in standalone \
+   mode (no netdev)
+   [  xxx] rocm_ernic 0000:00:04.0: registered ibdev \
+   rocm_ernicX
+
+Verifying the Device
+--------------------
+
+After loading the driver, confirm that the PCI device and
+the InfiniBand device are visible:
+
+.. code-block:: bash
+
+   lspci | grep 1022:1488
+   ibv_devices
+
+End-to-End Workflow
+-------------------
+
+1. Start the server on the host:
+
+   .. code-block:: bash
+
+      ./build/rocm-ernic \
+        --socket /tmp/vfio-user-rocm-ernic.sock \
+        --backend loopback --verbose
+
+2. Launch QEMU with the vfio-user device attached
+   (see :doc:`usage` for the full command line).
+
+3. Inside the guest, load the driver:
+
+   .. code-block:: bash
+
+      sudo modprobe rocm_ernic
+
+4. Run an RDMA application or test:
+
+   .. code-block:: bash
+
+      ibv_devices
+      ibv_devinfo -d rocm_ernic0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,60 @@
+rocm-ernic: Emulated RDMA NIC for Virtual Machines
+===================================================
+
+Introduction
+------------
+
+rocm-ernic is a userspace RDMA device server built on the
+`libvfio-user <https://github.com/nutanix/libvfio-user>`_
+framework. It provides full RDMA (Remote Direct Memory Access)
+functionality to virtual machines without requiring physical
+RDMA hardware or an in-guest software stack such as
+`Soft-RoCE <https://man7.org/linux/man-pages/man7/rxe.7.html>`_.
+
+Key Features
+^^^^^^^^^^^^
+
+- Full PCIe device emulation in userspace
+- Three memory-mapped BARs (MSI-X, registers, UAR)
+- MSI-X interrupt support
+- Multiple RDMA backends (loopback, TCP/IP, native verbs)
+- Companion Linux kernel driver (``rocm_ernic``)
+- Comprehensive statistics collection
+
+Quick Start
+^^^^^^^^^^^
+
+.. code-block:: bash
+
+   sudo apt install cmake meson ninja-build pkg-config \
+     libibverbs-dev librdmacm-dev libglib2.0-dev
+   cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+   cmake --build build
+
+   ./build/rocm-ernic \
+     --socket /tmp/vfio-user-rocm-ernic.sock \
+     --backend loopback --verbose
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide
+
+   building
+   architecture
+   usage
+   driver
+   testing
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
+
+   api
+
+License
+-------
+
+The userspace server and build infrastructure are licensed under
+GPL-2.0-or-later. The kernel driver carries the original VMware
+dual-license (GPL-2.0 / BSD-2-Clause) for files derived from
+the upstream PVRDMA driver.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,118 @@
+Testing
+=======
+
+rocm-ernic ships with several test programs and a CTest
+integration that can be run from the build directory.
+
+Test Programs
+-------------
+
+test_pci_client
+^^^^^^^^^^^^^^^
+
+A vfio-user client that connects to the server and performs
+basic PCI configuration space queries:
+
+- Socket connection to server
+- PCI Vendor ID verification (AMD: ``0x1022``)
+- PCI Device ID verification (ROCm ERNIC: ``0x8000``)
+- PCI Class Code verification (Network Controller)
+- PCI Header Type verification (Type 0)
+- BAR register reads
+- Interrupt configuration reads
+
+Exit codes: ``0`` = pass, ``1`` = failure.
+
+test_data_transfer
+^^^^^^^^^^^^^^^^^^
+
+Comprehensive RDMA data transfer test using libibverbs:
+
+- RDMA device discovery and opening
+- Protection Domain allocation
+- Completion Queue creation
+- Queue Pair creation and state transitions
+- Memory Region registration
+- Send / recv operations with varying buffer sizes
+  (64 to 4096 bytes)
+
+Requires an RDMA device (via the ``rocm_ernic`` driver or
+real hardware). Skipped if no device is found.
+
+test_rdma_cm
+^^^^^^^^^^^^
+
+RDMA Connection Manager test using libibverbs. Validates
+connection setup and teardown paths.
+
+Running Tests
+-------------
+
+Quick Local Test
+^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   ./scripts/run-local-tests.sh
+
+This script builds the project (if needed), starts the
+server, runs the test client, and cleans up automatically.
+
+Manual Testing
+^^^^^^^^^^^^^^
+
+Build and start the server in one terminal:
+
+.. code-block:: bash
+
+   cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+   cmake --build build
+
+   ./build/rocm-ernic /tmp/test.sock
+
+Run the test client in another terminal:
+
+.. code-block:: bash
+
+   ./build/tests/test_pci_client --socket /tmp/test.sock
+
+CTest
+^^^^^
+
+Run all registered tests via CTest:
+
+.. code-block:: bash
+
+   ctest --test-dir build
+
+With verbose output on failure:
+
+.. code-block:: bash
+
+   ctest --test-dir build --output-on-failure
+
+Adding New Tests
+----------------
+
+1. Create a test source file in ``tests/``.
+2. Add the executable to ``tests/CMakeLists.txt``.
+3. Register the test with ``add_test()``.
+
+Example:
+
+.. code-block:: cmake
+
+   add_executable(test_new_feature
+       test_new_feature.c
+   )
+
+   add_test(
+       NAME new-feature-test
+       COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/run-test.sh
+           $<TARGET_FILE:test_new_feature>
+           $<TARGET_FILE:rocm-ernic>
+   )
+   set_tests_properties(new-feature-test PROPERTIES
+       TIMEOUT 30
+       RUN_SERIAL TRUE
+   )

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,93 @@
+Usage
+=====
+
+Basic Usage
+-----------
+
+Start the server with a UNIX socket and the desired backend:
+
+.. code-block:: bash
+
+   # Loopback backend (no external dependencies)
+   ./build/rocm-ernic \
+     --socket /tmp/vfio-user-rocm-ernic.sock \
+     --backend loopback \
+     --verbose
+
+   # RDMA verbs backend (requires RDMA hardware)
+   ./build/rocm-ernic \
+     --socket /tmp/vfio-user-rocm-ernic.sock \
+     --backend verbs:device=mlx5_0,ethdev=eth0,port=1 \
+     --verbose
+
+   # No backend (minimal stubs)
+   ./build/rocm-ernic \
+     --socket /tmp/vfio-user-rocm-ernic.sock \
+     --backend none
+
+Launching a VM
+--------------
+
+Attach the emulated device to a QEMU virtual machine using
+the ``vfio-user-pci`` transport. QEMU 10.1 or later is
+required.
+
+.. code-block:: bash
+
+   qemu-system-x86_64 \
+     -machine q35,accel=kvm \
+     -cpu EPYC \
+     -smp cpus=2 \
+     -object memory-backend-memfd,\
+   id=mem0,share=on,size=2048M \
+     -machine memory-backend=mem0 \
+     -nographic \
+     -drive if=virtio,format=qcow2,\
+   file=vm-image.qcow2 \
+     -netdev user,id=net0,\
+   hostfwd=tcp::2222-:22 \
+     -device virtio-net-pci,netdev=net0 \
+     -device '{"driver":"vfio-user-pci",\
+   "socket":{"path":"/tmp/vfio-user-rocm-ernic.sock",\
+   "type":"unix"}}'
+
+Inside the guest, load the kernel driver and verify:
+
+.. code-block:: bash
+
+   sudo modprobe rocm_ernic
+   lspci | grep 1022:1488
+   ibv_devices
+
+Statistics Collection
+---------------------
+
+The server can collect detailed statistics about doorbell
+rings, WQE processing, and completion queue entries.
+Statistics are written to a file approximately every second
+while the server is running.
+
+.. code-block:: bash
+
+   ./build/rocm-ernic \
+     --socket /tmp/vfio-user-rocm-ernic.sock \
+     --backend loopback \
+     --stats-file /tmp/rocm_ernic_stats.txt
+
+   # Monitor statistics in real-time
+   watch -n 0.5 cat /tmp/rocm_ernic_stats.txt
+
+The statistics file includes:
+
+- Device-level statistics (commands, register reads/writes,
+  UAR writes, interrupts)
+- Per-QP statistics:
+
+  - Doorbell rings (send, receive, SRQ)
+  - WQEs processed (total and by opcode type)
+  - CQEs posted
+  - Continuation callbacks scheduled
+
+Statistics are automatically written on server exit
+(``SIGINT`` / ``SIGTERM``) in addition to the periodic
+updates.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+sphinx>=7.0
+breathe>=4.35
+sphinx-book-theme>=1.0


### PR DESCRIPTION
Add a CMake-driven documentation build following ROCm best practices (modeled after rocm-xio). Doxygen extracts API documentation from C headers into XML, Breathe imports it into Sphinx, and sphinx-book-theme renders the final HTML.

New files:
- cmake/ErnicDocumentation.cmake: venv, doxygen, and sphinx-html CMake targets
- docs/Doxyfile.in: Doxygen config (XML-only output, C-optimized, headers only)
- docs/conf.py: Sphinx config with Breathe extension
- docs/*.rst: index, building, architecture, usage, driver, testing, and api reference pages
- requirements.txt: sphinx, breathe, sphinx-book-theme
- .github/workflows/docs-check.yml: CI for sphinx-build and doc8 RST linting

Modified files:
- CMakeLists.txt: ERNIC_DOCS_ONLY early-return path and include(ErnicDocumentation) with summary line
- .gitignore: unignore docs/ so source RST is tracked
- .spellcheck.yml: add reStructuredText matrix entry
- .wordlist.txt: add documentation-related terms

Build documentation with:
  cmake -B build -DERNIC_DOCS_ONLY=ON -DERNIC_BUILD_DOCS=ON cmake --build build --target sphinx-html
