### PR TITLE
build: add DKMS and rdma-core CMake targets

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -14,4 +14,9 @@ with section("lint"):
         # expressions and version strings.  Matches the
         # hipFile .cmakelintrc approach.
         "C0301",
+        # E1122 crashes cmake-lint on add_custom_target()
+        # with COMMAND arguments (IndexError in the
+        # formatter).  CMake validates these calls at
+        # configure time so this lint adds no value.
+        "E1122",
     ]

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -42,8 +42,12 @@ jobs:
       
       - name: Clone and build libvfio-user
         run: |
+          # Pin to 082925c6 (Fix default "make all", Mar 16 2026)
+          # to avoid API break in f3742ed9 (#835) which added
+          # max_regions param to vfu_setup_device_dma().
           git clone https://github.com/nutanix/libvfio-user.git /tmp/libvfio-user
           cd /tmp/libvfio-user
+          git checkout 082925c6
           meson setup build --prefix=/usr -Dwarning_level=0
           ninja -C build
           sudo ninja -C build install

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -633,6 +633,122 @@ jobs:
             exit 1
         fi
     
+    - name: Sysfs loopback smoke test
+      shell: bash
+      run: |
+        echo "=== Sysfs Loopback Smoke Test ==="
+        SSH_PORT="$SSH_PORT"
+        VM_USER="$VM_USER"
+
+        # Start a loopback server for the sysfs test
+        ./build/rocm-ernic \
+          --socket /tmp/vfio-user-rocm-ernic-test.sock \
+          --backend loopback \
+          --verbose > /tmp/vfu_server_sysfs.log 2>&1 &
+        SERVER_PID=$!
+        SOCKET_READY=0
+        for i in {1..10}; do
+          if [ -S /tmp/vfio-user-rocm-ernic-test.sock ]; then
+            chmod 666 /tmp/vfio-user-rocm-ernic-test.sock
+            SOCKET_READY=1
+            break
+          fi
+          sleep 0.5
+        done
+        if [ $SOCKET_READY -eq 0 ]; then
+          echo "Server failed to start for sysfs test"
+          tail -20 /tmp/vfu_server_sysfs.log
+          exit 1
+        fi
+
+        set +e
+        ssh -o StrictHostKeyChecking=no -p "$SSH_PORT" \
+          "${VM_USER}@localhost" <<-'EOFVM'
+        	SYSFS_ETH=""
+        	SYSFS_IB=""
+
+        	# Locate the Ethernet loopback attribute
+        	for d in /sys/class/net/rocm_ernic*; do
+        	  if [ -f "$d/device/loopback" ]; then
+        	    SYSFS_ETH="$d/device/loopback"
+        	    break
+        	  fi
+        	done
+
+        	# Locate the IB loopback attribute
+        	for d in /sys/class/infiniband/rocm_ernic*; do
+        	  if [ -f "$d/loopback" ]; then
+        	    SYSFS_IB="$d/loopback"
+        	    break
+        	  fi
+        	done
+
+        	if [ -z "$SYSFS_ETH" ] && [ -z "$SYSFS_IB" ]; then
+        	  echo "No sysfs loopback attributes found"
+        	  exit 77
+        	fi
+
+        	FAIL=0
+
+        	# -- Ethernet attribute --
+        	if [ -n "$SYSFS_ETH" ]; then
+        	  echo "Ethernet attr: $SYSFS_ETH"
+        	  V=$(cat "$SYSFS_ETH")
+        	  echo "  default value: $V"
+        	  [ "$V" = "0" ] || { echo "  expected 0"; FAIL=1; }
+
+        	  echo 1 | sudo tee "$SYSFS_ETH" > /dev/null
+        	  V=$(cat "$SYSFS_ETH")
+        	  echo "  after enable: $V"
+        	  [ "$V" = "1" ] || { echo "  expected 1"; FAIL=1; }
+
+        	  echo 0 | sudo tee "$SYSFS_ETH" > /dev/null
+        	  V=$(cat "$SYSFS_ETH")
+        	  echo "  after disable: $V"
+        	  [ "$V" = "0" ] || { echo "  expected 0"; FAIL=1; }
+        	fi
+
+        	# -- IB attribute --
+        	if [ -n "$SYSFS_IB" ]; then
+        	  echo "IB attr: $SYSFS_IB"
+        	  V=$(cat "$SYSFS_IB")
+        	  echo "  default value: $V"
+        	  [ "$V" = "0" ] || { echo "  expected 0"; FAIL=1; }
+
+        	  echo 1 | sudo tee "$SYSFS_IB" > /dev/null
+        	  V=$(cat "$SYSFS_IB")
+        	  echo "  after enable: $V"
+        	  [ "$V" = "1" ] || { echo "  expected 1"; FAIL=1; }
+
+        	  echo 0 | sudo tee "$SYSFS_IB" > /dev/null
+        	  V=$(cat "$SYSFS_IB")
+        	  echo "  after disable: $V"
+        	  [ "$V" = "0" ] || { echo "  expected 0"; FAIL=1; }
+        	fi
+
+        	if [ $FAIL -ne 0 ]; then
+        	  echo "Sysfs loopback smoke test FAILED"
+        	  exit 1
+        	fi
+        	echo "Sysfs loopback smoke test PASSED"
+        EOFVM
+        TEST_EXIT=$?
+        set -e
+
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        rm -f /tmp/vfio-user-rocm-ernic-test.sock
+
+        if [ $TEST_EXIT -eq 0 ]; then
+          echo "Sysfs loopback smoke test passed"
+        elif [ $TEST_EXIT -eq 77 ]; then
+          echo "Sysfs loopback smoke test skipped"
+          echo "(RDMA device not available)"
+        else
+          echo "Sysfs loopback smoke test FAILED"
+          exit 1
+        fi
+    
     - name: Show logs
       if: always()
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,16 @@ add_subdirectory(tests)
 include(ErnicInstall)
 
 # ---------------------------------------------------------------
