### PR TITLE
feat: add RDMA stress-test playbook and variables

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -7,6 +7,7 @@ Apfelbaum
 Async
 BARs
 BW
+bidir
 Backend
 Backends
 Breathe
@@ -307,6 +308,7 @@ ns
 num
 numa
 nutanix
+overridable
 nvme
 oneline
 openssh

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -47,6 +47,9 @@ ansible-playbook playbooks/sanity-tests.yml
 
 # Full performance sweep (BW + latency + reliability)
 ansible-playbook playbooks/performance-tests.yml
+
+# Stress tests (multi-QP, bidir, soak, churn, etc.)
+ansible-playbook playbooks/stress-tests.yml
 ```
 
 ## Variable Overrides
@@ -71,6 +74,14 @@ ansible-playbook playbooks/performance-tests.yml \
   -e ernic_perf_bw_iters=200 \
   -e ernic_perf_reliability_runs=10
 
+# Run stress tests with a 1-hour soak
+ansible-playbook playbooks/stress-tests.yml \
+  -e ernic_stress_soak_duration=3600
+
+# Run stress tests with 50k iterations
+ansible-playbook playbooks/stress-tests.yml \
+  -e ernic_stress_high_iters=50000
+
 # Specify a golden backing image for overlays
 ansible-playbook site.yml \
   -e ernic_vm_backing=/path/to/backing.qcow2
@@ -94,7 +105,8 @@ ansible/
 │   ├── vm-create.yml          # Golden image + VM launch
 │   ├── guest-setup.yml        # Driver + rdma-core
 │   ├── sanity-tests.yml       # iperf3 + perftest
-│   └── performance-tests.yml  # Full BW/lat sweeps
+│   ├── performance-tests.yml  # Full BW/lat sweeps
+│   └── stress-tests.yml       # Multi-QP, soak, churn
 └── templates/
     └── rocm-ernic.env.j2 # Env file template
 ```
@@ -129,3 +141,39 @@ ansible/
    reliability at 64 KB and `ibv_rc_pingpong` rounds.
    Timestamped CSV files are written to
    `docs/perf-results/` for easy before/after comparison.
+
+6. **stress-tests** exercises the emulated RDMA device
+   under conditions the performance sweep never touches.
+   Eight test sections run sequentially:
+
+   - **Multi-QP** -- `ib_send_bw` / `ib_write_bw` with
+     `-q 2`, `-q 4`, `-q 8` queue pairs at 64 KB.
+   - **Bidirectional** -- `--bidirectional` flag at 64 KB,
+     256 KB, and 1 MB to test full-duplex traffic.
+   - **Duration soak** -- `--duration N` sustained load
+     (default 300 s) with periodic `ernicctl stats`
+     polling to a time-series CSV.
+   - **Concurrent verbs** -- `ib_send_bw` and
+     `ib_write_bw` running simultaneously on different
+     perftest ports for `ernic_stress_concurrent_duration`
+     seconds.
+   - **High iterations** -- `-n 10000` (overridable) at
+     64 KB and 1 MB to detect slow resource leaks.
+   - **QP churn** -- rapid create/destroy cycles via
+     `ibv_rc_pingpong` (default 50 cycles).
+   - **Resource limits** -- sequential QP creation up to
+     64 attempts to find the maximum.
+   - **iperf3 TCP baseline** -- TCP throughput over the
+     emulated Ethernet NICs for comparison with RDMA
+     numbers.
+
+   Override any knob via `-e`:
+
+   ```
+   ernic_stress_multi_qp_counts  [2, 4, 8]
+   ernic_stress_bidir_sizes      [65536, 262144, 1048576]
+   ernic_stress_soak_duration    300  (seconds)
+   ernic_stress_high_iters       10000
+   ernic_stress_qp_churn_cycles  50
+   ernic_stress_concurrent_duration  60  (seconds)
+   ```

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -68,6 +68,20 @@ ernic_perf_reliability_size: 65536
 ernic_perf_pingpong_iters: 100
 ernic_perf_pingpong_size: 4096
 
+# ── Stress-test defaults ─────────────────────────
+ernic_stress_multi_qp_counts:
+  - 2
+  - 4
+  - 8
+ernic_stress_bidir_sizes:
+  - 65536
+  - 262144
+  - 1048576
+ernic_stress_soak_duration: 300
+ernic_stress_high_iters: 10000
+ernic_stress_qp_churn_cycles: 50
+ernic_stress_concurrent_duration: 60
+
 # ── Feature gates ────────────────────────────────
 ernic_skip_build: false
 ernic_skip_golden_image: false

--- a/ansible/playbooks/stress-tests.yml
+++ b/ansible/playbooks/stress-tests.yml
@@ -491,28 +491,35 @@
 
           sleep 3
 
