### PR TITLE
feat: add IP/RDMA byte counters, uptime, and stats summary to ernicctl

### DIFF
--- a/docs/service.rst
+++ b/docs/service.rst
@@ -216,17 +216,33 @@ Or use ``ernicctl`` which wraps ``systemctl``:
 
 The ``ernicctl status`` command shows a table of all
 instances with their PID, MAC, socket, VM attachment,
-liveness state, and log file path:
+IP and RDMA byte counts (TX/RX), liveness state,
+uptime, and log file path:
 
 .. code-block:: text
 
-   ID  ROLE      PID    MAC                SOCKET                         VM           STATE      LOG
-   1   manager   12345  02:a1:b2:c3:d4:01  /run/rocm-ernic/1.sock         qmp:2222     running    /var/log/rocm-ernic/1.log
-   2   worker    12346  02:a1:b2:c3:d4:02  /run/rocm-ernic/2.sock         qmp:2223     running    /var/log/rocm-ernic/2.log
-   3   worker    12347  02:a1:b2:c3:d4:03  /run/rocm-ernic/3.sock         -            running    /var/log/rocm-ernic/3.log
-   4   worker    0      02:a1:b2:c3:d4:04  /run/rocm-ernic/4.sock         -            dead       /var/log/rocm-ernic/4.log
+   ID  ROLE      PID    STATE      UPTIME     MAC                SOCKET                         VM           IP (TX/RX)      RDMA (TX/RX)    LOG
+   1   manager   12345  running    2h15m      02:a1:b2:c3:d4:01  /run/rocm-ernic/1.sock         67890:2222   1.2K/3.4K       45M/12M         /var/log/rocm-ernic/1.log
+   2   worker    12346  running    2h14m      02:a1:b2:c3:d4:02  /run/rocm-ernic/2.sock         67891:2223   0B/0B           0B/0B           /var/log/rocm-ernic/2.log
+   3   worker    12347  running    2h14m      02:a1:b2:c3:d4:03  /run/rocm-ernic/3.sock         -            -               -               /var/log/rocm-ernic/3.log
+   4   worker    0      dead       -          02:a1:b2:c3:d4:04  /run/rocm-ernic/4.sock         -            -               -               /var/log/rocm-ernic/4.log
 
-Pass ``--json`` for machine-readable output.
+The VM column shows ``vm_pid:ssh_port`` when a VM is
+attached, ``detached`` when detached, or ``-`` when no
+VM is associated. The IP and RDMA columns show
+TX/RX byte totals with auto-scaled units (B, K, M,
+G, T). The UPTIME column shows how long each server
+process has been running (``45s``, ``3m47s``,
+``2h15m``, ``3d04h``).
+
+Pass ``--json`` for machine-readable output (includes
+raw ``ip_bytes_tx``, ``ip_bytes_rx``,
+``rdma_bytes_tx``, ``rdma_bytes_rx`` fields).
+
+Pass ``--rate SECS`` to show byte deltas measured over
+a SECS-second window instead of cumulative totals.
+This is useful with ``watch`` to monitor live
+throughput.
 
 ernicctl Command Reference
 --------------------------
@@ -236,13 +252,30 @@ Service lifecycle
 
 .. code-block:: bash
 
-   ernicctl start              # systemctl start
-   ernicctl stop               # systemctl stop
-   ernicctl restart            # systemctl restart
-   ernicctl reload             # re-read env, adjust instances
-   ernicctl status [--json]    # show instance table
-   ernicctl logs [N]           # tail logs (instance N or all)
-   ernicctl stats [N]          # show stats (instance N or all)
+   ernicctl start                    # systemctl start
+   ernicctl stop                     # systemctl stop
+   ernicctl restart                  # systemctl restart
+   ernicctl reload                   # re-read env
+   ernicctl status [--json]          # instance table
+   ernicctl status --rate 5          # 5s byte deltas
+   ernicctl logs [N]                 # tail logs
+   ernicctl stats [N]                # raw stats dump
+   ernicctl stats --summary          # one-row summary
+
+The ``ernicctl stats --summary`` command prints a
+concise table with one row per instance:
+
+.. code-block:: text
+
+   ID  CONN        IP (TX/RX)      RDMA-SR (TX/RX) RDMA-RW (R/W)   MMIO (R/W)      CMDS    INTS    QPS  FLR
+   1   connected   1.2K/3.4K       45M/12M         8.1M/22M        123K/456K       89      789     3    0
+   2   connected   0B/0B           0B/0B           0B/0B           0B/0B           0       0       0    0
+
+Columns: CONN = connection state, RDMA-SR = Send/Recv
+bytes, RDMA-RW = Read/Write bytes, MMIO = register
+reads/writes, CMDS = commands processed, INTS =
+interrupts, QPS = active queue pairs, FLR = Function
+Level Reset count.
 
 Dynamic mesh management
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/service/ernicctl
+++ b/service/ernicctl
@@ -112,6 +112,96 @@ def pid_alive(pid):
         return False
 
 