+# Kernel module (DKMS)
+# ---------------------------------------------------------------
+include(ErnicKernelModule)
+
+# ---------------------------------------------------------------
+# rdma-core with rocm_ernic provider
+# ---------------------------------------------------------------
+include(ErnicRdmaCore)
+
+# ---------------------------------------------------------------
 # Documentation (optional, requires -DERNIC_BUILD_DOCS=ON)
 # ---------------------------------------------------------------
 include(ErnicDocumentation)
@@ -293,6 +303,15 @@ message("")
 message("  Sanitizers:")
 message("    ASAN/LSAN/UBSAN : ${ERNIC_USE_SANITIZERS}")
 message("    TSAN            : ${ERNIC_USE_THREAD_SANITIZER}")
+message("")
+message("  Kernel module (DKMS):")
+message("    ERNIC_BUILD_KMOD : ${ERNIC_BUILD_KMOD}")
+message("")
+message("  rdma-core:")
+message("    ERNIC_RDMA_CORE_BUILD :"
+  " ${ERNIC_RDMA_CORE_BUILD}")
+message("    RDMA_CORE_VERSION     :"
+  " ${RDMA_CORE_VERSION}")
 message("")
 message("  Documentation:")
 message("    Build docs : ${ERNIC_BUILD_DOCS}")

--- a/cmake/ErnicKernelModule.cmake
+++ b/cmake/ErnicKernelModule.cmake
@@ -12,39 +12,39 @@
 # Included from the top-level CMakeLists.txt.
 
 option(ERNIC_BUILD_KMOD
-  "Setup rocm-ernic eth+RDMA DKMS modules" OFF)
+    "Setup rocm-ernic eth+RDMA DKMS modules" OFF)
 
 set(ERNIC_DKMS_SETUP_SCRIPT
-  "${CMAKE_SOURCE_DIR}/driver/setup-rocm-ernic-dkms.sh")
+    "${CMAKE_SOURCE_DIR}/driver/setup-rocm-ernic-dkms.sh")
 
 if(ERNIC_BUILD_KMOD)
-  message(STATUS
-    "ernic: DKMS kmod targets enabled"
-    " (${ERNIC_DKMS_SETUP_SCRIPT})")
+    message(STATUS
+        "ernic: DKMS kmod targets enabled"
+        " (${ERNIC_DKMS_SETUP_SCRIPT})")
 
-  add_custom_target(build-ernic-dkms
-    COMMAND ${ERNIC_DKMS_SETUP_SCRIPT}
-      --build-only
-    COMMENT
-      "Building rocm-ernic eth+RDMA DKMS"
-      " modules (no install)"
-    VERBATIM
-  )
+    add_custom_target(build-ernic-dkms
+        COMMAND ${ERNIC_DKMS_SETUP_SCRIPT}
+            --build-only
+        COMMENT
+            "Building rocm-ernic eth+RDMA DKMS"
+            " modules (no install)"
+        VERBATIM
+    )
 
-  add_custom_target(install-ernic-dkms
-    COMMAND ${ERNIC_DKMS_SETUP_SCRIPT}
-    COMMENT
-      "Building and installing rocm-ernic"
-      " eth+RDMA DKMS modules"
-    VERBATIM
-  )
+    add_custom_target(install-ernic-dkms
+        COMMAND ${ERNIC_DKMS_SETUP_SCRIPT}
+        COMMENT
+            "Building and installing rocm-ernic"
+            " eth+RDMA DKMS modules"
+        VERBATIM
+    )
 
-  add_custom_target(remove-ernic-dkms
-    COMMAND ${ERNIC_DKMS_SETUP_SCRIPT}
-      --uninstall
-    COMMENT
-      "Removing rocm-ernic eth+RDMA DKMS"
-      " modules"
-    VERBATIM
-  )
+    add_custom_target(remove-ernic-dkms
+        COMMAND ${ERNIC_DKMS_SETUP_SCRIPT}
+            --uninstall
+        COMMENT
+            "Removing rocm-ernic eth+RDMA DKMS"
+            " modules"
+        VERBATIM
+    )
 endif()

--- a/cmake/ErnicKernelModule.cmake
+++ b/cmake/ErnicKernelModule.cmake
@@ -1,0 +1,50 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# ErnicKernelModule.cmake
+#
+# Builds the rocm_ernic_eth.ko ethernet module
+# and rocm_ernic_rdma.ko RDMA kernel module via
+# DKMS.
+#
+# Included from the top-level CMakeLists.txt.
+
+option(ERNIC_BUILD_KMOD
+  "Setup rocm-ernic eth+RDMA DKMS modules" OFF)
+
+set(ERNIC_DKMS_SETUP_SCRIPT
+  "${CMAKE_SOURCE_DIR}/driver/setup-rocm-ernic-dkms.sh")
+
+if(ERNIC_BUILD_KMOD)
+  message(STATUS
+    "ernic: DKMS kmod targets enabled"
+    " (${ERNIC_DKMS_SETUP_SCRIPT})")
+
+  add_custom_target(build-ernic-dkms
+    COMMAND ${ERNIC_DKMS_SETUP_SCRIPT}
+      --build-only
+    COMMENT
+      "Building rocm-ernic eth+RDMA DKMS"
+      " modules (no install)"
+    VERBATIM
+  )
+
+  add_custom_target(install-ernic-dkms
+    COMMAND ${ERNIC_DKMS_SETUP_SCRIPT}
+    COMMENT
+      "Building and installing rocm-ernic"
+      " eth+RDMA DKMS modules"
+    VERBATIM
+  )
+
+  add_custom_target(remove-ernic-dkms
+    COMMAND ${ERNIC_DKMS_SETUP_SCRIPT}
+      --uninstall
+    COMMENT
+      "Removing rocm-ernic eth+RDMA DKMS"
+      " modules"
+    VERBATIM
+  )
+endif()