-          RAW_SEND=$({{ vm2_ssh }} "
+          SEND_OUT=$(mktemp /tmp/stress-conc-send.XXXXXX)
+          WRITE_OUT=$(mktemp /tmp/stress-conc-write.XXXXXX)
+
+          {{ vm2_ssh }} "
             timeout $TIMEOUT \
               ib_send_bw -d $DEV -x 1 -s $SZ \
               --duration $DUR -p 18515 \
               --report_gbits $SERVER_IP 2>&1
-          ") &
+          " > "$SEND_OUT" 2>&1 &
           SEND_PID=$!
 
           sleep 2
 
-          RAW_WRITE=$({{ vm2_ssh }} "
+          {{ vm2_ssh }} "
             timeout $TIMEOUT \
               ib_write_bw -d $DEV -x 1 -s $SZ \
               --duration $DUR -p 18516 \
               --report_gbits $SERVER_IP 2>&1
-          ") &
+          " > "$WRITE_OUT" 2>&1 &
           WRITE_PID=$!
 
           wait $SEND_PID
           SEND_RC=$?
           wait $WRITE_PID
           WRITE_RC=$?
+
+          RAW_SEND=$(cat "$SEND_OUT")
+          RAW_WRITE=$(cat "$WRITE_OUT")
+          rm -f "$SEND_OUT" "$WRITE_OUT"
 
           PASS_COUNT=0
           for VERB_NAME in send write; do
@@ -866,7 +873,7 @@
         cmd: >-
           grep -c 'FAIL\|NODATA'
           "{{ stress_csv }}"
-          2>/dev/null || echo 0
+          2>/dev/null || true
       register: stress_fail_count
       changed_when: false
 

--- a/ansible/playbooks/stress-tests.yml
+++ b/ansible/playbooks/stress-tests.yml
@@ -273,7 +273,7 @@
             sudo systemctl reset-failed $UNIT 2>/dev/null;
             sudo systemd-run --unit=$UNIT \
               bash -c '$TOOL -d $DEV -x 1 \
-                -s $SZ -n 100 --tx-depth=10 \
+                -s $SZ -n 100 \
                 --bidirectional --report_gbits \
                 >/tmp/${UNIT}.log 2>&1';
             sleep 1
@@ -284,7 +284,7 @@
           RAW=$({{ vm2_ssh }} "
             timeout 120 \
               $TOOL -d $DEV -x 1 -s $SZ -n 100 \
-              --tx-depth=10 --bidirectional \
+              --bidirectional \
               --report_gbits \
               $SERVER_IP 2>&1
           ")

--- a/ansible/playbooks/stress-tests.yml
+++ b/ansible/playbooks/stress-tests.yml
@@ -1,0 +1,888 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Play 6: RDMA stress tests.
+#
+# Exercises the emulated RDMA device under conditions
+# the performance-tests.yml never touches: multi-QP,
+# bidirectional, long-duration soak, concurrent verb
+# mix, QP churn, resource limits, and iperf3 TCP
+# baseline.
+#
+# This play assumes exactly two VMs with IPs already
+# configured by guest-setup.yml and that the sanity
+# tests have passed.
+#
+# Usage:
+#   ansible-playbook playbooks/stress-tests.yml
+#
+# Override parameters:
+#   ansible-playbook playbooks/stress-tests.yml \
+#     -e ernic_stress_soak_duration=3600 \
+#     -e ernic_stress_high_iters=50000
+
+---
+- name: Stress tests -- multi-QP, bidir, soak, churn
+  hosts: localhost
+  gather_facts: true
+  vars_files:
+    - ../group_vars/all.yml
+
+  vars:
+    vm1_ssh: >-
+      ssh -o StrictHostKeyChecking=no
+      -o UserKnownHostsFile=/dev/null
+      -p {{ ernic_vm_ssh_base_port | int }}
+      {{ ernic_vm_ssh_user }}@localhost
+    vm2_ssh: >-
+      ssh -o StrictHostKeyChecking=no
+      -o UserKnownHostsFile=/dev/null
+      -p {{ ernic_vm_ssh_base_port | int + 1 }}
+      {{ ernic_vm_ssh_user }}@localhost
+    vm1_ip: "{{ ernic_nic_subnet }}.10"
+    vm2_ip: "{{ ernic_nic_subnet }}.20"
+    rdma_dev: rocep1s0
+
+    multi_qp_counts: >-
+      {{ ernic_stress_multi_qp_counts
+         | default([2, 4, 8]) }}
+    bidir_sizes: >-
+      {{ ernic_stress_bidir_sizes
+         | default([65536, 262144, 1048576]) }}
+    soak_duration: >-
+      {{ ernic_stress_soak_duration
+         | default(300) | int }}
+    high_iters: >-
+      {{ ernic_stress_high_iters
+         | default(10000) | int }}
+    qp_churn_cycles: >-
+      {{ ernic_stress_qp_churn_cycles
+         | default(50) | int }}
+    concurrent_duration: >-
+      {{ ernic_stress_concurrent_duration
+         | default(60) | int }}
+
+    iperf_bw: >-
+      {{ ernic_iperf_bandwidth
+         | regex_replace('(?i)iB/s$', '')
+         | regex_replace('(?i)B/s$', '') }}
+    iperf_dur: >-
+      {{ ernic_iperf_duration | default(10) }}
+
+    kill_perftest: >-
+      sudo pkill -9 ib_send_bw  2>/dev/null;
+      sudo pkill -9 ib_write_bw 2>/dev/null;
+      sudo pkill -9 ib_read_bw  2>/dev/null;
+      sudo pkill -9 ib_send_lat  2>/dev/null;
+      sudo pkill -9 ib_write_lat 2>/dev/null;
+      sudo pkill -9 ib_read_lat  2>/dev/null;
+      sudo pkill -9 ibv_rc_pingpong 2>/dev/null;
+      sudo pkill -9 iperf3 2>/dev/null;
+      true
+
+    bw_verbs:
+      - { tool: ib_send_bw,  label: send  }
+      - { tool: ib_write_bw, label: write }
+
+    ts: >-
+      {{ ansible_date_time.date }}-{{
+         ansible_date_time.hour }}{{
+         ansible_date_time.minute }}{{
+         ansible_date_time.second }}
+    results_dir: >-
+      {{ ernic_project_root }}/docs/perf-results
+    stress_csv: >-
+      {{ results_dir }}/stress-{{ ts }}.csv
+
+  tasks:
+
+    - name: Skip if tests disabled
+      ansible.builtin.meta: end_play
+      when: ernic_skip_tests | bool
+
+    # ─────────────────────────────────────────────────
+    # Setup
+    # ─────────────────────────────────────────────────
+    - name: Kill stale perftest on VM1
+      ansible.builtin.shell:
+        cmd: >-
+          {{ vm1_ssh }}
+          '{{ kill_perftest }}'
+      changed_when: false
+      failed_when: false
+
+    - name: Kill stale perftest on VM2
+      ansible.builtin.shell:
+        cmd: >-
+          {{ vm2_ssh }}
+          '{{ kill_perftest }}'
+      changed_when: false
+      failed_when: false
+
+    - name: Wait for port 18515 to be released
+      ansible.builtin.pause:
+        seconds: 2
+
+    - name: Detect RDMA device name on VM1
+      ansible.builtin.shell:
+        cmd: >-
+          {{ vm1_ssh }}
+          'ibv_devices
+          | grep -oE "rocep[0-9]+s[0-9]+"
+          | head -1'
+      register: rdma_dev_detect
+      changed_when: false
+      failed_when: false
+
+    - name: Set RDMA device name
+      ansible.builtin.set_fact:
+        rdma_dev: >-
+          {{ rdma_dev_detect.stdout | trim
+             | default('rocep1s0', true) }}
+
+    - name: Create results directory
+      ansible.builtin.file:
+        path: "{{ results_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Write stress CSV header
+      ansible.builtin.copy:
+        dest: "{{ stress_csv }}"
+        content: >-
+          section,test,detail,result,value
+        mode: "0644"
+
+    - name: Display stress test configuration
+      ansible.builtin.debug:
+        msg:
+          - "=== Stress Test Config ==="
+          - "Device:             {{ rdma_dev }}"
+          - "Multi-QP counts:    {{ multi_qp_counts }}"
+          - "Bidir sizes:        {{ bidir_sizes }}"
+          - "Soak duration:      {{ soak_duration }}s"
+          - "High iterations:    {{ high_iters }}"
+          - "QP churn cycles:    {{ qp_churn_cycles }}"
+          - "Concurrent dur:     {{ concurrent_duration }}s"
+          - "iperf3 bandwidth:   {{ iperf_bw }}"
+          - "iperf3 duration:    {{ iperf_dur }}s"
+          - "Results:            {{ stress_csv }}"
+
+    # ─────────────────────────────────────────────────
+    # 1. Multi-QP bandwidth (-q flag)
+    # ─────────────────────────────────────────────────
+    - name: "Multi-QP: {{ item.0.label }} -q {{ item.1 }}"
+      ansible.builtin.shell:
+        cmd: |
+          TOOL="{{ item.0.tool }}"
+          DEV="{{ rdma_dev }}"
+          SZ=65536
+          QPS="{{ item.1 }}"
+          SERVER_IP="{{ vm1_ip }}"
+          UNIT="stress-mqp-$TOOL-q$QPS"
+
+          {{ vm1_ssh }} '{{ kill_perftest }}'
+          {{ vm2_ssh }} '{{ kill_perftest }}'
+          sleep 2
+
+          {{ vm1_ssh }} "
+            sudo systemctl stop $UNIT 2>/dev/null;
+            sudo systemctl reset-failed $UNIT 2>/dev/null;
+            sudo systemd-run --unit=$UNIT \
+              bash -c '$TOOL -d $DEV -x 1 \
+                -s $SZ -n 100 -q $QPS \
+                --report_gbits \
+                >/tmp/${UNIT}.log 2>&1';
+            sleep 1
+          "
+
+          sleep 3
+
+          RAW=$({{ vm2_ssh }} "
+            timeout 120 \
+              $TOOL -d $DEV -x 1 -s $SZ -n 100 \
+              -q $QPS --report_gbits \
+              $SERVER_IP 2>&1
+          ")
+          RC=$?
+
+          if [ $RC -ne 0 ]; then
+            echo "multi_qp,{{ item.0.label }},q=$QPS,FAIL,$RC" \
+              >> "{{ stress_csv }}"
+            echo "FAIL rc=$RC"
+            echo "$RAW"
+            exit 0
+          fi
+
+          LINE=$(echo "$RAW" \
+            | grep -E '^\s+[0-9]' | tail -1)
+          if [ -z "$LINE" ]; then
+            echo "multi_qp,{{ item.0.label }},q=$QPS,NODATA,0" \
+              >> "{{ stress_csv }}"
+            echo "NODATA"
+            exit 0
+          fi
+
+          PEAK=$(echo "$LINE" | awk '{print $3}')
+          AVG=$(echo "$LINE"  | awk '{print $4}')
+          PEAK_GB=$(echo "scale=2; $PEAK / 8" \
+            | bc -l 2>/dev/null || echo "$PEAK")
+          AVG_GB=$(echo "scale=2; $AVG / 8" \
+            | bc -l 2>/dev/null || echo "$AVG")
+
+          echo "multi_qp,{{ item.0.label }},q=$QPS,PASS,peak=${PEAK_GB}_avg=${AVG_GB}_GBs" \
+            >> "{{ stress_csv }}"
+          echo "{{ item.0.label }} q=$QPS: peak=${PEAK_GB} avg=${AVG_GB} GB/s"
+      register: mqp_result
+      changed_when: false
+      failed_when: false
+      loop: >-
+        {{ bw_verbs | product(multi_qp_counts) | list }}
+      loop_control:
+        label: "{{ item.0.label }} -q {{ item.1 }}"
+
+    - name: Display multi-QP results
+      ansible.builtin.debug:
+        msg: >-
+          {{ item.stdout_lines | default(['(no output)']) }}
+      loop: "{{ mqp_result.results }}"
+      loop_control:
+        label: >-
+          {{ item.item.0.label }} -q {{ item.item.1 }}
+      when: item.stdout is defined
+
+    # ─────────────────────────────────────────────────
+    # 2. Bidirectional bandwidth (--bidirectional)
+    # ─────────────────────────────────────────────────
+    - name: "Bidir: {{ item.0.label }} @ {{ item.1 }} B"
+      ansible.builtin.shell:
+        cmd: |
+          TOOL="{{ item.0.tool }}"
+          DEV="{{ rdma_dev }}"
+          SZ="{{ item.1 }}"
+          SERVER_IP="{{ vm1_ip }}"
+          UNIT="stress-bidir-$TOOL-$SZ"
+
+          {{ vm1_ssh }} '{{ kill_perftest }}'
+          {{ vm2_ssh }} '{{ kill_perftest }}'
+          sleep 2
+
+          {{ vm1_ssh }} "
+            sudo systemctl stop $UNIT 2>/dev/null;
+            sudo systemctl reset-failed $UNIT 2>/dev/null;
+            sudo systemd-run --unit=$UNIT \
+              bash -c '$TOOL -d $DEV -x 1 \
+                -s $SZ -n 100 --tx-depth=10 \
+                --bidirectional --report_gbits \
+                >/tmp/${UNIT}.log 2>&1';
+            sleep 1
+          "
+
+          sleep 3
+
+          RAW=$({{ vm2_ssh }} "
+            timeout 120 \
+              $TOOL -d $DEV -x 1 -s $SZ -n 100 \
+              --tx-depth=10 --bidirectional \
+              --report_gbits \
+              $SERVER_IP 2>&1
+          ")
+          RC=$?
+
+          if [ $RC -ne 0 ]; then
+            echo "bidir,{{ item.0.label }},$SZ,FAIL,$RC" \
+              >> "{{ stress_csv }}"
+            echo "FAIL rc=$RC"
+            echo "$RAW"
+            exit 0
+          fi
+
+          LINE=$(echo "$RAW" \
+            | grep -E '^\s+[0-9]' | tail -1)
+          if [ -z "$LINE" ]; then
+            echo "bidir,{{ item.0.label }},$SZ,NODATA,0" \
+              >> "{{ stress_csv }}"
+            echo "NODATA"
+            exit 0
+          fi
+
+          PEAK=$(echo "$LINE" | awk '{print $3}')
+          AVG=$(echo "$LINE"  | awk '{print $4}')
+          PEAK_GB=$(echo "scale=2; $PEAK / 8" \
+            | bc -l 2>/dev/null || echo "$PEAK")
+          AVG_GB=$(echo "scale=2; $AVG / 8" \
+            | bc -l 2>/dev/null || echo "$AVG")
+
+          echo "bidir,{{ item.0.label }},$SZ,PASS,peak=${PEAK_GB}_avg=${AVG_GB}_GBs" \
+            >> "{{ stress_csv }}"
+          echo "{{ item.0.label }} bidir $SZ: peak=${PEAK_GB} avg=${AVG_GB} GB/s"
+      register: bidir_result
+      changed_when: false
+      failed_when: false
+      loop: >-
+        {{ bw_verbs | product(bidir_sizes) | list }}
+      loop_control:
+        label: "{{ item.0.label }} bidir @ {{ item.1 }}"
+
+    - name: Display bidirectional results
+      ansible.builtin.debug:
+        msg: >-
+          {{ item.stdout_lines | default(['(no output)']) }}
+      loop: "{{ bidir_result.results }}"
+      loop_control:
+        label: >-
+          {{ item.item.0.label }} @ {{ item.item.1 }}
+      when: item.stdout is defined
+
+    # ─────────────────────────────────────────────────
+    # 3. Duration-based soak (--duration)
+    # ─────────────────────────────────────────────────
+    - name: "Soak: {{ item.label }} --duration {{ soak_duration }}"
+      ansible.builtin.shell:
+        cmd: |
+          TOOL="{{ item.tool }}"
+          DEV="{{ rdma_dev }}"
+          SZ=65536
+          DUR="{{ soak_duration }}"
+          SERVER_IP="{{ vm1_ip }}"
+          UNIT="stress-soak-$TOOL"
+          TIMEOUT=$(( DUR + 60 ))
+          STATS_LOG="{{ results_dir }}/soak-stats-{{ item.label }}-{{ ts }}.csv"
+
+          {{ vm1_ssh }} '{{ kill_perftest }}'
+          {{ vm2_ssh }} '{{ kill_perftest }}'
+          sleep 2
+
+          echo "ts,conn,ip_txrx,rdma_sr,rdma_rw,mmio,cmds,ints,qps,flr" \
+            > "$STATS_LOG"
+
+          {{ vm1_ssh }} "
+            sudo systemctl stop $UNIT 2>/dev/null;
+            sudo systemctl reset-failed $UNIT 2>/dev/null;
+            sudo systemd-run --unit=$UNIT \
+              bash -c '$TOOL -d $DEV -x 1 \
+                -s $SZ --duration $DUR \
+                --report_gbits \
+                >/tmp/${UNIT}.log 2>&1';
+            sleep 1
+          "
+
+          sleep 3
+
+          POLL_PID=""
+          if command -v ernicctl >/dev/null 2>&1; then
+            (
+              END=$(( $(date +%s) + DUR + 30 ))
+              while [ "$(date +%s)" -lt "$END" ]; do
+                ROW=$(sudo ernicctl stats --summary \
+                  2>/dev/null | tail -n +2 \
+                  | head -1 \
+                  | awk '{
+                    printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s",
+                      strftime("%H:%M:%S"),
+                      $2,$3,$4,$5,$6,$7,$8,$9,$10
+                  }')
+                if [ -n "$ROW" ]; then
+                  echo "$ROW" >> "$STATS_LOG"
+                fi
+                sleep 30
+              done
+            ) &
+            POLL_PID=$!
+          fi
+
+          RAW=$({{ vm2_ssh }} "
+            timeout $TIMEOUT \
+              $TOOL -d $DEV -x 1 -s $SZ \
+              --duration $DUR --report_gbits \
+              $SERVER_IP 2>&1
+          ")
+          RC=$?
+
+          if [ -n "$POLL_PID" ]; then
+            kill "$POLL_PID" 2>/dev/null
+            wait "$POLL_PID" 2>/dev/null
+          fi
+
+          if [ $RC -ne 0 ]; then
+            echo "soak,{{ item.label }},${DUR}s,FAIL,$RC" \
+              >> "{{ stress_csv }}"
+            echo "FAIL rc=$RC"
+            echo "$RAW"
+            exit 0
+          fi
+
+          LINE=$(echo "$RAW" \
+            | grep -E '^\s+[0-9]' | tail -1)
+          if [ -z "$LINE" ]; then
+            echo "soak,{{ item.label }},${DUR}s,NODATA,0" \
+              >> "{{ stress_csv }}"
+            echo "NODATA"
+            exit 0
+          fi
+
+          PEAK=$(echo "$LINE" | awk '{print $3}')
+          AVG=$(echo "$LINE"  | awk '{print $4}')
+          PEAK_GB=$(echo "scale=2; $PEAK / 8" \
+            | bc -l 2>/dev/null || echo "$PEAK")
+          AVG_GB=$(echo "scale=2; $AVG / 8" \
+            | bc -l 2>/dev/null || echo "$AVG")
+
+          echo "soak,{{ item.label }},${DUR}s,PASS,peak=${PEAK_GB}_avg=${AVG_GB}_GBs" \
+            >> "{{ stress_csv }}"
+          echo "{{ item.label }} soak ${DUR}s: peak=${PEAK_GB} avg=${AVG_GB} GB/s"
+          echo "Stats log: $STATS_LOG"
+      register: soak_result
+      changed_when: false
+      failed_when: false
+      loop: "{{ bw_verbs }}"
+      loop_control:
+        label: "{{ item.label }} soak {{ soak_duration }}s"
+
+    - name: Display soak results
+      ansible.builtin.debug:
+        msg: >-
+          {{ item.stdout_lines | default(['(no output)']) }}
+      loop: "{{ soak_result.results }}"
+      loop_control:
+        label: "{{ item.item.label }}"
+      when: item.stdout is defined
+
+    # ─────────────────────────────────────────────────
+    # 4. Concurrent verb mix
+    # ─────────────────────────────────────────────────
+    - name: "Concurrent: send + write for {{ concurrent_duration }}s"
+      ansible.builtin.shell:
+        cmd: |
+          DEV="{{ rdma_dev }}"
+          SZ=65536
+          DUR="{{ concurrent_duration }}"
+          SERVER_IP="{{ vm1_ip }}"
+          TIMEOUT=$(( DUR + 60 ))
+
+          {{ vm1_ssh }} '{{ kill_perftest }}'
+          {{ vm2_ssh }} '{{ kill_perftest }}'
+          sleep 2
+
+          {{ vm1_ssh }} "
+            sudo systemctl stop stress-conc-send 2>/dev/null;
+            sudo systemctl reset-failed stress-conc-send 2>/dev/null;
+            sudo systemd-run --unit=stress-conc-send \
+              bash -c 'ib_send_bw -d $DEV -x 1 \
+                -s $SZ --duration $DUR -p 18515 \
+                --report_gbits \
+                >/tmp/stress-conc-send.log 2>&1';
+            sleep 1
+          "
+
+          sleep 2
+
+          {{ vm1_ssh }} "
+            sudo systemctl stop stress-conc-write 2>/dev/null;
+            sudo systemctl reset-failed stress-conc-write 2>/dev/null;
+            sudo systemd-run --unit=stress-conc-write \
+              bash -c 'ib_write_bw -d $DEV -x 1 \
+                -s $SZ --duration $DUR -p 18516 \
+                --report_gbits \
+                >/tmp/stress-conc-write.log 2>&1';
+            sleep 1
+          "
+
+          sleep 3
+
+          RAW_SEND=$({{ vm2_ssh }} "
+            timeout $TIMEOUT \
+              ib_send_bw -d $DEV -x 1 -s $SZ \
+              --duration $DUR -p 18515 \
+              --report_gbits $SERVER_IP 2>&1
+          ") &
+          SEND_PID=$!
+
+          sleep 2
+
+          RAW_WRITE=$({{ vm2_ssh }} "
+            timeout $TIMEOUT \
+              ib_write_bw -d $DEV -x 1 -s $SZ \
+              --duration $DUR -p 18516 \
+              --report_gbits $SERVER_IP 2>&1
+          ") &
+          WRITE_PID=$!
+
+          wait $SEND_PID
+          SEND_RC=$?
+          wait $WRITE_PID
+          WRITE_RC=$?
+
+          PASS_COUNT=0
+          for VERB_NAME in send write; do
+            if [ "$VERB_NAME" = "send" ]; then
+              RAW="$RAW_SEND"; RC=$SEND_RC
+            else
+              RAW="$RAW_WRITE"; RC=$WRITE_RC
+            fi
+
+            if [ $RC -ne 0 ]; then
+              echo "concurrent,$VERB_NAME,${DUR}s,FAIL,$RC" \
+                >> "{{ stress_csv }}"
+              echo "concurrent $VERB_NAME: FAIL rc=$RC"
+              continue
+            fi
+
+            LINE=$(echo "$RAW" \
+              | grep -E '^\s+[0-9]' | tail -1)
+            if [ -z "$LINE" ]; then
+              echo "concurrent,$VERB_NAME,${DUR}s,NODATA,0" \
+                >> "{{ stress_csv }}"
+              echo "concurrent $VERB_NAME: NODATA"
+              continue
+            fi
+
+            PEAK=$(echo "$LINE" | awk '{print $3}')
+            AVG=$(echo "$LINE"  | awk '{print $4}')
+            PEAK_GB=$(echo "scale=2; $PEAK / 8" \
+              | bc -l 2>/dev/null || echo "$PEAK")
+            AVG_GB=$(echo "scale=2; $AVG / 8" \
+              | bc -l 2>/dev/null || echo "$AVG")
+
+            echo "concurrent,$VERB_NAME,${DUR}s,PASS,peak=${PEAK_GB}_avg=${AVG_GB}_GBs" \
+              >> "{{ stress_csv }}"
+            echo "concurrent $VERB_NAME: peak=${PEAK_GB} avg=${AVG_GB} GB/s"
+            PASS_COUNT=$((PASS_COUNT + 1))
+          done
+
+          echo "concurrent: ${PASS_COUNT}/2 verbs passed"
+      register: concurrent_result
+      changed_when: false
+      failed_when: false
+
+    - name: Display concurrent results
+      ansible.builtin.debug:
+        msg: >-
+          {{ concurrent_result.stdout_lines
+             | default(['(no output)']) }}
+
+    # ─────────────────────────────────────────────────
+    # 5. High iteration count
+    # ─────────────────────────────────────────────────
+    - name: "High-iter: {{ item.0.label }} -n {{ high_iters }} @ {{ item.1 }} B"
+      ansible.builtin.shell:
+        cmd: |
+          TOOL="{{ item.0.tool }}"
+          DEV="{{ rdma_dev }}"
+          SZ="{{ item.1 }}"
+          N="{{ high_iters }}"
+          SERVER_IP="{{ vm1_ip }}"
+          UNIT="stress-highiter-$TOOL-$SZ"
+          TIMEOUT=$(( N / 5 + 120 ))
+
+          {{ vm1_ssh }} '{{ kill_perftest }}'
+          {{ vm2_ssh }} '{{ kill_perftest }}'
+          sleep 2
+
+          {{ vm1_ssh }} "
+            sudo systemctl stop $UNIT 2>/dev/null;
+            sudo systemctl reset-failed $UNIT 2>/dev/null;
+            sudo systemd-run --unit=$UNIT \
+              bash -c '$TOOL -d $DEV -x 1 \
+                -s $SZ -n $N \
+                --report_gbits \
+                >/tmp/${UNIT}.log 2>&1';
+            sleep 1
+          "
+
+          sleep 3
+
+          RAW=$({{ vm2_ssh }} "
+            timeout $TIMEOUT \
+              $TOOL -d $DEV -x 1 -s $SZ -n $N \
+              --report_gbits $SERVER_IP 2>&1
+          ")
+          RC=$?
+
+          if [ $RC -ne 0 ]; then
+            echo "high_iter,{{ item.0.label }},$SZ/$N,FAIL,$RC" \
+              >> "{{ stress_csv }}"
+            echo "FAIL rc=$RC"
+            echo "$RAW"
+            exit 0
+          fi
+
+          LINE=$(echo "$RAW" \
+            | grep -E '^\s+[0-9]' | tail -1)
+          if [ -z "$LINE" ]; then
+            echo "high_iter,{{ item.0.label }},$SZ/$N,NODATA,0" \
+              >> "{{ stress_csv }}"
+            echo "NODATA"
+            exit 0
+          fi
+
+          PEAK=$(echo "$LINE" | awk '{print $3}')
+          AVG=$(echo "$LINE"  | awk '{print $4}')
+          PEAK_GB=$(echo "scale=2; $PEAK / 8" \
+            | bc -l 2>/dev/null || echo "$PEAK")
+          AVG_GB=$(echo "scale=2; $AVG / 8" \
+            | bc -l 2>/dev/null || echo "$AVG")
+
+          echo "high_iter,{{ item.0.label }},$SZ/$N,PASS,peak=${PEAK_GB}_avg=${AVG_GB}_GBs" \
+            >> "{{ stress_csv }}"
+          echo "{{ item.0.label }} n=$N $SZ: peak=${PEAK_GB} avg=${AVG_GB} GB/s"
+      register: highiter_result
+      changed_when: false
+      failed_when: false
+      loop: >-
+        {{ bw_verbs | product([65536, 1048576]) | list }}
+      loop_control:
+        label: >-
+          {{ item.0.label }} -n {{ high_iters }} @ {{ item.1 }}
+
+    - name: Display high-iteration results
+      ansible.builtin.debug:
+        msg: >-
+          {{ item.stdout_lines | default(['(no output)']) }}
+      loop: "{{ highiter_result.results }}"
+      loop_control:
+        label: >-
+          {{ item.item.0.label }} @ {{ item.item.1 }}
+      when: item.stdout is defined
+
+    # ─────────────────────────────────────────────────
+    # 6. QP churn / connection cycling
+    # ─────────────────────────────────────────────────
+    - name: "QP churn: {{ qp_churn_cycles }} cycles"
+      ansible.builtin.shell:
+        cmd: |
+          DEV="{{ rdma_dev }}"
+          CYCLES="{{ qp_churn_cycles }}"
+          SERVER_IP="{{ vm1_ip }}"
+          PASSES=0
+          FAILS=0
+
+          {{ vm1_ssh }} '{{ kill_perftest }}'
+          {{ vm2_ssh }} '{{ kill_perftest }}'
+          sleep 2
+
+          for i in $(seq 1 "$CYCLES"); do
+            UNIT="stress-churn-$i"
+
+            {{ vm1_ssh }} "
+              sudo systemctl stop $UNIT 2>/dev/null;
+              sudo systemctl reset-failed $UNIT 2>/dev/null;
+              sudo systemd-run --unit=$UNIT \
+                bash -c 'ibv_rc_pingpong -d $DEV \
+                  -g 1 -n 20 -s 4096 \
+                  >/tmp/${UNIT}.log 2>&1';
+              sleep 1
+            "
+
+            sleep 3
+
+            RAW=$({{ vm2_ssh }} "
+              timeout 60 ibv_rc_pingpong \
+                -d $DEV -g 1 -n 20 -s 4096 \
+                $SERVER_IP 2>&1
+            ")
+            RC=$?
+
+            if [ $RC -eq 0 ] \
+               && echo "$RAW" | grep -q "Mbit"; then
+              PASSES=$((PASSES + 1))
+            else
+              FAILS=$((FAILS + 1))
+              echo "  cycle $i: FAIL (rc=$RC)"
+            fi
+
+            {{ vm1_ssh }} '{{ kill_perftest }}'
+            {{ vm2_ssh }} '{{ kill_perftest }}'
+            sleep 1
+          done
+
+          RESULT="PASS"
+          if [ "$FAILS" -gt 0 ]; then
+            RESULT="PARTIAL"
+          fi
+
+          echo "qp_churn,pingpong,${CYCLES}_cycles,$RESULT,pass=${PASSES}_fail=${FAILS}" \
+            >> "{{ stress_csv }}"
+          echo "QP churn: $PASSES/$CYCLES passed, $FAILS failed"
+      register: churn_result
+      changed_when: false
+      failed_when: false
+
+    - name: Display QP churn results
+      ansible.builtin.debug:
+        msg: >-
+          {{ churn_result.stdout_lines
+             | default(['(no output)']) }}
+
+    # ─────────────────────────────────────────────────
+    # 7. Resource limit probing
+    # ─────────────────────────────────────────────────
+    - name: "Resource limits: max QP probe"
+      ansible.builtin.shell:
+        cmd: |
+          DEV="{{ rdma_dev }}"
+          SERVER_IP="{{ vm1_ip }}"
+          MAX_QP=0
+
+          {{ vm1_ssh }} '{{ kill_perftest }}'
+          {{ vm2_ssh }} '{{ kill_perftest }}'
+          sleep 2
+
+          for i in $(seq 1 64); do
+            UNIT="stress-reslim-$i"
+
+            {{ vm1_ssh }} "
+              sudo systemctl stop $UNIT 2>/dev/null;
+              sudo systemctl reset-failed $UNIT 2>/dev/null;
+              sudo systemd-run --unit=$UNIT \
+                bash -c 'ibv_rc_pingpong -d $DEV \
+                  -g 1 -n 5 -s 64 \
+                  >/tmp/${UNIT}.log 2>&1';
+              sleep 1
+            "
+
+            sleep 3
+
+            RAW=$({{ vm2_ssh }} "
+              timeout 30 ibv_rc_pingpong \
+                -d $DEV -g 1 -n 5 -s 64 \
+                $SERVER_IP 2>&1
+            ")
+            RC=$?
+
+            {{ vm1_ssh }} '{{ kill_perftest }}'
+            {{ vm2_ssh }} '{{ kill_perftest }}'
+            sleep 1
+
+            if [ $RC -ne 0 ]; then
+              echo "  QP $i: FAIL (rc=$RC)"
+              break
+            fi
+
+            if ! echo "$RAW" | grep -q "Mbit"; then
+              echo "  QP $i: no throughput data"
+              break
+            fi
+
+            MAX_QP=$i
+          done
+
+          echo "resource_limit,max_qp_sequential,probe,$MAX_QP,of_64_attempted" \
+            >> "{{ stress_csv }}"
+          echo "Max sequential QP create/destroy: $MAX_QP of 64"
+      register: reslim_result
+      changed_when: false
+      failed_when: false
+
+    - name: Display resource limit results
+      ansible.builtin.debug:
+        msg: >-
+          {{ reslim_result.stdout_lines
+             | default(['(no output)']) }}
+
+    # ─────────────────────────────────────────────────
+    # 8. iperf3 TCP baseline
+    # ─────────────────────────────────────────────────
+    - name: "iperf3: TCP baseline over emulated NIC"
+      ansible.builtin.shell:
+        cmd: |
+          SERVER_IP="{{ vm1_ip }}"
+          DUR="{{ iperf_dur }}"
+          BW="{{ iperf_bw }}"
+          UNIT="stress-iperf3"
+
+          {{ vm1_ssh }} '{{ kill_perftest }}'
+          {{ vm2_ssh }} '{{ kill_perftest }}'
+          sleep 1
+
+          {{ vm1_ssh }} "
+            sudo systemctl stop $UNIT 2>/dev/null;
+            sudo systemctl reset-failed $UNIT 2>/dev/null;
+            sudo systemd-run --unit=$UNIT \
+              bash -c 'iperf3 -s -1 \
+                --bind $SERVER_IP \
+                >/tmp/${UNIT}.log 2>&1';
+            sleep 1
+          "
+
+          sleep 3
+
+          RAW=$({{ vm2_ssh }} "
+            timeout $(( DUR * 4 + 30 )) \
+              iperf3 -c $SERVER_IP -t $DUR \
+              -b $BW --json 2>&1
+          ")
+          RC=$?
+
+          if [ $RC -ne 0 ]; then
+            echo "iperf3,tcp,${DUR}s,FAIL,$RC" \
+              >> "{{ stress_csv }}"
+            echo "iperf3 FAIL rc=$RC"
+            echo "$RAW"
+            exit 0
+          fi
+
+          BPS_SEND=$(echo "$RAW" \
+            | python3 -c "
+          import sys, json
+          try:
+              d = json.load(sys.stdin)
+              bps = d['end']['sum_sent']['bits_per_second']
+              print(f'{bps/1e6:.2f}')
+          except Exception:
+              print('N/A')
+          " 2>/dev/null)
+
+          BPS_RECV=$(echo "$RAW" \
+            | python3 -c "
+          import sys, json
+          try:
+              d = json.load(sys.stdin)
+              bps = d['end']['sum_received']['bits_per_second']
+              print(f'{bps/1e6:.2f}')
+          except Exception:
+              print('N/A')
+          " 2>/dev/null)
+
+          echo "iperf3,tcp,${DUR}s,PASS,send=${BPS_SEND}_recv=${BPS_RECV}_Mbps" \
+            >> "{{ stress_csv }}"
+          echo "iperf3 TCP: send=${BPS_SEND} recv=${BPS_RECV} Mbit/s"
+      register: iperf_result
+      changed_when: false
+      failed_when: false
+
+    - name: Display iperf3 results
+      ansible.builtin.debug:
+        msg: >-
+          {{ iperf_result.stdout_lines
+             | default(['(no output)']) }}
+
+    # ─────────────────────────────────────────────────
+    # Summary
+    # ─────────────────────────────────────────────────
+    - name: Count stress test failures
+      ansible.builtin.shell:
+        cmd: >-
+          grep -c 'FAIL\|NODATA'
+          "{{ stress_csv }}"
+          2>/dev/null || echo 0
+      register: stress_fail_count
+      changed_when: false
+
+    - name: Stress test summary
+      ansible.builtin.debug:
+        msg:
+          - "=== Stress Tests Complete ==="
+          - "Results CSV:  {{ stress_csv }}"
+          - "Failures:     {{ stress_fail_count.stdout | default('0') }}"
+
+    - name: Display stress CSV
+      ansible.builtin.shell:
+        cmd: "column -t -s, {{ stress_csv }}"
+      register: stress_table
+      changed_when: false
+
+    - name: Stress results table
+      ansible.builtin.debug:
+        msg: "{{ stress_table.stdout_lines }}"

--- a/src/from-qemu/hw/rdma/rdma_backend_tcp.c
+++ b/src/from-qemu/hw/rdma/rdma_backend_tcp.c
@@ -51,7 +51,7 @@
  */
 
 #define TCP_PROTOCOL_MAGIC     0x52444D41 /* "RDMA" */
-#define TCP_PROTOCOL_VERSION   2          /* Multi-node version */
+#define TCP_PROTOCOL_VERSION   3          /* v3: wc_opcode in TcpWR */
 #define TCP_MAX_ETH_FRAME_LEN  2048
 #define TCP_MAX_PAYLOAD_LEN    (16u << 20)   /* 16 MiB */
 #define TCP_COALESCE_THRESHOLD (256u * 1024) /* 256 KB */
@@ -2004,8 +2004,20 @@ static void *tcp_accept_thread(void *opaque)
 
             hs_payload = (TcpHandshakePayload *)payload;
             uint32_t remote_node_id = ntohl(hs_payload->node_id);
+            uint32_t remote_version = ntohl(hs_payload->version);
 
-            rdma_info_report("TCP: Handshake from node %u", remote_node_id);
+            rdma_info_report("TCP: Handshake from node %u (v%u)",
+                             remote_node_id, remote_version);
+
+            if (remote_version != TCP_PROTOCOL_VERSION) {
+                rdma_error_report(
+                    "TCP: Protocol version mismatch: local=%u remote=%u",
+                    TCP_PROTOCOL_VERSION, remote_version);
+                close(sockfd);
+                g_free(payload);
+                payload = NULL;
+                continue;
+            }
 
             /* Check if connection already exists */
             qemu_mutex_lock(&priv->conn_table_lock);
@@ -3089,6 +3101,8 @@ static void tcp_post_send(RdmaBackendDev *backend_dev, RdmaBackendQP *qp,
 
     if (!priv) {
         rdma_error_report("TCP: Invalid backend");
+        rdma_backend_complete_work(IBV_WC_GENERAL_ERR, VENDOR_ERR_FAIL_BACKEND,
+                                   0, 0, wc_opcode, ctx);
         return;
     }
 
@@ -3097,6 +3111,8 @@ static void tcp_post_send(RdmaBackendDev *backend_dev, RdmaBackendQP *qp,
     if (!tqp) {
         qemu_mutex_unlock(&priv->lock);
         rdma_error_report("TCP: QP %u not found", qpn);
+        rdma_backend_complete_work(IBV_WC_GENERAL_ERR, VENDOR_ERR_FAIL_BACKEND,
+                                   0, qpn, wc_opcode, ctx);
         return;
     }
 
@@ -3118,7 +3134,7 @@ static void tcp_post_send(RdmaBackendDev *backend_dev, RdmaBackendQP *qp,
     }
     if (!conn || !conn->is_connected) {
         rdma_error_report("TCP: No connection to node %u", dst_node);
-        return;
+        goto fail;
     }
 
     uint32_t total_len = 0;
@@ -3230,14 +3246,30 @@ static void tcp_post_send(RdmaBackendDev *backend_dev, RdmaBackendQP *qp,
                 }
             }
         }
+    } else {
+        ret = -1;
     }
     qemu_mutex_unlock(&conn->lock);
+
+    if (ret < 0) {
+        goto fail;
+    }
 
     tcp_wr_unmap_sge(tqp, wr);
 
     rdma_info_report("TCP: Posted send QP %u -> node %u, "
                      "%u SGEs, opcode=%u",
                      qpn, dst_node, num_sge, pvrdma_opcode);
+    return;
+
+fail:
+    qemu_mutex_lock(&priv->lock);
+    g_queue_remove(tqp->send_queue, wr);
+    qemu_mutex_unlock(&priv->lock);
+    tcp_wr_unmap_sge(tqp, wr);
+    g_free(wr);
+    rdma_backend_complete_work(IBV_WC_GENERAL_ERR, VENDOR_ERR_FAIL_BACKEND, 0,
+                               qpn, wc_opcode, ctx);
 }
 
 static void tcp_post_recv(RdmaBackendDev *backend_dev, RdmaBackendQP *qp,

--- a/src/from-qemu/hw/rdma/rdma_backend_tcp.c
+++ b/src/from-qemu/hw/rdma/rdma_backend_tcp.c
@@ -58,7 +58,7 @@
 
 /* Tunable defaults -- overridable via env vars */
 #define TCP_DEFAULT_LISTEN_BACKLOG    32
-#define TCP_DEFAULT_SOCKBUF_BYTES     (2 * 1024 * 1024)
+#define TCP_DEFAULT_SOCKBUF_BYTES     (4 * 1024 * 1024)
 #define TCP_DEFAULT_HEALTH_INTERVAL_S 5
 
 static int tcp_env_int(const char *name, int fallback)
@@ -195,6 +195,7 @@ typedef struct {
 typedef struct {
     uint64_t wr_id;
     uint32_t num_sge;
+    enum ibv_wc_opcode wc_opcode;
     TcpSGE sge[32]; /* Max SGEs */
 } TcpWR;
 
@@ -1276,15 +1277,16 @@ static void *tcp_recv_thread_per_conn(void *opaque)
                     TcpWR *send_wr = g_queue_pop_head(tqp->send_queue);
                     if (send_wr) {
                         uint64_t wr_id = send_wr->wr_id;
+                        enum ibv_wc_opcode op = send_wr->wc_opcode;
                         uint32_t send_bytes = 0;
                         for (uint32_t si = 0; si < send_wr->num_sge; si++)
                             send_bytes += send_wr->sge[si].length;
                         g_free(send_wr);
 
                         qemu_mutex_unlock(&priv->lock);
-                        tcp_update_stats(priv, send_bytes, IBV_WC_SEND);
+                        tcp_update_stats(priv, send_bytes, op);
                         rdma_backend_complete_work(IBV_WC_SUCCESS, 0, 0,
-                                                   hdr.dst_qpn, IBV_WC_SEND,
+                                                   hdr.dst_qpn, op,
                                                    (void *)wr_id);
                         qemu_mutex_lock(&priv->lock);
 
@@ -3067,6 +3069,7 @@ static void tcp_post_send(RdmaBackendDev *backend_dev, RdmaBackendQP *qp,
     typedef struct {
         void *dev;
         uint32_t cq_handle;
+        uint32_t qp_handle;
         struct pvrdma_cqe cqe;
         uint32_t opcode;
         uint64_t remote_addr;
@@ -3077,6 +3080,8 @@ static void tcp_post_send(RdmaBackendDev *backend_dev, RdmaBackendQP *qp,
     uint32_t pvrdma_opcode = comp ? comp->opcode : 0;
     uint64_t remote_addr = comp ? comp->remote_addr : 0;
     uint32_t rkey = comp ? comp->rkey : 0;
+    enum ibv_wc_opcode wc_opcode =
+        comp ? (enum ibv_wc_opcode)comp->cqe.opcode : IBV_WC_SEND;
 
     rdma_info_report("TCP: >>> post_send QPN %u opcode=%u "
                      "remote_addr=0x%lx rkey=0x%x",
@@ -3100,6 +3105,7 @@ static void tcp_post_send(RdmaBackendDev *backend_dev, RdmaBackendQP *qp,
     wr = g_new0(TcpWR, 1);
     wr->wr_id = (uint64_t)(uintptr_t)ctx;
     wr->num_sge = 0;
+    wr->wc_opcode = wc_opcode;
     tcp_wr_map_sge(tqp, wr, sge, num_sge);
     g_queue_push_tail(tqp->send_queue, wr);
     seq = priv->next_seq++;

--- a/src/from-qemu/hw/rdma/rdma_rm_defs.h
+++ b/src/from-qemu/hw/rdma/rdma_rm_defs.h
@@ -38,6 +38,14 @@
 #define MAX_AH              64
 #define MAX_SRQ             512
 
+/*
+ * Number of page-table pages backing each WQ/CQ ring.
+ * Upstream PVRDMA uses 1; we double it so that bidirectional
+ * traffic at 64 KB+ does not exhaust MR page-table entries
+ * when both send and recv rings are fully populated.
+ */
+#define PVRDMA_PG_TBL_PAGES 2
+
 #define MAX_RM_TBL_NAME          16
 #define MAX_CONSEQ_EMPTY_POLL_CQ 4096 /* considered as error above this */
 

--- a/src/from-qemu/hw/rdma/rdma_rm_defs.h
+++ b/src/from-qemu/hw/rdma/rdma_rm_defs.h
@@ -83,10 +83,12 @@ typedef struct RdmaRmUC {
     uint64_t uc_handle;
 } RdmaRmUC;
 
-/* WQE processing state for incremental batch processing */
+/* Per-direction WQE processing state for incremental batch processing */
 typedef struct RdmaRmQPWqeProcessingState {
-    bool processing_active;  /* Is this QP currently processing WQEs? */
-    uint32_t wqes_processed; /* Count for this batch */
+    bool send_processing_active;
+    uint32_t send_wqes_processed;
+    bool recv_processing_active;
+    uint32_t recv_wqes_processed;
 } RdmaRmQPWqeProcessingState;
 
 typedef struct RdmaRmQP {
@@ -98,7 +100,8 @@ typedef struct RdmaRmQP {
     uint32_t recv_cq_handle;
     enum ibv_qp_state qp_state;
     uint8_t is_srq;
-    RdmaRmQPWqeProcessingState wqe_state; /* WQE processing state */
+    RdmaRmQPWqeProcessingState wqe_state;
+    _Atomic uint32_t send_in_flight;
 } RdmaRmQP;
 
 /* WQE processing state for SRQ incremental batch processing */

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_main.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_main.c
@@ -1066,7 +1066,8 @@ static void __attribute__((unused)) init_regs(PCIDevice *pdev)
 
 static void __attribute__((unused)) init_dev_caps(PVRDMADev *dev)
 {
-    size_t pg_tbl_bytes = 2 * PAGE_SIZE * (PAGE_SIZE / sizeof(uint64_t));
+    size_t pg_tbl_bytes =
+        PVRDMA_PG_TBL_PAGES * PAGE_SIZE * (PAGE_SIZE / sizeof(uint64_t));
     size_t wr_sz =
         MAX(sizeof(struct pvrdma_sq_wqe_hdr), sizeof(struct pvrdma_rq_wqe_hdr));
 

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_main.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_main.c
@@ -1066,7 +1066,7 @@ static void __attribute__((unused)) init_regs(PCIDevice *pdev)
 
 static void __attribute__((unused)) init_dev_caps(PVRDMADev *dev)
 {
-    size_t pg_tbl_bytes = PAGE_SIZE * (PAGE_SIZE / sizeof(uint64_t));
+    size_t pg_tbl_bytes = 2 * PAGE_SIZE * (PAGE_SIZE / sizeof(uint64_t));
     size_t wr_sz =
         MAX(sizeof(struct pvrdma_sq_wqe_hdr), sizeof(struct pvrdma_rq_wqe_hdr));
 

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_qp_ops.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_qp_ops.c
@@ -63,6 +63,7 @@ typedef struct CompHandlerCtx {
 typedef struct DeferredCompletion {
     PVRDMADev *dev;
     uint32_t cq_handle;
+    uint32_t qp_handle;
     struct pvrdma_cqe cqe;
     struct ibv_wc wc;
 } DeferredCompletion;
@@ -154,25 +155,18 @@ static void pvrdma_qp_ops_comp_handler(void *ctx, struct ibv_wc *wc)
 {
     CompHandlerCtx *comp_ctx = (CompHandlerCtx *)ctx;
 
-    /* Decrement in-flight counter for send completions */
-    if (comp_ctx->qp_handle) {
-        RdmaRmQP *qp =
-            rdma_rm_get_qp(&comp_ctx->dev->rdma_dev_res, comp_ctx->qp_handle);
-        if (qp) {
-            uint32_t prev =
-                __atomic_fetch_sub(&qp->send_in_flight, 1, __ATOMIC_ACQ_REL);
-            (void)prev;
-        }
-    }
-
     /*
      * Queue the completion for the main loop to
      * post.  All vfio-user / DMA-mapped memory
      * access must happen on the main thread.
+     * send_in_flight is also decremented there to
+     * avoid racing rdma_rm_get_qp (g_hash_table)
+     * against QP alloc/dealloc on the main thread.
      */
     DeferredCompletion *dc = g_new(DeferredCompletion, 1);
     dc->dev = comp_ctx->dev;
     dc->cq_handle = comp_ctx->cq_handle;
+    dc->qp_handle = comp_ctx->qp_handle;
     dc->cqe = comp_ctx->cqe;
     dc->wc = *wc;
 
@@ -230,6 +224,14 @@ void pvrdma_drain_deferred_completions(void)
 
         if (!dc) {
             break;
+        }
+
+        if (dc->qp_handle) {
+            RdmaRmQP *qp =
+                rdma_rm_get_qp(&dc->dev->rdma_dev_res, dc->qp_handle);
+            if (qp) {
+                __atomic_fetch_sub(&qp->send_in_flight, 1, __ATOMIC_ACQ_REL);
+            }
         }
 
         pvrdma_post_cqe(dc->dev, dc->cq_handle, &dc->cqe, &dc->wc);
@@ -561,6 +563,7 @@ static gboolean continue_srq_recv_processing(gpointer user_data)
         comp_ctx = g_new(CompHandlerCtx, 1);
         comp_ctx->dev = dev;
         comp_ctx->cq_handle = srq->recv_cq_handle;
+        comp_ctx->qp_handle = 0;
         comp_ctx->cqe.wr_id = wqe->hdr.wr_id;
         comp_ctx->cqe.qp = 0;
         comp_ctx->cqe.opcode = IBV_WC_RECV;
@@ -885,6 +888,7 @@ void pvrdma_srq_recv(PVRDMADev *dev, uint32_t srq_handle)
         comp_ctx = g_new(CompHandlerCtx, 1);
         comp_ctx->dev = dev;
         comp_ctx->cq_handle = srq->recv_cq_handle;
+        comp_ctx->qp_handle = 0;
         comp_ctx->cqe.wr_id = wqe->hdr.wr_id;
         comp_ctx->cqe.qp = 0;
         comp_ctx->cqe.opcode = IBV_WC_RECV;

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_qp_ops.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_qp_ops.c
@@ -33,11 +33,22 @@
 #include "pvrdma_qp_ops.h"
 
 /* Number of WQEs to process per batch before yielding to event loop */
-#define WQE_BATCH_SIZE 4
+#define WQE_BATCH_SIZE 16
+
+/*
+ * Max send WQEs posted to backend but not yet completed, per QP.
+ * Kept small to prevent TCP buffer exhaustion: the TCP send path
+ * busy-waits when the socket buffer is full, blocking the main
+ * thread and preventing completion delivery.  At 4 WQEs with
+ * 1 MB messages the total in-flight is 4 MB, within the default
+ * TCP socket buffer (net.core.wmem_max).
+ */
+#define MAX_SEND_IN_FLIGHT 4
 
 typedef struct CompHandlerCtx {
     PVRDMADev *dev;
     uint32_t cq_handle;
+    uint32_t qp_handle;
     struct pvrdma_cqe cqe;
     /* RDMA operation parameters */
     uint32_t opcode;      /* PVRDMA_WR_* opcode */
@@ -142,6 +153,17 @@ static int pvrdma_post_cqe(PVRDMADev *dev, uint32_t cq_handle,
 static void pvrdma_qp_ops_comp_handler(void *ctx, struct ibv_wc *wc)
 {
     CompHandlerCtx *comp_ctx = (CompHandlerCtx *)ctx;
+
+    /* Decrement in-flight counter for send completions */
+    if (comp_ctx->qp_handle) {
+        RdmaRmQP *qp =
+            rdma_rm_get_qp(&comp_ctx->dev->rdma_dev_res, comp_ctx->qp_handle);
+        if (qp) {
+            uint32_t prev =
+                __atomic_fetch_sub(&qp->send_in_flight, 1, __ATOMIC_ACQ_REL);
+            (void)prev;
+        }
+    }
 
     /*
      * Queue the completion for the main loop to
@@ -271,19 +293,17 @@ static gboolean continue_qp_recv_processing(gpointer user_data)
 
     ring = &((PvrdmaRing *)qp->opaque)[1];
 
-    /* Reset counter for this batch */
-    qp->wqe_state.wqes_processed = 0;
+    qp->wqe_state.recv_wqes_processed = 0;
 
     wqe = pvrdma_ring_next_elem_read(ring);
 
-    /* Process batch of WQEs */
-    while (wqe && qp->wqe_state.wqes_processed < WQE_BATCH_SIZE) {
+    while (wqe && qp->wqe_state.recv_wqes_processed < WQE_BATCH_SIZE) {
         CompHandlerCtx *comp_ctx;
 
-        /* Prepare CQE */
         comp_ctx = g_new(CompHandlerCtx, 1);
         comp_ctx->dev = dev;
         comp_ctx->cq_handle = qp->recv_cq_handle;
+        comp_ctx->qp_handle = 0;
         comp_ctx->cqe.wr_id = wqe->hdr.wr_id;
         comp_ctx->cqe.qp = qp_handle;
         comp_ctx->cqe.opcode = IBV_WC_RECV;
@@ -293,17 +313,15 @@ static gboolean continue_qp_recv_processing(gpointer user_data)
                               dev->dev_attr.max_sge);
             complete_with_error(VENDOR_ERR_INV_NUM_SGE, comp_ctx);
             pvrdma_ring_read_inc(ring);
-            qp->wqe_state.wqes_processed++;
+            qp->wqe_state.recv_wqes_processed++;
             wqe = pvrdma_ring_next_elem_read(ring);
             continue;
         }
 
-        /* Track WQE processing */
         {
             PVRDMAQPStats *qp_stats = pvrdma_get_qp_stats(dev, qp_handle);
             if (qp_stats) {
                 qp_stats->wqes_processed++;
-                /* RECV opcode is implicit */
                 qp_stats->wqes_by_opcode[PVRDMA_WR_SEND]++;
             }
         }
@@ -313,21 +331,19 @@ static gboolean continue_qp_recv_processing(gpointer user_data)
                                comp_ctx);
 
         pvrdma_ring_read_inc(ring);
-        qp->wqe_state.wqes_processed++;
+        qp->wqe_state.recv_wqes_processed++;
         wqe = pvrdma_ring_next_elem_read(ring);
     }
 
-    /* Check if more WQEs remain */
     if (wqe) {
         more_wqes = true;
     } else {
-        qp->wqe_state.processing_active = false;
-        qp->wqe_state.wqes_processed = 0;
+        qp->wqe_state.recv_processing_active = false;
+        qp->wqe_state.recv_wqes_processed = 0;
     }
 
     g_free(ctx);
 
-    /* Track continuation */
     {
         PVRDMAQPStats *qp_stats = pvrdma_get_qp_stats(dev, qp_handle);
         if (qp_stats && more_wqes) {
@@ -335,7 +351,6 @@ static gboolean continue_qp_recv_processing(gpointer user_data)
         }
     }
 
-    /* Reschedule if more WQEs remain */
     if (more_wqes) {
         QPContinuationCtx *new_ctx = g_new(QPContinuationCtx, 1);
         new_ctx->dev = dev;
@@ -380,32 +395,32 @@ static gboolean continue_qp_send_processing(gpointer user_data)
 
     ring = (PvrdmaRing *)qp->opaque;
 
-    /* Reset counter for this batch */
-    qp->wqe_state.wqes_processed = 0;
+    qp->wqe_state.send_wqes_processed = 0;
 
     wqe = pvrdma_ring_next_elem_read(ring);
 
-    /* Process batch of WQEs */
-    while (wqe && qp->wqe_state.wqes_processed < WQE_BATCH_SIZE) {
+    while (wqe && qp->wqe_state.send_wqes_processed < WQE_BATCH_SIZE) {
         CompHandlerCtx *comp_ctx;
         uint32_t pvrdma_opcode = wqe->hdr.opcode;
 
-        /* Prepare CQE */
+        if (__atomic_load_n(&qp->send_in_flight, __ATOMIC_ACQUIRE) >=
+            MAX_SEND_IN_FLIGHT) {
+            break;
+        }
+
         comp_ctx = g_new(CompHandlerCtx, 1);
         comp_ctx->dev = dev;
         comp_ctx->cq_handle = qp->send_cq_handle;
+        comp_ctx->qp_handle = qp_handle;
         comp_ctx->cqe.wr_id = wqe->hdr.wr_id;
         comp_ctx->cqe.qp = qp_handle;
         comp_ctx->opcode = pvrdma_opcode;
         comp_ctx->remote_addr = 0;
         comp_ctx->rkey = 0;
 
-        /* Map PVRDMA opcode to IBV completion opcode */
         comp_ctx->cqe.opcode = pvrdma_to_ibv_wc_opcode(pvrdma_opcode);
 
-        /* Handle different QP types */
         if (qp->qp_type == IBV_QPT_UD) {
-            /* UD QP: use wr.ud union */
             sgid = rdma_rm_get_gid(&dev->rdma_dev_res,
                                    wqe->hdr.wr.ud.av.gid_index);
             if (!sgid) {
@@ -414,7 +429,7 @@ static gboolean continue_qp_send_processing(gpointer user_data)
                 complete_with_error(VENDOR_ERR_INV_GID_IDX, comp_ctx);
                 pvrdma_ring_read_inc(ring);
                 wqe = pvrdma_ring_next_elem_read(ring);
-                qp->wqe_state.wqes_processed++;
+                qp->wqe_state.send_wqes_processed++;
                 continue;
             }
 
@@ -427,7 +442,7 @@ static gboolean continue_qp_send_processing(gpointer user_data)
                 complete_with_error(VENDOR_ERR_INV_GID_IDX, comp_ctx);
                 pvrdma_ring_read_inc(ring);
                 wqe = pvrdma_ring_next_elem_read(ring);
-                qp->wqe_state.wqes_processed++;
+                qp->wqe_state.send_wqes_processed++;
                 continue;
             }
 
@@ -435,7 +450,6 @@ static gboolean continue_qp_send_processing(gpointer user_data)
             dqpn = wqe->hdr.wr.ud.remote_qpn;
             dqkey = wqe->hdr.wr.ud.remote_qkey;
         } else if (qp->qp_type == IBV_QPT_RC || qp->qp_type == IBV_QPT_UC) {
-            /* RC/UC QP: extract RDMA parameters if present */
             if (pvrdma_opcode == PVRDMA_WR_RDMA_READ ||
                 pvrdma_opcode == PVRDMA_WR_RDMA_WRITE ||
                 pvrdma_opcode == PVRDMA_WR_RDMA_WRITE_WITH_IMM ||
@@ -444,18 +458,17 @@ static gboolean continue_qp_send_processing(gpointer user_data)
                 comp_ctx->rkey = wqe->hdr.wr.rdma.rkey;
             }
 
-            /* For RC/UC, use GID from QP attributes */
-            sgid_idx = 0; /* Default GID index */
+            sgid_idx = 0;
             sgid = rdma_rm_get_gid(&dev->rdma_dev_res, 0);
-            dgid = NULL; /* Not used for connected QPs */
-            dqpn = 0;    /* Remote QPN comes from QP pairing */
-            dqkey = 0;   /* Not used for connected QPs */
+            dgid = NULL;
+            dqpn = 0;
+            dqkey = 0;
         } else {
             rdma_error_report("Unsupported QP type %d for send", qp->qp_type);
             complete_with_error(VENDOR_ERR_INV_QP_TYPE, comp_ctx);
             pvrdma_ring_read_inc(ring);
             wqe = pvrdma_ring_next_elem_read(ring);
-            qp->wqe_state.wqes_processed++;
+            qp->wqe_state.send_wqes_processed++;
             continue;
         }
 
@@ -465,30 +478,30 @@ static gboolean continue_qp_send_processing(gpointer user_data)
             complete_with_error(VENDOR_ERR_INV_NUM_SGE, comp_ctx);
             pvrdma_ring_read_inc(ring);
             wqe = pvrdma_ring_next_elem_read(ring);
-            qp->wqe_state.wqes_processed++;
+            qp->wqe_state.send_wqes_processed++;
             continue;
         }
+
+        __atomic_fetch_add(&qp->send_in_flight, 1, __ATOMIC_ACQ_REL);
 
         rdma_backend_post_send(&dev->backend_dev, &qp->backend_qp, qp->qp_type,
                                (struct ibv_sge *)&wqe->sge[0], wqe->hdr.num_sge,
                                sgid_idx, sgid, dgid, dqpn, dqkey, comp_ctx);
 
         pvrdma_ring_read_inc(ring);
-        qp->wqe_state.wqes_processed++;
+        qp->wqe_state.send_wqes_processed++;
         wqe = pvrdma_ring_next_elem_read(ring);
     }
 
-    /* Check if more WQEs remain */
     if (wqe) {
         more_wqes = true;
     } else {
-        qp->wqe_state.processing_active = false;
-        qp->wqe_state.wqes_processed = 0;
+        qp->wqe_state.send_processing_active = false;
+        qp->wqe_state.send_wqes_processed = 0;
     }
 
     g_free(ctx);
 
-    /* Track continuation */
     {
         PVRDMAQPStats *qp_stats = pvrdma_get_qp_stats(dev, qp_handle);
         if (qp_stats && more_wqes) {
@@ -496,7 +509,6 @@ static gboolean continue_qp_send_processing(gpointer user_data)
         }
     }
 
-    /* Reschedule if more WQEs remain */
     if (more_wqes) {
         QPContinuationCtx *new_ctx = g_new(QPContinuationCtx, 1);
         new_ctx->dev = dev;
@@ -626,10 +638,8 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
 
     rdma_info_report(">>> DOORBELL: Found QP, qp_type=%d", qp->qp_type);
 
-    /* Check if already processing - if so, just mark for continuation */
-    if (qp->wqe_state.processing_active) {
-        /* Already processing, will be continued by idle callback */
-        rdma_info_report(">>> DOORBELL: QP %u already processing, "
+    if (qp->wqe_state.send_processing_active) {
+        rdma_info_report(">>> DOORBELL: QP %u send already processing, "
                          "continuation scheduled",
                          qp_handle);
         return;
@@ -642,35 +652,34 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
     rdma_info_report(">>> DOORBELL: Got WQE=%p", wqe);
 
     if (!wqe) {
-        /* No WQEs to process */
         return;
     }
 
-    /* Mark as processing */
-    qp->wqe_state.processing_active = true;
-    qp->wqe_state.wqes_processed = 0;
+    qp->wqe_state.send_processing_active = true;
+    qp->wqe_state.send_wqes_processed = 0;
 
-    /* Process batch of WQEs */
-    while (wqe && qp->wqe_state.wqes_processed < WQE_BATCH_SIZE) {
+    while (wqe && qp->wqe_state.send_wqes_processed < WQE_BATCH_SIZE) {
         CompHandlerCtx *comp_ctx;
         uint32_t pvrdma_opcode = wqe->hdr.opcode;
 
-        /* Prepare CQE */
+        if (__atomic_load_n(&qp->send_in_flight, __ATOMIC_ACQUIRE) >=
+            MAX_SEND_IN_FLIGHT) {
+            break;
+        }
+
         comp_ctx = g_new(CompHandlerCtx, 1);
         comp_ctx->dev = dev;
         comp_ctx->cq_handle = qp->send_cq_handle;
+        comp_ctx->qp_handle = qp_handle;
         comp_ctx->cqe.wr_id = wqe->hdr.wr_id;
         comp_ctx->cqe.qp = qp_handle;
         comp_ctx->opcode = pvrdma_opcode;
         comp_ctx->remote_addr = 0;
         comp_ctx->rkey = 0;
 
-        /* Map PVRDMA opcode to IBV completion opcode */
         comp_ctx->cqe.opcode = pvrdma_to_ibv_wc_opcode(pvrdma_opcode);
 
-        /* Handle different QP types */
         if (qp->qp_type == IBV_QPT_UD) {
-            /* UD QP: use wr.ud union */
             sgid = rdma_rm_get_gid(&dev->rdma_dev_res,
                                    wqe->hdr.wr.ud.av.gid_index);
             if (!sgid) {
@@ -678,7 +687,7 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
                                   wqe->hdr.wr.ud.av.gid_index);
                 complete_with_error(VENDOR_ERR_INV_GID_IDX, comp_ctx);
                 pvrdma_ring_read_inc(ring);
-                qp->wqe_state.wqes_processed++;
+                qp->wqe_state.send_wqes_processed++;
                 wqe = pvrdma_ring_next_elem_read(ring);
                 continue;
             }
@@ -691,7 +700,7 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
                                   wqe->hdr.wr.ud.av.gid_index);
                 complete_with_error(VENDOR_ERR_INV_GID_IDX, comp_ctx);
                 pvrdma_ring_read_inc(ring);
-                qp->wqe_state.wqes_processed++;
+                qp->wqe_state.send_wqes_processed++;
                 wqe = pvrdma_ring_next_elem_read(ring);
                 continue;
             }
@@ -700,7 +709,6 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
             dqpn = wqe->hdr.wr.ud.remote_qpn;
             dqkey = wqe->hdr.wr.ud.remote_qkey;
         } else if (qp->qp_type == IBV_QPT_RC || qp->qp_type == IBV_QPT_UC) {
-            /* RC/UC QP: extract RDMA parameters if present */
             if (pvrdma_opcode == PVRDMA_WR_RDMA_READ ||
                 pvrdma_opcode == PVRDMA_WR_RDMA_WRITE ||
                 pvrdma_opcode == PVRDMA_WR_RDMA_WRITE_WITH_IMM ||
@@ -709,17 +717,16 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
                 comp_ctx->rkey = wqe->hdr.wr.rdma.rkey;
             }
 
-            /* For RC/UC, use GID from QP attributes */
-            sgid_idx = 0; /* Default GID index */
+            sgid_idx = 0;
             sgid = rdma_rm_get_gid(&dev->rdma_dev_res, 0);
-            dgid = NULL; /* Not used for connected QPs */
-            dqpn = 0;    /* Remote QPN comes from QP pairing */
-            dqkey = 0;   /* Not used for connected QPs */
+            dgid = NULL;
+            dqpn = 0;
+            dqkey = 0;
         } else {
             rdma_error_report("Unsupported QP type %d for send", qp->qp_type);
             complete_with_error(VENDOR_ERR_INV_QP_TYPE, comp_ctx);
             pvrdma_ring_read_inc(ring);
-            qp->wqe_state.wqes_processed++;
+            qp->wqe_state.send_wqes_processed++;
             wqe = pvrdma_ring_next_elem_read(ring);
             continue;
         }
@@ -729,7 +736,7 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
                               dev->dev_attr.max_sge);
             complete_with_error(VENDOR_ERR_INV_NUM_SGE, comp_ctx);
             pvrdma_ring_read_inc(ring);
-            qp->wqe_state.wqes_processed++;
+            qp->wqe_state.send_wqes_processed++;
             wqe = pvrdma_ring_next_elem_read(ring);
             continue;
         }
@@ -740,7 +747,6 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
             qp, pvrdma_opcode, (unsigned long)comp_ctx->remote_addr,
             comp_ctx->rkey);
 
-        /* Track WQE processing */
         {
             PVRDMAQPStats *qp_stats = pvrdma_get_qp_stats(dev, qp_handle);
             if (qp_stats) {
@@ -751,22 +757,22 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
             }
         }
 
+        __atomic_fetch_add(&qp->send_in_flight, 1, __ATOMIC_ACQ_REL);
+
         rdma_backend_post_send(&dev->backend_dev, &qp->backend_qp, qp->qp_type,
                                (struct ibv_sge *)&wqe->sge[0], wqe->hdr.num_sge,
                                sgid_idx, sgid, dgid, dqpn, dqkey, comp_ctx);
 
         pvrdma_ring_read_inc(ring);
-        qp->wqe_state.wqes_processed++;
+        qp->wqe_state.send_wqes_processed++;
         wqe = pvrdma_ring_next_elem_read(ring);
     }
 
-    /* If more WQEs remain, schedule continuation */
     if (wqe) {
         schedule_wqe_processing_continuation(dev, qp_handle);
     } else {
-        /* All WQEs processed, clear processing flag */
-        qp->wqe_state.processing_active = false;
-        qp->wqe_state.wqes_processed = 0;
+        qp->wqe_state.send_processing_active = false;
+        qp->wqe_state.send_wqes_processed = 0;
     }
 }
 
@@ -786,10 +792,8 @@ void pvrdma_qp_recv(PVRDMADev *dev, uint32_t qp_handle)
     ring = &((PvrdmaRing *)qp->opaque)[1];
     rdma_info_report(">>> pvrdma_qp_recv: Computed ring=%p", ring);
 
-    /* Check if already processing - if so, just mark for continuation */
-    if (qp->wqe_state.processing_active) {
-        /* Already processing, will be continued by idle callback */
-        rdma_info_report(">>> pvrdma_qp_recv: QP %u already processing, "
+    if (qp->wqe_state.recv_processing_active) {
+        rdma_info_report(">>> pvrdma_qp_recv: QP %u recv already processing, "
                          "continuation scheduled",
                          qp_handle);
         return;
@@ -797,22 +801,19 @@ void pvrdma_qp_recv(PVRDMADev *dev, uint32_t qp_handle)
 
     wqe = pvrdma_ring_next_elem_read(ring);
     if (!wqe) {
-        /* No WQEs to process */
         return;
     }
 
-    /* Mark as processing */
-    qp->wqe_state.processing_active = true;
-    qp->wqe_state.wqes_processed = 0;
+    qp->wqe_state.recv_processing_active = true;
+    qp->wqe_state.recv_wqes_processed = 0;
 
-    /* Process batch of WQEs */
-    while (wqe && qp->wqe_state.wqes_processed < WQE_BATCH_SIZE) {
+    while (wqe && qp->wqe_state.recv_wqes_processed < WQE_BATCH_SIZE) {
         CompHandlerCtx *comp_ctx;
 
-        /* Prepare CQE */
         comp_ctx = g_new(CompHandlerCtx, 1);
         comp_ctx->dev = dev;
         comp_ctx->cq_handle = qp->recv_cq_handle;
+        comp_ctx->qp_handle = 0;
         comp_ctx->cqe.wr_id = wqe->hdr.wr_id;
         comp_ctx->cqe.qp = qp_handle;
         comp_ctx->cqe.opcode = IBV_WC_RECV;
@@ -822,7 +823,7 @@ void pvrdma_qp_recv(PVRDMADev *dev, uint32_t qp_handle)
                               dev->dev_attr.max_sge);
             complete_with_error(VENDOR_ERR_INV_NUM_SGE, comp_ctx);
             pvrdma_ring_read_inc(ring);
-            qp->wqe_state.wqes_processed++;
+            qp->wqe_state.recv_wqes_processed++;
             wqe = pvrdma_ring_next_elem_read(ring);
             continue;
         }
@@ -832,17 +833,15 @@ void pvrdma_qp_recv(PVRDMADev *dev, uint32_t qp_handle)
                                comp_ctx);
 
         pvrdma_ring_read_inc(ring);
-        qp->wqe_state.wqes_processed++;
+        qp->wqe_state.recv_wqes_processed++;
         wqe = pvrdma_ring_next_elem_read(ring);
     }
 
-    /* If more WQEs remain, schedule continuation */
     if (wqe) {
         schedule_recv_processing_continuation(dev, qp_handle);
     } else {
-        /* All WQEs processed, clear processing flag */
-        qp->wqe_state.processing_active = false;
-        qp->wqe_state.wqes_processed = 0;
+        qp->wqe_state.recv_processing_active = false;
+        qp->wqe_state.recv_wqes_processed = 0;
     }
 }
 

--- a/src/rocm_ernic_compat.c
+++ b/src/rocm_ernic_compat.c
@@ -147,7 +147,8 @@ pvrdma_handle_t pvrdma_device_create(rocm_ernic_dev_t *dev,
     /* Calculate dynamic device capabilities (from init_dev_caps in
      * pvrdma_main.c) */
     {
-        size_t pg_tbl_bytes = 2 * PAGE_SIZE * (PAGE_SIZE / sizeof(uint64_t));
+        size_t pg_tbl_bytes =
+            PVRDMA_PG_TBL_PAGES * PAGE_SIZE * (PAGE_SIZE / sizeof(uint64_t));
         size_t wr_sz = MAX(sizeof(struct pvrdma_sq_wqe_hdr),
                            sizeof(struct pvrdma_rq_wqe_hdr));
 

--- a/src/rocm_ernic_compat.c
+++ b/src/rocm_ernic_compat.c
@@ -147,7 +147,7 @@ pvrdma_handle_t pvrdma_device_create(rocm_ernic_dev_t *dev,
     /* Calculate dynamic device capabilities (from init_dev_caps in
      * pvrdma_main.c) */
     {
-        size_t pg_tbl_bytes = PAGE_SIZE * (PAGE_SIZE / sizeof(uint64_t));
+        size_t pg_tbl_bytes = 2 * PAGE_SIZE * (PAGE_SIZE / sizeof(uint64_t));
         size_t wr_sz = MAX(sizeof(struct pvrdma_sq_wqe_hdr),
                            sizeof(struct pvrdma_rq_wqe_hdr));
 


### PR DESCRIPTION
Introduce ansible/playbooks/stress-tests.yml with eight sequential test sections that exercise the emulated RDMA device beyond what the existing performance sweep covers: multi-QP bandwidth (-q 2/4/8), bidirectional transfer, duration-based soak with ernicctl stats polling, concurrent Send + Write verb mix, high iteration counts, QP churn (rapid create/destroy via ibv_rc_pingpong), sequential resource-limit probing, and an iperf3 TCP baseline for comparison.

All knobs are driven by new defaults in group_vars/all.yml (ernic_stress_multi_qp_counts, ernic_stress_bidir_sizes, ernic_stress_soak_duration, ernic_stress_high_iters, ernic_stress_qp_churn_cycles, ernic_stress_concurrent_duration) and are overridable via -e on the command line.

Update ansible/README.md with the new playbook entry in the quickstart, example override invocations, the directory tree, and a detailed description of each stress-test section.