+# ── Stats helpers ────────────────────────────────
+
+def parse_stats_file(path):
+    """Parse a .stats text file into {key: value}.
+
+    Integer values are returned as int; string values
+    (like connection state) are returned as str.
+    Returns empty dict if file is missing or unreadable.
+    """
+    result = {}
+    if not os.path.isfile(path):
+        return result
+    try:
+        with open(path) as fh:
+            for line in fh:
+                line = line.strip()
+                if " : " not in line:
+                    continue
+                key, _, val = line.partition(" : ")
+                key = key.strip()
+                val = val.strip()
+                try:
+                    result[key] = int(val)
+                except ValueError:
+                    result[key] = val
+    except OSError:
+        pass
+    return result
+
+
+def count_qps(path):
+    """Count QP sections in a raw stats file."""
+    count = 0
+    if not os.path.isfile(path):
+        return count
+    try:
+        with open(path) as fh:
+            for line in fh:
+                if line.strip().startswith("QP ") \
+                        and line.strip().endswith(":"):
+                    count += 1
+    except OSError:
+        pass
+    return count
+
+
+def format_bytes(n):
+    """Format byte count with auto-scaled short units.
+
+    Returns a compact string like '0B', '1.2K', '45M'.
+    """
+    if n < 0:
+        return "-"
+    units = ["B", "K", "M", "G", "T"]
+    val = float(n)
+    for u in units:
+        if val < 1024.0 or u == units[-1]:
+            if val == int(val) and val < 10000:
+                return f"{int(val)}{u}"
+            if val < 10:
+                return f"{val:.1f}{u}"
+            return f"{int(val)}{u}"
+        val /= 1024.0
+    return f"{int(val)}T"
+
+
+def format_txrx(tx, rx):
+    """Format a TX/RX pair as 'TX/RX'."""
+    return f"{format_bytes(tx)}/{format_bytes(rx)}"
+
+
+def read_all_stats():
+    """Read stats for every *.stats file in RUN_DIR.
+
+    Returns {instance_id_int: stats_dict}.
+    """
+    import glob
+    result = {}
+    for sf in glob.glob(
+        os.path.join(RUN_DIR, "*.stats")
+    ):
+        name = pathlib.Path(sf).stem
+        try:
+            inst_id = int(name)
+        except ValueError:
+            continue
+        result[inst_id] = parse_stats_file(sf)
+    return result
+
+
 # ── QMP helpers ──────────────────────────────────
 
 def qmp_send(qmp_socket, command):
@@ -205,17 +295,156 @@ def guest_ssh(ssh_user, ssh_port, command):
 
 # ── Subcommands: service lifecycle ───────────────
 
