### PR TITLE
fix: update PCI device ID to 0x8000 and add pci.ids/dmesg helpers

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -316,7 +316,7 @@ jobs:
         
         echo "=== PCI Devices ==="
         sudo lspci | grep -i amd || echo "AMD device not found yet"
-        sudo lspci -nn | grep -E "1022:1488|AMD.*ERNIC" || echo "ROCm ERNIC device not found"
+        sudo lspci -nn | grep -E "1022:8000|AMD.*ERNIC" || echo "ROCm ERNIC device not found"
         
         echo ""
         echo "=== Checking for RDMA device ==="

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -174,6 +174,7 @@ cqn
 cqs
 ctrl
 ctx
+cz
 deadbeef
 del
 depmod
@@ -182,6 +183,7 @@ dev
 devel
 devinfo
 dir
+distros
 dkms
 dlopen
 dlsym
@@ -384,6 +386,7 @@ systemd
 symlink
 symvers
 sys
+sysctl
 sysfs
 sz
 tbl
@@ -396,6 +399,7 @@ toolchains
 typedef
 ubuntu
 uapi
+ucw
 uint
 uint16
 uint32

--- a/ansible/playbooks/guest-setup.yml
+++ b/ansible/playbooks/guest-setup.yml
@@ -216,6 +216,44 @@
         cmd: udevadm control --reload-rules
       changed_when: true
 
+    # ── Merge pci.ids fragment for lspci display ─────
+    - name: Find system pci.ids path
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      loop:
+        - /usr/share/hwdata/pci.ids
+        - /usr/share/misc/pci.ids
+      register: pciids_stat
+
+    - name: Set pci.ids path fact
+      ansible.builtin.set_fact:
+        pciids_path: >-
+          {{ (pciids_stat.results
+              | selectattr('stat.exists')
+              | first
+              | default({})).item | default('') }}
+
+    - name: Check if ROCm ERNIC entry exists in pci.ids
+      ansible.builtin.command:
+        argv:
+          - grep
+          - -q
+          - "8000  ROCm Emulated RDMA NIC"
+          - "{{ pciids_path }}"
+      register: pciids_grep
+      failed_when: false
+      changed_when: false
+      when: pciids_path | length > 0
+
+    - name: Merge ROCm ERNIC device into pci.ids
+      ansible.builtin.replace:
+        path: "{{ pciids_path }}"
+        regexp: '^(1022\s+.*)$'
+        replace: '\1\n\t8000  ROCm Emulated RDMA NIC'
+      when:
+        - pciids_path | length > 0
+        - pciids_grep.rc | default(1) != 0
+
     # ── Load driver modules ──────────────────────────
     - name: Load ib_core module
       community.general.modprobe:

--- a/docs/driver.rst
+++ b/docs/driver.rst
@@ -51,7 +51,7 @@ the InfiniBand device are visible:
 
 .. code-block:: bash
 
-   lspci | grep 1022:1488
+   lspci | grep 1022:8000
    ibv_devices
 
 Sysfs Loopback Mode

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -56,7 +56,7 @@ Inside the guest, load the kernel driver and verify:
 .. code-block:: bash
 
    sudo modprobe rocm_ernic
-   lspci | grep 1022:1488
+   lspci | grep 1022:8000
    ibv_devices
 
 Statistics Collection

--- a/driver/README.md
+++ b/driver/README.md
@@ -64,6 +64,37 @@ dmesg | grep rocm_ernic
 
 4. Verify the device is recognized:
    ```bash
-   lspci | grep 1022:1488
+   lspci | grep 1022:8000
    ibv_devices
    ```
+
+## PCI device name
+
+To have `lspci` show "ROCm Emulated RDMA NIC" for device
+`0x1022:0x8000`, merge the fragment from the project into your
+system pci.ids:
+
+- Fragment: [../scripts/pci.ids.rocm-ernic](../scripts/pci.ids.rocm-ernic)
+- Add the device line `8000  ROCm Emulated RDMA NIC` under vendor
+  `1022` (AMD) in your system pci.ids (e.g.
+  `/usr/share/hwdata/pci.ids` or `/usr/share/misc/pci.ids`). You
+  can merge the fragment or add the line manually.
+- For inclusion in the official PCI ID database, submit
+  `0x1022`/`0x8000` with name "ROCm Emulated RDMA NIC" at
+  <https://admin.pci-ids.ucw.cz/> (see <https://pci-ids.ucw.cz/>
+  for instructions).
+
+## Unprivileged dmesg (optional)
+
+For rocm-ernic testing, you may want any user to run `dmesg`
+without root.
+
+- **Option A (e.g. Ubuntu 24.04):** Allow all users to read the
+  kernel log:
+  - Temporarily: `sudo sysctl -w kernel.dmesg_restrict=0`
+  - Persistently: copy
+    [../scripts/99-rocm-ernic-dmesg.conf](../scripts/99-rocm-ernic-dmesg.conf)
+    to `/etc/sysctl.d/` and reboot or run
+    `sudo sysctl -p /etc/sysctl.d/99-rocm-ernic-dmesg.conf`.
+- **Option B:** On distros where the `adm` group can read kernel
+  logs, add the test user to group `adm` and re-login.