--- a/cmake/ErnicRdmaCore.cmake
+++ b/cmake/ErnicRdmaCore.cmake
@@ -1,0 +1,101 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# ErnicRdmaCore.cmake
+#
+# Builds rdma-core with the rocm_ernic provider.
+# Downloads the upstream tarball, injects the
+# provider, and builds/installs via a helper
+# script.
+#
+# Included from the top-level CMakeLists.txt.
+
+set(RDMA_CORE_VERSION "62.0" CACHE STRING
+  "Upstream rdma-core version to download")
+
+option(ERNIC_RDMA_CORE_BUILD
+  "Build rdma-core with rocm_ernic provider" OFF)
+
+# -----------------------------------------------
+# Derived paths
+# -----------------------------------------------
+
+set(RDMA_CORE_DEPS_DIR
+  "${CMAKE_BINARY_DIR}/_deps/rdma-core")
+set(RDMA_CORE_INSTALL_DIR
+  "${RDMA_CORE_DEPS_DIR}/install")
+
+set(RDMA_CORE_BUILD_SCRIPT
+  "${CMAKE_SOURCE_DIR}/scripts/build-rdma-core.sh")
+
+# -----------------------------------------------
+# Build targets
+# -----------------------------------------------
+
+if(ERNIC_RDMA_CORE_BUILD)
+  include(ProcessorCount)
+  ProcessorCount(NPROC)
+  if(NPROC EQUAL 0)
+    set(NPROC 4)
+  endif()
+
+  set(_RDMA_CORE_PROVIDER_DIR
+    "${CMAKE_SOURCE_DIR}/rdma-core/providers/rocm_ernic")
+  if(NOT IS_DIRECTORY "${_RDMA_CORE_PROVIDER_DIR}"
+     OR NOT EXISTS
+     "${_RDMA_CORE_PROVIDER_DIR}/CMakeLists.txt")
+    message(FATAL_ERROR
+      "ERNIC_RDMA_CORE_BUILD=ON but provider"
+      " source not found at"
+      " ${_RDMA_CORE_PROVIDER_DIR}")
+  endif()
+
+  set(_RDMA_CORE_ENV
+    ${CMAKE_COMMAND} -E env
+      "RDMA_CORE_VERSION=${RDMA_CORE_VERSION}"
+  )
+
+  message(STATUS
+    "rdma-core: build v${RDMA_CORE_VERSION}"
+    " with rocm_ernic provider")
+
+  add_custom_target(build-rdma-core
+    COMMAND ${_RDMA_CORE_ENV}
+      ${RDMA_CORE_BUILD_SCRIPT}
+      ${RDMA_CORE_DEPS_DIR}
+      ${RDMA_CORE_INSTALL_DIR}
+      ${NPROC}
+      --build-only
+    COMMENT
+      "Building rdma-core with rocm_ernic"
+      " provider (no install)"
+    VERBATIM
+  )
+
+  add_custom_target(install-rdma-core
+    COMMAND ${_RDMA_CORE_ENV}
+      ${RDMA_CORE_BUILD_SCRIPT}
+      ${RDMA_CORE_DEPS_DIR}
+      ${RDMA_CORE_INSTALL_DIR}
+      ${NPROC}
+    COMMENT
+      "Building and installing rdma-core"
+      " with rocm_ernic provider"
+    VERBATIM
+  )
+
+  set(RDMA_CORE_LIB_DIR
+    "${RDMA_CORE_INSTALL_DIR}/lib"
+    CACHE PATH
+    "rdma-core library directory" FORCE)
+  set(RDMA_CORE_INCLUDE_DIR
+    "${RDMA_CORE_INSTALL_DIR}/include"
+    CACHE PATH
+    "rdma-core include directory" FORCE)
+
+  message(STATUS
+    "rdma-core: will install to"
+    " ${RDMA_CORE_INSTALL_DIR}")
+endif()

--- a/cmake/ErnicRdmaCore.cmake
+++ b/cmake/ErnicRdmaCore.cmake
@@ -13,89 +13,89 @@
 # Included from the top-level CMakeLists.txt.
 
 set(RDMA_CORE_VERSION "62.0" CACHE STRING
-  "Upstream rdma-core version to download")
+    "Upstream rdma-core version to download")
 
 option(ERNIC_RDMA_CORE_BUILD
-  "Build rdma-core with rocm_ernic provider" OFF)
+    "Build rdma-core with rocm_ernic provider" OFF)
 
 # -----------------------------------------------
 # Derived paths
 # -----------------------------------------------
 
 set(RDMA_CORE_DEPS_DIR
-  "${CMAKE_BINARY_DIR}/_deps/rdma-core")
+    "${CMAKE_BINARY_DIR}/_deps/rdma-core")
 set(RDMA_CORE_INSTALL_DIR
-  "${RDMA_CORE_DEPS_DIR}/install")
+    "${RDMA_CORE_DEPS_DIR}/install")
 
 set(RDMA_CORE_BUILD_SCRIPT
-  "${CMAKE_SOURCE_DIR}/scripts/build-rdma-core.sh")
+    "${CMAKE_SOURCE_DIR}/scripts/build-rdma-core.sh")
 
 # -----------------------------------------------
 # Build targets
 # -----------------------------------------------
 
 if(ERNIC_RDMA_CORE_BUILD)
-  include(ProcessorCount)
-  ProcessorCount(NPROC)
-  if(NPROC EQUAL 0)
-    set(NPROC 4)
-  endif()
+    include(ProcessorCount)
+    ProcessorCount(NPROC)
+    if(NPROC EQUAL 0)
+        set(NPROC 4)
+    endif()
 
-  set(_RDMA_CORE_PROVIDER_DIR
-    "${CMAKE_SOURCE_DIR}/rdma-core/providers/rocm_ernic")
-  if(NOT IS_DIRECTORY "${_RDMA_CORE_PROVIDER_DIR}"
-     OR NOT EXISTS
-     "${_RDMA_CORE_PROVIDER_DIR}/CMakeLists.txt")
-    message(FATAL_ERROR
-      "ERNIC_RDMA_CORE_BUILD=ON but provider"
-      " source not found at"
-      " ${_RDMA_CORE_PROVIDER_DIR}")
-  endif()
+    set(ERNIC_PROVIDER_DIR
+        "${CMAKE_SOURCE_DIR}/rdma-core/providers/rocm_ernic")
+    if(NOT IS_DIRECTORY "${ERNIC_PROVIDER_DIR}"
+       OR NOT EXISTS
+       "${ERNIC_PROVIDER_DIR}/CMakeLists.txt")
+        message(FATAL_ERROR
+            "ERNIC_RDMA_CORE_BUILD=ON but provider"
+            " source not found at"
+            " ${ERNIC_PROVIDER_DIR}")
+    endif()
 