+def _get_uptime(pid):
+    """Return process uptime in seconds, or None."""
+    try:
+        with open("/proc/uptime") as f:
+            sys_up = float(f.read().split()[0])
+        with open(f"/proc/{pid}/stat") as f:
+            fields = f.read().rsplit(") ", 1)[1]
+            start_ticks = int(fields.split()[19])
+        hz = os.sysconf("SC_CLK_TCK")
+        age = sys_up - (start_ticks / hz)
+        return max(0, age)
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def format_duration(secs):
+    """Format seconds as compact duration string."""
+    if secs is None:
+        return "-"
+    s = int(secs)
+    if s < 60:
+        return f"{s}s"
+    m = s // 60
+    if m < 60:
+        return f"{m}m{s % 60:02d}s"
+    h = m // 60
+    if h < 24:
+        return f"{h}h{m % 60:02d}m"
+    d = h // 24
+    return f"{d}d{h % 24:02d}h"
+
+
+def _get_vm_info(inst):
+    """Build the VM column string from manifest."""
+    if not inst.get("vm") or not inst["vm"]:
+        return "-"
+    vm = inst["vm"]
+    if vm.get("attached"):
+        pid = vm.get("vm_pid", "?")
+        port = vm.get("ssh_port", "?")
+        return f"{pid}:{port}"
+    return "detached"
+
+
+def _get_vm_uptime(inst):
+    """Return formatted VM uptime, or '-'."""
+    if not inst.get("vm") or not inst["vm"]:
+        return "-"
+    vm = inst["vm"]
+    vm_pid = vm.get("vm_pid")
+    if not vm_pid or not vm.get("attached"):
+        return "-"
+    return format_duration(_get_uptime(vm_pid))
+
+
+def _get_byte_cols(stats):
+    """Compute IP and RDMA TX/RX strings."""
+    if not stats:
+        return "-", "-"
+    ip_tx = stats.get("total_ip_bytes_tx", 0)
+    ip_rx = stats.get("total_ip_bytes_rx", 0)
+    rdma_tx = (
+        stats.get("total_bytes_sent", 0)
+        + stats.get("total_bytes_rdma_write", 0)
+    )
+    rdma_rx = (
+        stats.get("total_bytes_received", 0)
+        + stats.get("total_bytes_rdma_read", 0)
+    )
+    return (
+        format_txrx(ip_tx, ip_rx),
+        format_txrx(rdma_tx, rdma_rx),
+    )
+
+
+def _delta_stats(s1, s2):
+    """Compute per-key delta between two stats dicts.
+
+    Returns None if either is empty.  Returns -1 for
+    any key whose value decreased (server restart).
+    """
+    if not s1 or not s2:
+        return None
+    out = {}
+    for k in s2:
+        if not isinstance(s2[k], int):
+            out[k] = s2[k]
+            continue
+        v1 = s1.get(k, 0)
+        v2 = s2[k]
+        if not isinstance(v1, int):
+            v1 = 0
+        out[k] = v2 - v1 if v2 >= v1 else -1
+    return out
+
+
 def cmd_status(args):
     m = read_manifest()
+    rate = getattr(args, "rate", None)
+
+    all_stats = read_all_stats()
+
+    if rate:
+        snap1 = {k: dict(v) for k, v in
+                 all_stats.items()}
+        time.sleep(rate)
+        all_stats = read_all_stats()
+        for iid in all_stats:
+            all_stats[iid] = _delta_stats(
+                snap1.get(iid, {}), all_stats[iid]
+            ) or {}
 
     if args.json:
         for inst in m["instances"]:
+            iid = inst["id"]
+            alive = pid_alive(inst["pid"])
             inst["state"] = (
-                "running" if pid_alive(inst["pid"])
-                else "dead"
+                "running" if alive else "dead"
             )
             inst["log_file"] = os.path.join(
-                LOG_DIR, f"{inst['id']}.log"
+                LOG_DIR, f"{iid}.log"
+            )
+            up = _get_uptime(inst["pid"]) if alive \
+                else None
+            inst["uptime_seconds"] = (
+                int(up) if up is not None else None
+            )
+            vm = inst.get("vm")
+            vm_pid = (
+                vm.get("vm_pid") if vm
+                and vm.get("attached") else None
+            )
+            vm_up = _get_uptime(vm_pid) \
+                if vm_pid else None
+            inst["vm_uptime_seconds"] = (
+                int(vm_up) if vm_up is not None
+                else None
+            )
+            st = all_stats.get(iid, {})
+            inst["ip_bytes_tx"] = st.get(
+                "total_ip_bytes_tx", 0)
+            inst["ip_bytes_rx"] = st.get(
+                "total_ip_bytes_rx", 0)
+            inst["rdma_bytes_tx"] = (
+                st.get("total_bytes_sent", 0)
+                + st.get("total_bytes_rdma_write", 0)
+            )
+            inst["rdma_bytes_rx"] = (
+                st.get("total_bytes_received", 0)
+                + st.get("total_bytes_rdma_read", 0)
             )
         print(json.dumps(m, indent=2))
         return
@@ -226,23 +455,26 @@ def cmd_status(args):
         return
 
     fmt = (
-        "{:<4} {:<9} {:<7} {:<19}"
-        " {:<30} {:<12} {:<10} {}"
+        "{:<4} {:<9} {:<7} {:<10} {:<10}"
+        " {:<19} {:<30} {:<12} {:<10}"
+        " {:<15} {:<15} {}"
     )
     print(fmt.format(
-        "ID", "ROLE", "PID", "MAC",
-        "SOCKET", "VM", "STATE", "LOG",
+        "ID", "ROLE", "PID", "STATE", "UPTIME",
+        "MAC", "SOCKET", "VM", "VM_UPTIME",
+        "IP (TX/RX)", "RDMA (TX/RX)", "LOG",
     ))
     for inst in m["instances"]:
         alive = pid_alive(inst["pid"])
         state = "running" if alive else "dead"
