### PR TITLE
docs: slim README, add INSTALL and standard top-level files

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -447,3 +447,17 @@ xio
 xxxx
 yml
 yuval
+bugfix
+bugfixing
+changelog
+GLib
+html
+MERCHANTABILITY
+NONINFRINGEMENT
+PRs
+rst
+SPDX
+sublicense
+syscall
+UNRELEASED
+www

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog for rocm-ernic
+
+## UNRELEASED - rocm-ernic 0.0.1
+
+### Added
+
+### Changed
+
+### Removed
+
+### Limitations
+
+### Known issues

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# rocm-ernic Code of Conduct
+
+rocm-ernic is a part of ROCm and, like other ROCm components, requires that
+engagement with the rocm-ernic community abides by the
+[GitHub community guidelines][gh-guidelines] and the
+[GitHub community code of conduct][gh-coc].
+
+<!-- References -->
+
+[gh-guidelines]: https://docs.github.com/en/site-policy/github-terms/github-community-guidelines
+[gh-coc]: https://docs.github.com/en/site-policy/github-terms/github-community-code-of-conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to rocm-ernic
+
+Thank you for contributing! This guide outlines the development workflow,
+contribution standards, and best practices when working on rocm-ernic.
+
+## Development Setup
+
+Install the dependencies listed in [INSTALL.md](INSTALL.md) and build the
+project. Run the test suite with `ctest --test-dir build` before submitting
+changes.
+
+## Branching Model
+
+The main development trunk of rocm-ernic is the `main` branch.
+
+rocm-ernic generally uses trunk-based development, where feature branches are
+intended to be relatively short-lived. When necessary, feature branches will be
+created and prefixed with `feature/`. These feature branches will be deleted
+after the feature has been merged to `main`. Any feature branches which are not
+merged to `main`, but should be kept around for posterity, will be renamed
+`feature` --> `inactive`.
+
+External developers must use forks for development. You will sometimes see
+branches from AMD staff named `<category>/<user>/<description>`. These will be
+very short-lived.
+
+### Release branches
+
+Releases are tagged `vX.Y.Z`, where `X`, `Y`, and `Z` are the major, minor,
+and patch versions of the release.
+
+Releases occur from `main`. Upon release, the tag is created and the minor
+version number is bumped. The major version number will only be bumped on `main`
+when making an API/ABI-breaking change.
+
+Release branches are created retroactively and only when it is necessary to
+bugfix supported versions. Bugfixing should take place on `main` and be
+cherry-picked to any branches that are being maintained.
+
+## Pull Requests
+
+We welcome pull requests from outside contributors. Pull requests must pass our
+CI and be approved by at least one code owner. Outside contributors should fully
+fill out the PR template for non-trivial PRs.
+
+Please also ensure that your code complies with the project's `.clang-format`
+configuration.
+
+## Issue Reporting
+
+* Non-security issues should be reported as GitHub issues
+* Security issues should be reported as directed in [SECURITY.md](SECURITY.md)
+* Feature requests should be made using GitHub discussions

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,117 @@
+# Install guide for rocm-ernic
+
+## Quick Install Guide
+
+rocm-ernic requires libvfio-user and several RDMA/networking development
+libraries. On Ubuntu 24.04, install the required packages:
+
+```
+sudo apt install cmake meson ninja-build pkg-config \
+  libibverbs-dev librdmacm-dev libglib2.0-dev
+```
+
+Build and install libvfio-user if it is not already available on your system:
+
+```
+git clone https://github.com/nutanix/libvfio-user.git
+cd libvfio-user
+meson setup build --prefix=/usr
+ninja -C build
+sudo ninja -C build install
+sudo ldconfig
+```
+
+Then build rocm-ernic:
+
+```
+git clone https://github.com/ROCm/rocm-ernic.git
+cd rocm-ernic
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
+```
+
+Verify the build by starting the server with the loopback backend:
+
+```
+./build/rocm-ernic \
+  --socket /tmp/vfio-user-rocm-ernic.sock \
+  --backend loopback --verbose
+```
+
+## Building rocm-ernic
+
+> [!NOTE]
+> rocm-ernic is early-access software that has undergone testing on limited
+> hardware. It may not work on your system at this time.
+
+Supported compilers: gcc, clang
+
+Supported platforms: Linux (tested on Ubuntu 24.04)
+
+### Requirements
+
+* CMake 3.16 or later
+* Meson and Ninja (for libvfio-user)
+* pkg-config
+* libvfio-user (built from source; see above)
+* libibverbs and librdmacm development packages
+* GLib 2.0 development package
+
+### Configure
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| CMAKE\_BUILD\_TYPE | Debug | Build type (Debug, Release, etc.) |
+| ERNIC\_USE\_SANITIZERS | OFF | Enable ASAN / LSAN / UBSAN |
+| ERNIC\_USE\_THREAD\_SANITIZER | OFF | Enable TSAN (incompatible with above) |
+| ERNIC\_BUILD\_DOCS | OFF | Build Sphinx + Breathe + Doxygen documentation |
+| ERNIC\_DOCS\_ONLY | OFF | Docs-only build (no library dependencies required) |
+| CMAKE\_INSTALL\_PREFIX | /usr/local | Installation prefix |
+
+### Build
+
+```
+cmake --build build
+```
+
+### Run tests
+
+```
+ctest --test-dir build
+```
+
+### Install
+
+The default install prefix is `/usr/local`.
+
+```
+sudo cmake --install build
+```
+
+Custom install prefix:
+
+```
+cmake --install build --prefix /tmp/rocm-ernic-test
+```
+
+### Documentation
+
+Build the documentation with Sphinx, Breathe, and Doxygen. A Python virtual
+environment is created automatically in the build tree.
+
+```
+cmake -B build -G Ninja -DERNIC_BUILD_DOCS=ON
+cmake --build build --target sphinx-html
+```
+
+Output appears in `build/docs/html/index.html`.
+
+To build documentation without needing the project's library dependencies
+(libvfio-user, GLib, libibverbs):
+
+```
+cmake -B build -DERNIC_DOCS_ONLY=ON -DERNIC_BUILD_DOCS=ON
+cmake --build build --target sphinx-html
+```
+
+For full build details see [docs/building.rst](docs/building.rst).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,35 @@
+MIT License
+
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+## Files with different licenses
+
+Some files in this repository carry different licenses as noted in their
+individual SPDX headers:
+
+* Files under `src/from-qemu/` are derived from the QEMU project and are
+  licensed under `GPL-2.0-or-later`.
+* Files under `driver/` are Linux kernel driver sources and carry either
+  `GPL-2.0` (with Linux-syscall-note), dual `GPL-2.0 / BSD-2-Clause`, or
+  `Dual BSD/GPL` licenses as indicated by their SPDX headers.
+
+The per-file SPDX header takes precedence for any file that contains one.