-  set(_RDMA_CORE_ENV
-    ${CMAKE_COMMAND} -E env
-      "RDMA_CORE_VERSION=${RDMA_CORE_VERSION}"
-  )
+    set(ERNIC_RDMA_CORE_ENV
+        ${CMAKE_COMMAND} -E env
+            "RDMA_CORE_VERSION=${RDMA_CORE_VERSION}"
+    )
 
-  message(STATUS
-    "rdma-core: build v${RDMA_CORE_VERSION}"
-    " with rocm_ernic provider")
+    message(STATUS
+        "rdma-core: build v${RDMA_CORE_VERSION}"
+        " with rocm_ernic provider")
 
-  add_custom_target(build-rdma-core
-    COMMAND ${_RDMA_CORE_ENV}
-      ${RDMA_CORE_BUILD_SCRIPT}
-      ${RDMA_CORE_DEPS_DIR}
-      ${RDMA_CORE_INSTALL_DIR}
-      ${NPROC}
-      --build-only
-    COMMENT
-      "Building rdma-core with rocm_ernic"
-      " provider (no install)"
-    VERBATIM
-  )
+    add_custom_target(build-rdma-core
+        COMMAND ${ERNIC_RDMA_CORE_ENV}
+            ${RDMA_CORE_BUILD_SCRIPT}
+            ${RDMA_CORE_DEPS_DIR}
+            ${RDMA_CORE_INSTALL_DIR}
+            ${NPROC}
+            --build-only
+        COMMENT
+            "Building rdma-core with rocm_ernic"
+            " provider (no install)"
+        VERBATIM
+    )
 
-  add_custom_target(install-rdma-core
-    COMMAND ${_RDMA_CORE_ENV}
-      ${RDMA_CORE_BUILD_SCRIPT}
-      ${RDMA_CORE_DEPS_DIR}
-      ${RDMA_CORE_INSTALL_DIR}
-      ${NPROC}
-    COMMENT
-      "Building and installing rdma-core"
-      " with rocm_ernic provider"
-    VERBATIM
-  )
+    add_custom_target(install-rdma-core
+        COMMAND ${ERNIC_RDMA_CORE_ENV}
+            ${RDMA_CORE_BUILD_SCRIPT}
+            ${RDMA_CORE_DEPS_DIR}
+            ${RDMA_CORE_INSTALL_DIR}
+            ${NPROC}
+        COMMENT
+            "Building and installing rdma-core"
+            " with rocm_ernic provider"
+        VERBATIM
+    )
 
-  set(RDMA_CORE_LIB_DIR
-    "${RDMA_CORE_INSTALL_DIR}/lib"
-    CACHE PATH
-    "rdma-core library directory" FORCE)
-  set(RDMA_CORE_INCLUDE_DIR
-    "${RDMA_CORE_INSTALL_DIR}/include"
-    CACHE PATH
-    "rdma-core include directory" FORCE)
+    set(RDMA_CORE_LIB_DIR
+        "${RDMA_CORE_INSTALL_DIR}/lib"
+        CACHE PATH
+        "rdma-core library directory" FORCE)
+    set(RDMA_CORE_INCLUDE_DIR
+        "${RDMA_CORE_INSTALL_DIR}/include"
+        CACHE PATH
+        "rdma-core include directory" FORCE)
 
-  message(STATUS
-    "rdma-core: will install to"
-    " ${RDMA_CORE_INSTALL_DIR}")
+    message(STATUS
+        "rdma-core: will install to"
+        " ${RDMA_CORE_INSTALL_DIR}")
 endif()

--- a/docs/driver.rst
+++ b/docs/driver.rst
@@ -54,6 +54,49 @@ the InfiniBand device are visible:
    lspci | grep 1022:1488
    ibv_devices
 
+Sysfs Loopback Mode
+-------------------
+
+The driver exposes a ``loopback`` sysfs attribute on both the
+Ethernet PCI device and the InfiniBand device. When enabled,
+the driver operates without a real network path: TX packets
+are reflected back as RX at the Ethernet layer, and the RDMA
+module skips GID binding commands. This is useful for testing
+RDMA applications in the guest without a fully configured
+userspace server backend.
+
+**Ethernet-level loopback** (TX packets reflected as RX):
+
+.. code-block:: bash
+
+   # Enable
+   echo 1 > /sys/class/net/rocm_ernic0/device/loopback
+
+   # Disable
+   echo 0 > /sys/class/net/rocm_ernic0/device/loopback
+
+   # Check current state
+   cat /sys/class/net/rocm_ernic0/device/loopback
+
+**RDMA-level loopback** (skips GID binding, syncs with
+Ethernet loopback):
+
+.. code-block:: bash
+
+   # Enable (also enables Ethernet loopback)
+   echo 1 > /sys/class/infiniband/rocm_ernic0/loopback
+
+   # Disable
+   echo 0 > /sys/class/infiniband/rocm_ernic0/loopback
+
+   # Check current state
+   cat /sys/class/infiniband/rocm_ernic0/loopback
+
+The RDMA-level attribute is the primary control; writing to
+it automatically propagates to the Ethernet module. Writing
+directly to the Ethernet attribute only affects the Ethernet
+layer.
+
 End-to-End Workflow
 -------------------
 

--- a/driver/dkms.conf
+++ b/driver/dkms.conf
@@ -1,0 +1,26 @@
+# DKMS configuration for rocm_ernic eth+RDMA
+#
+# Two modules:
+#   rocm_ernic_eth.ko  - ethernet driver
+#   rocm_ernic_rdma.ko - RDMA driver
+#
+# SPDX-License-Identifier: GPL-2.0
+
+PACKAGE_NAME="rocm-ernic-eth-rdma"
+PACKAGE_VERSION="0.2.0"
+
+BUILT_MODULE_NAME[0]="rocm_ernic_eth"
+DEST_MODULE_LOCATION[0]="/updates/dkms"
+
+BUILT_MODULE_NAME[1]="rocm_ernic_rdma"
+DEST_MODULE_LOCATION[1]="/updates/dkms"
+
+AUTOINSTALL="yes"
+
+MAKE="make -C ${kernel_source_dir} \
+  M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build \
+  modules"
+
+CLEAN="make -C ${kernel_source_dir} \
+  M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build \
+  clean"