-        vm_info = "-"
-        if inst.get("vm") and inst["vm"]:
-            vm = inst["vm"]
-            if vm.get("attached"):
-                vm_info = f"qmp:{vm.get('ssh_port', '?')}"
-            else:
-                vm_info = "detached"
+        vm_info = _get_vm_info(inst)
+        vm_up = _get_vm_uptime(inst)
+        st = all_stats.get(inst["id"], {})
+        ip_col, rdma_col = _get_byte_cols(st)
+        uptime = format_duration(
+            _get_uptime(inst["pid"]) if alive
+            else None
+        )
         logfile = os.path.join(
             LOG_DIR, f"{inst['id']}.log"
         )
@@ -250,10 +482,14 @@ def cmd_status(args):
             inst["id"],
             inst["role"],
             inst["pid"] if alive else 0,
+            state,
+            uptime,
             inst["mac"],
             inst["socket"],
             vm_info,
-            state,
+            vm_up,
+            ip_col,
+            rdma_col,
             logfile,
         ))
 
@@ -305,7 +541,87 @@ def cmd_logs(args):
         subprocess.run(["tail", "-f"] + logs)
 
 
+def _stats_summary_row(iid, stats, sf):
+    """Build one summary-table row for an instance."""
+    if not stats:
+        return (str(iid), "-", "-", "-",
+                "-", "-", "-", "-", "-", "-")
+    conn = stats.get("connection", "-")
+    if isinstance(conn, str) and len(conn) > 10:
+        conn = conn[:10]
+    ip_col = format_txrx(
+        stats.get("total_ip_bytes_tx", 0),
+        stats.get("total_ip_bytes_rx", 0),
+    )
+    sr_col = format_txrx(
+        stats.get("total_bytes_sent", 0),
+        stats.get("total_bytes_received", 0),
+    )
+    rw_col = format_txrx(
+        stats.get("total_bytes_rdma_read", 0),
+        stats.get("total_bytes_rdma_write", 0),
+    )
+    mmio_r = stats.get("mmio_reads_total", 0)
+    mmio_w = stats.get("mmio_writes_total", 0)
+    if not isinstance(mmio_r, int):
+        mmio_r = 0
+    if not isinstance(mmio_w, int):
+        mmio_w = 0
+    mmio_col = format_txrx(mmio_r, mmio_w)
+    cmds = stats.get("commands", 0)
+    ints = stats.get("interrupts", 0)
+    qps = count_qps(sf)
+    flr = stats.get("flr_reset_count", 0)
+    return (
+        str(iid), conn, ip_col, sr_col,
+        rw_col, mmio_col,
+        str(cmds), str(ints),
+        str(qps), str(flr),
+    )
+
+
+def _print_stats_summary(inst_id):
+    """Print a one-row-per-instance summary table."""
+    import glob
+    fmt = (
+        "{:<4} {:<11} {:<15} {:<15}"
+        " {:<15} {:<15}"
+        " {:<7} {:<7} {:<4} {}"
+    )
+    print(fmt.format(
+        "ID", "CONN",
+        "IP (TX/RX)", "RDMA-SR (TX/RX)",
+        "RDMA-RW (R/W)", "MMIO (R/W)",
+        "CMDS", "INTS", "QPS", "FLR",
+    ))
+    if inst_id:
+        sf = os.path.join(
+            RUN_DIR, f"{inst_id}.stats"
+        )
+        stats = parse_stats_file(sf)
+        row = _stats_summary_row(inst_id, stats, sf)
+        print(fmt.format(*row))
+    else:
+        for sf in sorted(
+            glob.glob(
+                os.path.join(RUN_DIR, "*.stats")
+            )
+        ):
+            name = pathlib.Path(sf).stem
+            try:
+                iid = int(name)
+            except ValueError:
+                continue
+            stats = parse_stats_file(sf)
+            row = _stats_summary_row(iid, stats, sf)
+            print(fmt.format(*row))
+
+
 def cmd_stats(args):
+    if getattr(args, "summary", False):
+        _print_stats_summary(args.instance)
+        return
+
     inst_id = args.instance
     if inst_id:
         sf = os.path.join(RUN_DIR, f"{inst_id}.stats")
@@ -878,6 +1194,11 @@ def build_parser():
         "--json", action="store_true",
         help="Output as JSON",
     )
+    sp.add_argument(
+        "--rate", type=int, default=None,
+        metavar="SECS",
+        help="Show byte deltas over SECS seconds",
+    )
 
     sub.add_parser("start", help="Start the service")
     sub.add_parser("stop", help="Stop the service")