--- a/scripts/99-rocm-ernic-dmesg.conf
+++ b/scripts/99-rocm-ernic-dmesg.conf
@@ -1,0 +1,3 @@
+# Allow unprivileged users to run dmesg (for rocm-ernic driver debugging).
+# Copy to /etc/sysctl.d/ and run: sudo sysctl -p /etc/sysctl.d/99-rocm-ernic-dmesg.conf
+kernel.dmesg_restrict = 0

--- a/scripts/pci.ids.rocm-ernic
+++ b/scripts/pci.ids.rocm-ernic
@@ -1,0 +1,9 @@
+# PCI ID fragment for ROCm ERNIC (0x1022:0x8000).
+# Merge under vendor 1022 (AMD) in your system pci.ids so lspci shows
+# "ROCm Emulated RDMA NIC". Typical paths: /usr/share/hwdata/pci.ids or
+# /usr/share/misc/pci.ids. Add the device line below under the existing
+# "1022  AMD" vendor block. Note: running update-pciids will overwrite
+# the system pci.ids and discard this edit; re-apply after each update.
+#
+1022  AMD
+	8000  ROCm Emulated RDMA NIC

--- a/tests/test_loopback_configs.sh
+++ b/tests/test_loopback_configs.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
-# Test multiple loopback backend configurations
-# This script tests rdma_cm emulation with different backend options
+# Test multiple loopback backend configurations.
+# Uses TEST_BIN for client test (default: test_rdma_cm). CI may set
+# TEST_BIN=$BUILD_DIR/tests/test_data_transfer. Override SERVER_BIN/BUILD_DIR as needed.
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BUILD_DIR="${BUILD_DIR:-$PROJECT_ROOT/build}"
-SERVER_BIN="$BUILD_DIR/rocm-ernic"
-TEST_BIN="$BUILD_DIR/tests/test_rdma_cm"
+SERVER_BIN="${SERVER_BIN:-$BUILD_DIR/rocm-ernic}"
+TEST_BIN="${TEST_BIN:-$BUILD_DIR/tests/test_rdma_cm}"
 SOCKET_PATH="/tmp/test-loopback-$$.sock"
 
 # Colors for output

--- a/udev/99-rocm-ernic.rules
+++ b/udev/99-rocm-ernic.rules
@@ -25,16 +25,26 @@ SUBSYSTEM=="net", ACTION=="add", \
 
 # --- InfiniBand device naming ---
 #
-# Renames the RDMA device from the default
-# PCI-topology name (e.g. rocep1s0) to
-# rocm-rdma-ernic0.  The rename is deferred via a
-# backgrounded subshell because rdma-netlink calls
-# from a synchronous udev RUN can fail while the
-# device is still settling.
+# Renames the RDMA device from the PCI-topology
+# name (e.g. rocep2s0) to rocm-rdma-ernic0.
+#
+# The system rule 60-rdma-persistent-naming.rules
+# renames the device from its kernel-registered
+# name (rocm_ernic%d) to a PCI-topology name via
+# rdma_rename before this rule runs, making the
+# %k substitution stale.  Instead of using %k, we
+# look up the current RDMA device name by scanning
+# sysfs for vendor 0x1022.  A 2-second sleep lets
+# rdma_rename and device settling finish first.
 
 SUBSYSTEM=="infiniband", ACTION=="add", \
   DRIVERS=="rocm_ernic_eth", \
   ATTRS{vendor}=="0x1022", \
-  RUN+="/bin/sh -c '(sleep 1; \
-    /usr/bin/rdma dev set %k \
-    name rocm-rdma-ernic%n) &'"
+  RUN+="/bin/sh -c '(sleep 2; \
+    for v in /sys/class/infiniband/*/device/vendor; do \
+      [ -f $v ] || continue; \
+      read vid < $v; \
+      [ $vid = 0x1022 ] || continue; \
+      d=${v%%/device/vendor}; n=${d##*/}; \
+      /usr/bin/rdma dev set $n name rocm-rdma-ernic0; \
+    done) &'"


### PR DESCRIPTION
The driver and server use PCI device ID 0x8000, but docs and CI still referenced the old PVRDMA ID 0x1488. Update all lspci checks across driver/README.md, docs/driver.rst, docs/usage.rst, and system-tests.yml.

Cherry-pick useful bits from origin/dev/stebates/setup-vm that are not already covered by the Ansible automation on this branch:

- scripts/pci.ids.rocm-ernic: fragment so lspci shows "ROCm Emulated RDMA NIC" for 1022:8000.
- scripts/99-rocm-ernic-dmesg.conf: sysctl snippet to allow unprivileged dmesg for driver debugging.
- driver/README.md: add "PCI device name" and "Unprivileged dmesg" sections documenting the two new helpers.
- tests/test_loopback_configs.sh: accept TEST_BIN and SERVER_BIN from environment so CI can override the test binary.
- .wordlist.txt: add sysctl, distros, cz, ucw for spellcheck.

Skipped from setup-vm: setup-vm-rocm-ernic.py (Ansible covers this), 85-rocm-ernic-net.rules (conflicts with existing rocm-ernic%n naming), netplan example, and CI workflow rewrites (incompatible with CMake/Ansible CI on this branch).