--- a/driver/rocm_ernic.h
+++ b/driver/rocm_ernic.h
@@ -250,6 +250,9 @@ struct rocm_ernic_dev {
     struct net_device *netdev;
     struct net_device *mesh_dummy_netdev;
     struct notifier_block nb_netdev;
+
+    /* Sysfs-controlled loopback: skip GID binding, use local table */
+    bool loopback_mode;
 };
 
 struct rocm_ernic_netdevice_work {

--- a/driver/rocm_ernic_eth.c
+++ b/driver/rocm_ernic_eth.c
@@ -554,6 +554,29 @@ static netdev_tx_t rocm_ernic_eth_xmit(struct sk_buff *skb,
         return NETDEV_TX_OK;
     }
 
+    if (eth_dev->loopback_mode) {
+        struct sk_buff *lb_skb;
+        struct ethhdr *eth;
+
+        lb_skb = skb_copy(skb, GFP_ATOMIC);
+        if (!lb_skb) {
+            dev_kfree_skb_any(skb);
+            return NETDEV_TX_OK;
+        }
+
+        if (skb_headlen(lb_skb) >= ETH_HLEN) {
+            eth = eth_hdr(lb_skb);
+            ether_addr_copy(eth->h_dest, ndev->dev_addr);
+            ether_addr_copy(eth->h_source, ndev->dev_addr);
+        }
+
+        lb_skb->protocol = eth_type_trans(lb_skb, ndev);
+        lb_skb->pkt_type = PACKET_HOST;
+        netif_receive_skb(lb_skb);
+        dev_kfree_skb_any(skb);
+        return NETDEV_TX_OK;
+    }
+
     ring = &eth_dev->tx_ring;
     if (!ring->desc) {
         dev_kfree_skb_any(skb);
@@ -780,6 +803,73 @@ struct pci_dev *rocm_ernic_eth_get_pdev(struct rocm_ernic_eth_dev *eth_dev)
 }
 EXPORT_SYMBOL(rocm_ernic_eth_get_pdev);
 
+bool rocm_ernic_eth_get_loopback(struct pci_dev *pdev)
+{
+    struct rocm_ernic_eth_dev *eth_dev = rocm_ernic_eth_get_dev(pdev);
+
+    return eth_dev ? eth_dev->loopback_mode : false;
+}
+EXPORT_SYMBOL(rocm_ernic_eth_get_loopback);
+
+void rocm_ernic_eth_set_loopback(struct pci_dev *pdev, bool enable)
+{
+    struct rocm_ernic_eth_dev *eth_dev = rocm_ernic_eth_get_dev(pdev);
+
+    if (!eth_dev)
+        return;
+
+    if (eth_dev->loopback_mode != enable) {
+        eth_dev->loopback_mode = enable;
+        dev_info(&pdev->dev, "Ethernet loopback mode %s\n",
+                 enable ? "enabled" : "disabled");
+    }
+}
+EXPORT_SYMBOL(rocm_ernic_eth_set_loopback);
+
+static ssize_t loopback_show(struct device *device,
+                             struct device_attribute *attr, char *buf)
+{
+    struct pci_dev *pdev = to_pci_dev(device);
+    struct rocm_ernic_eth_dev *eth_dev = pci_get_drvdata(pdev);
+
+    if (!eth_dev)
+        return -ENODEV;
+
+    return sysfs_emit(buf, "%d\n", eth_dev->loopback_mode ? 1 : 0);
+}
+
+static ssize_t loopback_store(struct device *device,
+                              struct device_attribute *attr, const char *buf,
+                              size_t count)
+{
+    struct pci_dev *pdev = to_pci_dev(device);
+    bool enable;
+    int ret;
+
+    ret = kstrtobool(buf, &enable);
+    if (ret)
+        return ret;
+
+    rocm_ernic_eth_set_loopback(pdev, enable);
+
+    return count;
+}
+static DEVICE_ATTR_RW(loopback);
+
+static struct attribute *rocm_ernic_eth_pci_attrs[] = {
+    &dev_attr_loopback.attr,
+    NULL,
+};
+
+static const struct attribute_group rocm_ernic_eth_pci_attr_group = {
+    .attrs = rocm_ernic_eth_pci_attrs,
+};
+
+static const struct attribute_group *rocm_ernic_eth_pci_groups[] = {
+    &rocm_ernic_eth_pci_attr_group,
+    NULL,
+};
+
 static const struct pci_device_id rocm_ernic_eth_pci_table[] = {
     {
         PCI_DEVICE(PCI_VENDOR_ID_ROCM_ERNIC, PCI_DEVICE_ID_ROCM_ERNIC),
@@ -908,6 +998,7 @@ static struct pci_driver rocm_ernic_eth_driver = {
     .id_table = rocm_ernic_eth_pci_table,
     .probe = rocm_ernic_eth_pci_probe,
     .remove = rocm_ernic_eth_pci_remove,
+    .driver.dev_groups = rocm_ernic_eth_pci_groups,
 };
 
 static int __init rocm_ernic_eth_init(void)

--- a/driver/rocm_ernic_eth.h
+++ b/driver/rocm_ernic_eth.h
@@ -59,6 +59,8 @@ struct rocm_ernic_eth_dev {
     struct rocm_ernic_eth_tx_ring tx_ring;
     /* RX descriptor ring */
     struct rocm_ernic_eth_rx_ring rx_ring;
+    /* Sysfs-controlled loopback: TX packets are reflected as RX */
+    bool loopback_mode;
     /* Private data for Ethernet driver */
     void *priv;
 };
@@ -69,5 +71,7 @@ struct net_device *rocm_ernic_eth_get_netdev(struct pci_dev *pdev);
 void __iomem *rocm_ernic_eth_get_regs(struct pci_dev *pdev);
 struct pci_dev *rocm_ernic_eth_get_pdev(struct rocm_ernic_eth_dev *eth_dev);
 void rocm_ernic_eth_handle_rx_interrupt(struct pci_dev *pdev);
+bool rocm_ernic_eth_get_loopback(struct pci_dev *pdev);
+void rocm_ernic_eth_set_loopback(struct pci_dev *pdev, bool enable);
 
 #endif /* __ROCM_ERNIC_ETH_H__ */

--- a/driver/rocm_ernic_main.c
+++ b/driver/rocm_ernic_main.c
@@ -130,10 +130,44 @@ static ssize_t board_id_show(struct device *device,
 }
 static DEVICE_ATTR_RO(board_id);
 
+static ssize_t loopback_show(struct device *device,
+                             struct device_attribute *attr, char *buf)
+{
+    struct ib_device *ibdev = container_of(device, struct ib_device, dev);
+    struct rocm_ernic_dev *dev = to_vdev(ibdev);
+
+    return sysfs_emit(buf, "%d\n", dev->loopback_mode ? 1 : 0);
+}
+
+static ssize_t loopback_store(struct device *device,
+                              struct device_attribute *attr, const char *buf,
+                              size_t count)
+{
+    struct ib_device *ibdev = container_of(device, struct ib_device, dev);
+    struct rocm_ernic_dev *dev = to_vdev(ibdev);
+    bool enable;
+    int ret;
+
+    ret = kstrtobool(buf, &enable);
+    if (ret)
+        return ret;
+
+    if (dev->loopback_mode != enable) {
+        dev->loopback_mode = enable;
+        rocm_ernic_eth_set_loopback(dev->pdev, enable);
+        dev_info(&dev->pdev->dev, "RDMA loopback mode %s\n",
+                 enable ? "enabled" : "disabled");
+    }
+
+    return count;
+}
+static DEVICE_ATTR_RW(loopback);
+
 static struct attribute *rocm_ernic_class_attributes[] = {
     &dev_attr_hw_rev.attr,
     &dev_attr_hca_type.attr,
     &dev_attr_board_id.attr,
+    &dev_attr_loopback.attr,
     NULL,
 };
 
@@ -744,7 +778,8 @@ static int rocm_ernic_add_gid_at_index(struct rocm_ernic_dev *dev,
 static int rocm_ernic_add_gid(const struct ib_gid_attr *attr, void **context)
 {
     struct rocm_ernic_dev *dev = to_vdev(attr->device);
-    bool is_loopback = dev->netdev && (dev->netdev->flags & IFF_LOOPBACK);
+    bool is_loopback = dev->loopback_mode ||
+                       (dev->netdev && (dev->netdev->flags & IFF_LOOPBACK));
     bool is_dummy =
         dev->netdev && (dev->netdev->priv_flags & IFF_NO_QUEUE) && !is_loopback;
     union ib_gid gid = attr->gid;
@@ -876,7 +911,8 @@ static int rocm_ernic_del_gid_at_index(struct rocm_ernic_dev *dev, int index)
 static int rocm_ernic_del_gid(const struct ib_gid_attr *attr, void **context)
 {
     struct rocm_ernic_dev *dev = to_vdev(attr->device);
-    bool is_loopback = dev->netdev && (dev->netdev->flags & IFF_LOOPBACK);
+    bool is_loopback = dev->loopback_mode ||
+                       (dev->netdev && (dev->netdev->flags & IFF_LOOPBACK));
 
     dev_info(&dev->pdev->dev, "del_gid called: index=%d netdev=%s%s\n",
              attr->index, dev->netdev ? dev->netdev->name : "none",

--- a/driver/setup-rocm-ernic-dkms.sh
+++ b/driver/setup-rocm-ernic-dkms.sh
@@ -1,0 +1,267 @@
+#!/bin/bash
+# Copyright (c) Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Setup DKMS tree for rocm_ernic_eth + rocm_ernic_rdma.
+#
+# 1. Copies driver source from driver/
+# 2. Copies ABI and DV UAPI headers to include/rdma/
+# 3. Populates /usr/src/rocm-ernic-eth-rdma-<ver>/
+# 4. Registers and builds with DKMS.
+#
+# Usage:
+#   setup-rocm-ernic-dkms.sh [OPTIONS]
+#
+# Options:
+#   --version VER   DKMS package version
+#                   (default: 0.2.0-g<shortrev>)
+#   --build-only    Build but do not install
+#   --uninstall     Remove the DKMS module
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DRIVER_DIR="${SCRIPT_DIR}"
+
+PKG_NAME="rocm-ernic-eth-rdma"
+BASE_VERSION="0.2.0"
+PKG_VERSION=""
+BUILD_ONLY=false
+UNINSTALL=false
+
+# ---------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      PKG_VERSION="$2"; shift 2 ;;
+    --build-only)
+      BUILD_ONLY=true; shift ;;
+    --uninstall)
+      UNINSTALL=true; shift ;;
+    -h|--help)
+      echo "Usage: $0 [--version VER]" \
+        "[--build-only] [--uninstall]"
+      exit 0 ;;
+    *)
+      echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+GIT_REV="$(git -C "${PROJECT_ROOT}" \
+  rev-parse --short HEAD 2>/dev/null \
+  || echo "unknown")"
+
+if [ -z "${PKG_VERSION}" ]; then
+  PKG_VERSION="${BASE_VERSION}-g${GIT_REV}"
+fi
+
+DKMS_SRC="/usr/src/${PKG_NAME}-${PKG_VERSION}"
+
+# ---------------------------------------------------
+# Uninstall
+# ---------------------------------------------------
+
+if $UNINSTALL; then
+  echo "Removing DKMS module" \
+    "${PKG_NAME}/${PKG_VERSION}..."
+  sudo dkms remove \
+    "${PKG_NAME}/${PKG_VERSION}" \
+    --all 2>/dev/null || true
+  sudo rm -rf "${DKMS_SRC}"
+  echo "Done."
+  exit 0
+fi
+
+# ---------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------
+
+check_prereqs() {
+  local missing=()
+  command -v dkms &>/dev/null \
+    || missing+=("dkms")
+  command -v make &>/dev/null \
+    || missing+=("make")
+
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "ERROR: Missing required tools:" \
+      "${missing[*]}"
+    echo "Install with:"
+    echo "  sudo apt install ${missing[*]}"
+    exit 1
+  fi
+
+  if [ ! -f "${DRIVER_DIR}/rocm_ernic_main.c" ]; then
+    echo "ERROR: rocm_ernic_main.c not found" \
+      "in ${DRIVER_DIR}"
+    exit 1
+  fi
+
+  local kver
+  kver="$(uname -r)"
+  if [ ! -f \
+    "/lib/modules/${kver}/build/Makefile" ]; then
+    echo "ERROR: Kernel headers not found" \
+      "for ${kver}."
+    echo "Install with:"
+    echo "  sudo apt install" \
+      "linux-headers-${kver}"
+    exit 1
+  fi
+}
+
+check_prereqs
+
+# ---------------------------------------------------
+# Print status
+# ---------------------------------------------------
+
+echo ""
+echo "=== setup-rocm-ernic-dkms ==="
+echo "  project   : ${PROJECT_ROOT}"
+echo "  driver    : ${DRIVER_DIR}"
+echo "  DKMS src  : ${DKMS_SRC}"
+echo "  package   :" \
+  "${PKG_NAME}/${PKG_VERSION}"
+echo ""
+
+# ---------------------------------------------------
+# Skip if already installed
+# ---------------------------------------------------
+
+if ! $BUILD_ONLY && \
+    dkms status \
+    "${PKG_NAME}/${PKG_VERSION}" \
+    2>/dev/null | grep -q "installed"; then
+  echo "${PKG_NAME}/${PKG_VERSION}" \
+    "already installed."
+  echo "Use --uninstall to remove first."
+  exit 0
+fi
+
+# ---------------------------------------------------
+# Populate DKMS source tree
+# ---------------------------------------------------
+
+populate_dkms() {
+  echo "Installing source to ${DKMS_SRC}..."
+  sudo rm -rf "${DKMS_SRC}"
+  sudo mkdir -p "${DKMS_SRC}/include/rdma"
+
+  sudo cp -a "${DRIVER_DIR}/"*.c \
+    "${DKMS_SRC}/" 2>/dev/null || true
+  sudo cp -a "${DRIVER_DIR}/"*.h \
+    "${DKMS_SRC}/" 2>/dev/null || true
+
+  if [ -f \
+    "${DRIVER_DIR}/rocm_ernic-abi.h" ]; then
+    sudo cp \
+      "${DRIVER_DIR}/rocm_ernic-abi.h" \
+      "${DKMS_SRC}/include/rdma/"
+  fi
+
+  if [ -f \
+    "${DRIVER_DIR}/rocm_ernic_dv_uapi.h" ]; then
+    sudo cp \
+      "${DRIVER_DIR}/rocm_ernic_dv_uapi.h" \
+      "${DKMS_SRC}/include/rdma/"
+  fi
+
+  echo "${GIT_REV}" | sudo tee \
+    "${DKMS_SRC}/SOURCE_SHA" >/dev/null
+
+  sudo cp "${DRIVER_DIR}/Makefile" \
+    "${DKMS_SRC}/"
+  sudo cp "${DRIVER_DIR}/dkms.conf" \
+    "${DKMS_SRC}/"
+  sudo sed -i \
+    "s/^PACKAGE_VERSION=.*/PACKAGE_VERSION=\"${PKG_VERSION}\"/" \
+    "${DKMS_SRC}/dkms.conf"
+
+  echo "Source tree populated."
+}
+
+populate_dkms
+
+# ---------------------------------------------------
+# Register and build with DKMS
+# ---------------------------------------------------
+
+build_dkms() {
+  echo ""
+
+  if dkms status \
+      "${PKG_NAME}/${PKG_VERSION}" \
+      2>/dev/null | grep -q .; then
+    echo "Removing stale DKMS registration..."
+    sudo dkms remove \
+      "${PKG_NAME}/${PKG_VERSION}" \
+      --all 2>/dev/null || true
+  fi
+
+  echo "Registering with DKMS..."
+  sudo dkms add "${PKG_NAME}/${PKG_VERSION}"
+
+  local kver
+  kver="$(uname -r)"
+
+  echo "Building rocm_ernic_eth +" \
+    "rocm_ernic_rdma for ${kver}..."
+  if ! sudo dkms build \
+      "${PKG_NAME}/${PKG_VERSION}" \
+      -k "${kver}"; then
+    echo ""
+    echo "ERROR: DKMS build failed."
+    echo "Check: /var/lib/dkms/${PKG_NAME}/" \
+      "${PKG_VERSION}/build/make.log"
+    exit 1
+  fi
+
+  echo ""
+  echo "=== rocm_ernic eth+RDMA built" \
+    "via DKMS ==="
+  echo "  Module: /var/lib/dkms/${PKG_NAME}/" \
+    "${PKG_VERSION}/${kver}/$(uname -m)/module/"
+  echo ""
+  echo "To install:"
+  echo "  $0  (re-run without --build-only)"
+}
+
+install_dkms() {
+  local kver
+  kver="$(uname -r)"
+
+  echo "Installing rocm_ernic_eth +" \
+    "rocm_ernic_rdma..."
+  sudo dkms install \
+    "${PKG_NAME}/${PKG_VERSION}" -k "${kver}"
+
+  echo ""
+  echo "=== rocm_ernic eth+RDMA installed" \
+    "via DKMS ==="
+  echo ""
+  echo "DKMS will rebuild on kernel upgrades."
+  echo ""
+  echo "To load now:"
+  echo "  sudo modprobe rocm_ernic_eth"
+  echo "  sudo modprobe rocm_ernic_rdma"
+  echo ""
+  echo "To unload (reverse order):"
+  echo "  sudo modprobe -r rocm_ernic_rdma"
+  echo "  sudo modprobe -r rocm_ernic_eth"
+  echo ""
+  echo "To revert:"
+  echo "  $0 --uninstall"
+  echo "  sudo depmod -a"
+}
+
+build_dkms
+if ! $BUILD_ONLY; then
+  install_dkms
+fi

--- a/scripts/build-rdma-core.sh
+++ b/scripts/build-rdma-core.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Copyright (c) Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Build rdma-core with the rocm_ernic provider.
+# Downloads the upstream tarball, injects the
+# provider via apply-rocm-ernic-dv.sh, and builds.
+#
+# Usage:
+#   build-rdma-core.sh \
+#     <build_dir> <install_dir> \
+#     [nproc] [--build-only]
+#
+# Environment:
+#   RDMA_CORE_VERSION - upstream version
+#                       (default 62.0)
+
+set -euo pipefail
+
+BUILD_DIR="$(realpath -m "$1")"
+INSTALL_DIR="$(realpath -m "$2")"
+NPROC="${3:-$(nproc)}"
+BUILD_ONLY=false
+if [ "${4:-}" = "--build-only" ]; then
+  BUILD_ONLY=true
+fi
+
+VERSION="${RDMA_CORE_VERSION:-62.0}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+APPLY_SCRIPT="${PROJECT_DIR}/rdma-core"
+APPLY_SCRIPT="${APPLY_SCRIPT}/rocm-ernic-dv"
+APPLY_SCRIPT="${APPLY_SCRIPT}/apply-rocm-ernic-dv.sh"
+
+TARBALL_URL="https://github.com/linux-rdma"
+TARBALL_URL="${TARBALL_URL}/rdma-core"
+TARBALL_URL="${TARBALL_URL}/releases/download"
+TARBALL_URL="${TARBALL_URL}/v${VERSION}"
+TARBALL_URL="${TARBALL_URL}/rdma-core-${VERSION}.tar.gz"
+
+SRC_DIR="${BUILD_DIR}/rdma-core-${VERSION}"
+TARBALL="${BUILD_DIR}/rdma-core-${VERSION}.tar.gz"
+CMAKE_BUILD="${BUILD_DIR}/cmake-build"
+
+echo "=== build-rdma-core ==="
+echo "  version  : ${VERSION}"
+echo "  build    : ${BUILD_DIR}"
+echo "  install  : ${INSTALL_DIR}"
+echo ""
+
+if [ -f "${INSTALL_DIR}/lib/libibverbs.so" ]; then
+  echo "rdma-core already installed, skipping."
+  exit 0
+fi
+
+mkdir -p "${BUILD_DIR}"
+
+# --- Download tarball ---
+if [ ! -f "${TARBALL}" ]; then
+  echo "Downloading rdma-core v${VERSION}..."
+  curl -fsSL -o "${TARBALL}" "${TARBALL_URL}"
+fi
+
+# --- Extract ---
+if [ ! -d "${SRC_DIR}" ]; then
+  echo "Extracting..."
+  tar xf "${TARBALL}" -C "${BUILD_DIR}"
+fi
+
+# --- Inject rocm_ernic provider ---
+echo ""
+echo "--- Injecting rocm_ernic provider ---"
+if [ -x "${APPLY_SCRIPT}" ]; then
+  "${APPLY_SCRIPT}" "${SRC_DIR}"
+else
+  echo "ERROR: apply script not found:" \
+    "${APPLY_SCRIPT}"
+  exit 1
+fi
+
+# Record git SHA for provenance
+if [ -d "${PROJECT_DIR}/.git" ]; then
+  ERNIC_SHA="$(git -C "${PROJECT_DIR}" \
+    rev-parse --short HEAD 2>/dev/null \
+    || echo "unknown")"
+  echo "${ERNIC_SHA}" > \
+    "${SRC_DIR}/providers/rocm_ernic/SOURCE_SHA"
+  echo "  rocm-ernic SHA: ${ERNIC_SHA}"
+fi
+
+# --- Build with cmake ---
+echo ""
+echo "Configuring rdma-core..."
+mkdir -p "${CMAKE_BUILD}"
+cmake -S "${SRC_DIR}" -B "${CMAKE_BUILD}" \
+  -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DIOCTL_MODE=both \
+  -DNO_PYVERBS=1 \
+  -DNO_MAN_PAGES=1 \
+  -DENABLE_STATIC=0
+
+echo "Building rdma-core (${NPROC} jobs)..."
+cmake --build "${CMAKE_BUILD}" -j "${NPROC}"
+
+if $BUILD_ONLY; then
+  echo ""
+  echo "=== rdma-core built (no install) ==="
+  echo "  build dir : ${CMAKE_BUILD}"
+  exit 0
+fi
+
+echo "Installing rdma-core to ${INSTALL_DIR}..."
+cmake --install "${CMAKE_BUILD}"
+
+echo ""
+echo "=== rdma-core installed ==="
+echo "  libibverbs     : ${INSTALL_DIR}/lib/"
+echo "  librocm_ernic  : ${INSTALL_DIR}/lib/"
+echo "  headers        : ${INSTALL_DIR}/include/"

--- a/src/rocm_ernic_server.c
+++ b/src/rocm_ernic_server.c
@@ -1049,7 +1049,12 @@ int main(int argc, char *argv[])
     }
 
     /* Setup DMA callbacks */
+#ifdef LIBVFIO_USER_MAX_DMA_REGIONS
+    ret = vfu_setup_device_dma(vfu_ctx, LIBVFIO_USER_MAX_DMA_REGIONS,
+                               dma_register_cb, dma_unregister_cb);
+#else
     ret = vfu_setup_device_dma(vfu_ctx, dma_register_cb, dma_unregister_cb);
+#endif
     if (ret < 0) {
         err(EXIT_FAILURE, "vfu_setup_device_dma() failed");
     }


### PR DESCRIPTION
Add optional CMake targets for building the kernel driver modules via DKMS and for building rdma-core with the rocm_ernic provider. Both are gated behind options (ERNIC_BUILD_KMOD and ERNIC_RDMA_CORE_BUILD, default OFF) and excluded from ALL so normal builds are unaffected.

Kernel module DKMS targets (build-ernic-dkms,
install-ernic-dkms, remove-ernic-dkms) wrap a setup script that copies driver sources to /usr/src/ and drives dkms add/build/install. The dkms.conf and setup script follow the established rocm-xio pattern.

rdma-core targets (build-rdma-core, install-rdma-core) wrap a build script that downloads the upstream tarball, injects the rocm_ernic provider via the existing apply script, and builds with cmake.