@@ -902,6 +1223,10 @@ def build_parser():
     sp.add_argument(
         "instance", nargs="?", type=int, default=None,
         help="Instance ID (omit for all)",
+    )
+    sp.add_argument(
+        "--summary", action="store_true",
+        help="Concise one-row-per-instance table",
     )
 
     # -- dynamic mesh --

--- a/src/from-qemu/hw/rdma/vmw/pvrdma.h
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma.h
@@ -110,6 +110,8 @@ typedef struct PVRDMADevStats {
     uint64_t total_bytes_received;   /* Total bytes received across all QPs */
     uint64_t total_bytes_rdma_read;  /* Total bytes read via RDMA Read */
     uint64_t total_bytes_rdma_write; /* Total bytes written via RDMA Write */
+    uint64_t total_ip_bytes_tx;      /* Total IP/Ethernet bytes transmitted */
+    uint64_t total_ip_bytes_rx;      /* Total IP/Ethernet bytes received */
     uint64_t flr_reset_count;        /* PCI Function Level Reset count */
 } PVRDMADevStats;
 

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_eth.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_eth.c
@@ -246,6 +246,7 @@ void pvrdma_eth_process_tx(PVRDMADev *dev)
 
         /* Process Ethernet frame */
         pvrdma_eth_rx_frame(dev, packet_vaddr, packet_len);
+        dev->stats.total_ip_bytes_tx += packet_len;
 
         /* Mark descriptor as done */
         desc.status |= ROCM_ERNIC_ETH_DESC_STATUS_DD;

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_main.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_main.c
@@ -185,6 +185,10 @@ void pvrdma_write_stats_impl(PVRDMADev *dev)
             "total_bytes_rdma_read", dev->stats.total_bytes_rdma_read);
     fprintf(fp, "  %-*s : %" PRIu64 "\n", STATS_LABEL_WIDTH,
             "total_bytes_rdma_write", dev->stats.total_bytes_rdma_write);
+    fprintf(fp, "  %-*s : %" PRIu64 "\n", STATS_LABEL_WIDTH,
+            "total_ip_bytes_tx", dev->stats.total_ip_bytes_tx);
+    fprintf(fp, "  %-*s : %" PRIu64 "\n", STATS_LABEL_WIDTH,
+            "total_ip_bytes_rx", dev->stats.total_ip_bytes_rx);
 #undef STATS_LABEL_WIDTH
     fprintf(fp, "\n");
 

--- a/src/from-qemu/utils/eth_rx_inject.c
+++ b/src/from-qemu/utils/eth_rx_inject.c
@@ -94,6 +94,7 @@ int eth_rx_inject_frame(PVRDMADev *dev, const void *frame_data, size_t len)
 
     /* Advance tail pointer */
     eth->rx_tail = next_tail;
+    dev->stats.total_ip_bytes_rx += len;
 
     /* Set interrupt */
     eth->icr |= ROCM_ERNIC_ETH_ICR_RX_PACKET;


### PR DESCRIPTION
Add per-instance IP and RDMA byte counters to the
rocm-ernic server and surface them in ernicctl status and a new ernicctl stats --summary view.

Server (C):
- Add total_ip_bytes_tx and total_ip_bytes_rx to PVRDMADevStats; increment in pvrdma_eth_process_tx (VM TX) and eth_rx_inject_frame (VM RX); write both counters in pvrdma_write_stats_impl.

ernicctl status:
- Add IP (TX/RX) and RDMA (TX/RX) columns showing auto-scaled byte counts (B, K, M, G, T) per instance.
- Add UPTIME and VM_UPTIME columns derived from /proc/<pid>/stat process start time.
- Change VM column from "qmp:<port>" to "<vm_pid>:<ssh_port>" for easy process identification.
- Move STATE and UPTIME columns after PID, before MAC.
- Add --rate SECS option: takes two snapshots separated by SECS seconds and displays the byte deltas.
- Add uptime_seconds, vm_uptime_seconds, ip_bytes_tx, ip_bytes_rx, rdma_bytes_tx, rdma_bytes_rx to the --json output.

ernicctl stats --summary:
- New one-row-per-instance summary table with columns: ID, CONN, IP (TX/RX), RDMA-SR (TX/RX), RDMA-RW (R/W), MMIO (R/W), CMDS, INTS, QPS, FLR.
- Parses the raw .stats text files; reuses the same format_bytes/format_txrx helpers as status.

Documentation:
- Update docs/service.rst with new column layout, --rate, and --summary examples.

Verified: IP counters confirmed via ICMP ping between two VMs (29K TX/RX after 20 pings); --rate captures live deltas; stats --summary renders correctly with watch.