### PR TITLE
ci: add GitHub Pages deploy workflow for Sphinx docs

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,68 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# Deploy Sphinx documentation to GitHub Pages.
+#
+# Prerequisites (one-time, requires repo-admin access):
+#   Settings > Pages > Source = "GitHub Actions"
+
+name: docs-deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'src/**/*.h'
+      - 'driver/**/*.h'
+      - 'service/**'
+      - 'requirements.txt'
+      - '.github/workflows/docs-deploy.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: sphinx-build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake doxygen
+
+    - name: Configure docs-only build
+      run: |
+        cmake -S . -B build \
+          -DERNIC_DOCS_ONLY=ON \
+          -DERNIC_BUILD_DOCS=ON
+
+    - name: Build documentation
+      run: cmake --build build --target sphinx-html
+
+    - name: Upload Pages artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: build/docs/html
+
+  deploy:
+    name: deploy
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
Publishes the sphinx-html output to GitHub Pages on pushes to main that touch docs/, public headers, service code, or requirements.txt.  Also supports manual dispatch.

Mirrors the build steps from the existing docs-check workflow (cmake docs-only configure + sphinx-html target) and adds upload-pages-artifact / deploy-pages for the actual deployment.

Prerequisite: repo Settings > Pages > Source = "GitHub Actions".