--- a/README.md
+++ b/README.md
@@ -1,183 +1,45 @@
-# ROCm ERNIC: Emulated RDMA NIC for Virtual Machines
+# rocm-ernic
 
-This project contains a userspace implementation of an RDMA (Remote Direct
-Memory Access) device using the [libvfio-user][ref-libvfio] framework.
-It enables RDMA functionality for virtual machines without requiring
-actual RDMA hardware or relying on an in-guest framework like
-[soft RoCE][ref-softroce].
+[![MIT](https://img.shields.io/badge/License-MIT-blue.svg)][license]
+[![Build](https://github.com/ROCm/rocm-ernic/actions/workflows/build-test.yml/badge.svg)][ci-build]
+[![Docs](https://github.com/ROCm/rocm-ernic/actions/workflows/docs-check.yml/badge.svg)][ci-docs]
+[![Lint](https://github.com/ROCm/rocm-ernic/actions/workflows/lint.yml/badge.svg)][ci-lint]
+[![Spelling](https://github.com/ROCm/rocm-ernic/actions/workflows/spell-check.yml/badge.svg)][ci-spell]
+[![Platform](https://img.shields.io/badge/platform-linux-lightgrey.svg)](INSTALL.md)
 
-## Overview
+> [!CAUTION]
+> This release is an *early-access* software technology preview. Running
+> production workloads is *not* recommended.
 
-This project implements a fully functional RDMA device that can be attached to
-virtual machines (VMs) via the VFIO (Virtual Function I/O) user-space device
-framework. The device provides RDMA (Remote Direct Memory Access) capabilities
-to guest VMs via a number of different backends.
+Userspace emulated RDMA NIC for virtual machines, built on
+[libvfio-user][libvfio]. Provides full RDMA functionality to guest VMs without
+requiring physical RDMA hardware or an in-guest software stack such as
+[Soft-RoCE][softroce]. Backends include loopback (for testing and CI), TCP/IP
+(multi-node without hardware), and native verbs (real InfiniBand HCA
+pass-through).
 
-This project is intended to aid in RDMA-related software development without
-needing actual RDMA hardware. However it can also be used for CI and, possibly,
-in production via the RDMA backend.
+## Installing and Using rocm-ernic
 
-## Key Features
+See [INSTALL.md](INSTALL.md) for dependencies, supported platforms, and build
+instructions.
 
-  - Full PCIe device emulation in userspace
-  - Three memory-mapped BARs
-  - MSI-X interrupt support (command ring, async events, completion queue)
-  - Compatible with the Linux kernel `rocm_ernic` driver which is available in
-    the [driver](./driver) directory.
-  - Comprehensive statistics collection (doorbell rings, WQE processing, CQE
-    posting) with periodic updates to a file
+## Documentation
 
-# Architecture
+Full documentation lives in the [`docs/`](docs/) directory and covers building,
+architecture, usage, the kernel driver, the systemd service, testing, and the
+API reference.
 
-```
-┌──────────────────────────────────────────────┐
-│          Virtual Machine (Guest)             │
-│  ┌────────────────────────────────────┐      │
-│  │   Linux Kernel rocm_ernic Driver   │      │
-│  └─────────────┬──────────────────────┘      │
-│                │ PCI Interface               │
-└────────────────┼─────────────────────────────┘
-                 │ VFIO-User Protocol
-┌────────────────┼─────────────────────────────┐
-│                ▼                             │
-│  ┌──────────────────────────────────────┐    │
-│  │    rocm_ernic Server                 │    │
-│  │  (This Project)                      │    │
-│  │                                      │    │
-│  │  ┌───────────────────────┐           │    │
-│  │  │  RDMA Device Logic    │           │    │
-│  │  │  (adapted from QEMU)  │           │    │
-│  │  └──────────┬────────────┘           │    │
-│  │             │                        │    │
-│  │    ┌────────┴────────┐──────┐        │    │
-│  │    │                 │      │        │    │
-│  │    ▼                 ▼      ▼        │    │
-│  │  ┌──────┐  ┌──────────┐  ┌──────┐    │    │
-│  │  │Loop- │  │ TCP/IP   │  │RDMA/ │    │    │
-│  │  │back  │  │ Backend  │  │Verbs │    │    │
-│  │  │      │  │          │  │      │    │    │
-│  │  │In-   │  │TCP Socket│  │      │    │    │
-│  │  │Memory│  │Protocol  │  │      │    │    │
-│  │  │Emul. │  │          │  │      │    │    │
-│  │  └──────┘  └────┬─────┘  └──┬───┘    │    │
-│  └─────────────────┼───────────┼────────┘    │
-│                    │           │             │
-│     Host (Userspace/Kernel)    │             │
-│                    │           │             │
-│         ┌──────────┘           │             │
-│         │                      │             │
-│         ▼                      ▼             │
-│  ┌──────────────┐    ┌──────────────┐        │
-│  │Another       │    │  libibverbs  │        │
-│  │rocm_ernic    │    └──────┬───────┘        │
-│  │Server        │           │                │
-│  │(Remote VM)   │           ▼                │
-│  └──────────────┘    ┌──────────────┐        │
-│                      │ InfiniBand   │        │
-│                      │ Hardware     │        │
-│                      │              │        │
-│                      └──────────────┘        │
-└──────────────────────────────────────────────┘
-```
+## License
 
-# Building and Installing
+[MIT](LICENSE.md). Some files carry different licenses per their SPDX headers;
+see [LICENSE.md](LICENSE.md) for details.
 
-## Dependencies
+<!-- References -->
 
-```bash
-# Ubuntu/Debian
-sudo apt install cmake meson ninja-build pkg-config \
-  libibverbs-dev librdmacm-dev libglib2.0-dev
-
-# Build and install libvfio-user (if not already installed)
-# Note: libvfio-user uses Meson, not CMake
-cd /path/to/libvfio-user
-meson setup build --prefix=/usr
-ninja -C build
-sudo ninja -C build install
-sudo ldconfig
-```
-
-## Compilation
-
-```bash
-# From the project root directory
-cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
-cmake --build build
-
-# The executable will be at: build/rocm-ernic
-```
-
-## Installation
-
-```bash
-sudo cmake --install build
-# Installs to /usr/local/bin/rocm-ernic by default
-```
-
-## Build Options
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `CMAKE_BUILD_TYPE` | `Debug` | Build type |
-| `ERNIC_USE_SANITIZERS` | `OFF` | Enable ASAN/LSAN/UBSAN |
-| `ERNIC_USE_THREAD_SANITIZER` | `OFF` | Enable TSAN |
-| `CMAKE_INSTALL_PREFIX` | `/usr/local` | Install prefix |
-
-# Usage
-
-## Basic Usage
-
-```bash
-# Start the ROCm ERNIC device server with verbs backend
-./build/rocm-ernic --socket /tmp/vfio-user-rocm-ernic.sock \
-                   --backend verbs:device=mlx5_0,ethdev=eth0,port=1 \
-                   --verbose
-
-# Start with loopback backend (for testing)
-./build/rocm-ernic --socket /tmp/vfio-user-rocm-ernic.sock \
-                   --backend loopback \
-                   --verbose
-
-# Start with no backend (minimal stubs)
-./build/rocm-ernic --socket /tmp/vfio-user-rocm-ernic.sock \
-                   --backend none
-```
-
-## Statistics Collection
-
-The server can collect detailed statistics about doorbell rings, WQE processing,
-and completion queue entries. Statistics are written to a file approximately
-every second while the server is running.
-
-```bash
-# Start server with statistics collection
-./build/rocm-ernic --socket /tmp/vfio-user-rocm-ernic.sock \
-                   --backend loopback \
-                   --stats-file /tmp/rocm_ernic_stats.txt
-
-# Monitor statistics in real-time
-watch -n 0.5 cat /tmp/rocm_ernic_stats.txt
-```
-
-The statistics file includes:
-- Device-level statistics (commands, register reads/writes, UAR writes,
-  interrupts)
-- Per-QP statistics:
-  - Doorbell rings (send, receive, SRQ)
-  - WQEs processed (total and by opcode type)
-  - CQEs posted
-  - Continuation callbacks scheduled
-
-Statistics are automatically written on server exit (SIGINT/SIGTERM) in
-addition to the periodic updates.
-
-# Acknowledgments
-
-## Original QEMU PVRDMA Implementation
-
-- Yuval Shaia <yuval.shaia@oracle.com> (Oracle)
-- Marcel Apfelbaum <marcel@redhat.com> (Red Hat)
-
-[ref-libvfio]: https://github.com/nutanix/libvfio-user
-[ref-softroce]: https://man7.org/linux/man-pages/man7/rxe.7.html
+[license]: https://github.com/ROCm/rocm-ernic/blob/main/LICENSE.md
+[ci-build]: https://github.com/ROCm/rocm-ernic/actions/workflows/build-test.yml
+[ci-docs]: https://github.com/ROCm/rocm-ernic/actions/workflows/docs-check.yml
+[ci-lint]: https://github.com/ROCm/rocm-ernic/actions/workflows/lint.yml
+[ci-spell]: https://github.com/ROCm/rocm-ernic/actions/workflows/spell-check.yml
+[libvfio]: https://github.com/nutanix/libvfio-user
+[softroce]: https://man7.org/linux/man-pages/man7/rxe.7.html

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you have discovered a security vulnerability in rocm-ernic, please do NOT
+report it publicly using a GitHub issue. Instead, you should report the issue
+via the AMD Product Security website:
+
+<https://www.amd.com/en/resources/product-security.html>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,10 +53,24 @@ Quick Start
 
    api
 
+Acknowledgments
+---------------
+
+The RDMA device logic in ``src/from-qemu/`` is adapted from the
+QEMU PVRDMA implementation. The original authors of that work:
+
+- Yuval Shaia <yuval.shaia@oracle.com> (Oracle)
+- Marcel Apfelbaum <marcel@redhat.com> (Red Hat)
+
 License
 -------
 
-The userspace server and build infrastructure are licensed under
-GPL-2.0-or-later. The kernel driver carries the original VMware
-dual-license (GPL-2.0 / BSD-2-Clause) for files derived from
-the upstream PVRDMA driver.
+The project is licensed under the
+`MIT license <https://github.com/ROCm/rocm-ernic/blob/main/LICENSE.md>`_.
+Some files carry different licenses per their SPDX headers:
+
+- Files under ``src/from-qemu/`` are derived from QEMU and are
+  licensed under ``GPL-2.0-or-later``.
+- Files under ``driver/`` are Linux kernel driver sources and
+  carry ``GPL-2.0 / BSD-2-Clause`` dual licenses as indicated
+  by their SPDX headers.


### PR DESCRIPTION
Rewrite README.md to match the rocm-xio/hipFile badge-driven pattern: CI status badges, tech-preview caution box, one-paragraph description, and links to INSTALL.md and docs/.  All build instructions, usage examples, architecture diagrams, and acknowledgments that were previously inlined in the README already exist in docs/ and are no longer duplicated.

New top-level files (modeled on rocm-xio):

- INSTALL.md: quick install guide, requirements, CMake options table, build/test/install/docs-build instructions
- LICENSE.md: MIT license with note that src/from-qemu/ files keep GPL-2.0-or-later and driver/ files keep dual GPL-2.0/BSD-2-Clause
- CONTRIBUTING.md: branching model, PR guidelines, issue reporting
- CODE_OF_CONDUCT.md: points to GitHub community guidelines
- SECURITY.md: points to AMD Product Security for vulnerability reports
- CHANGELOG.md: keep-a-changelog skeleton with UNRELEASED section

Also:
- docs/index.rst: add Acknowledgments section (migrated from README), update License section to reflect MIT with per-file SPDX note
- .wordlist.txt: add terms introduced by the new files
