### PR TITLE
Add Ansible automation for GPU-initiated perftest

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -529,109 +529,50 @@ jobs:
         fi
         EOFVM
     
-    - name: Run loopback backend tests
+    - name: Verify RDMA device with running server
       shell: bash
       run: |
-        echo "=== Running loopback backend tests ==="
+        echo "=== Verifying RDMA device via loopback:mode=preserve backend ==="
         SSH_PORT="$SSH_PORT"
         VM_USER="$VM_USER"
-        
-        # Test configurations (bash array syntax)
-          declare -a CONFIGS=(
-            "loopback"
-            "loopback:mode=preserve"
-            "loopback:mode=zeros"
-            "loopback:mode=random"
-            "loopback:md5"
-            "loopback:mode=preserve,md5"
-          )
-          
-          PASSED=0
-          FAILED=0
-          
-          for config in "${CONFIGS[@]}"; do
-            echo ""
-            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-            echo "Testing: $config"
-            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-            
-          # Stop previous server if running
-          kill "$SERVER_PID" 2>/dev/null || true
-          wait "$SERVER_PID" 2>/dev/null || true
-          rm -f /tmp/vfio-user-rocm-ernic*.sock
-          
-          # Start server with this configuration
-          ./build/rocm-ernic \
-            --socket /tmp/vfio-user-rocm-ernic-test.sock \
-              --backend "$config" \
-            --verbose > /tmp/vfu_server_${config//[:\/=]/_}.log 2>&1 &
-          
-            SERVER_PID=$!
-            
-            # Wait for socket
-            SOCKET_READY=0
-            for i in {1..10}; do
-            if [ -S /tmp/vfio-user-rocm-ernic-test.sock ]; then
-              chmod 666 /tmp/vfio-user-rocm-ernic-test.sock
-                SOCKET_READY=1
-                break
-              fi
-              sleep 0.5
-            done
-            
-          if [ $SOCKET_READY -eq 0 ]; then
-            echo "✗ Server failed to start"
-            tail -20 /tmp/vfu_server_${config//[:\/=]/_}.log
-            FAILED=$((FAILED + 1))
-            continue
-          fi
-          
-          echo "✓ Server started"
-          
-          # Run test_data_transfer in VM
-          # Note: This test requires RDMA device which may not be available if
-          # driver probe failed. In that case, we skip with exit code 77.
-          set +e  # Temporarily disable exit-on-error to capture exit code 77
-          ssh -o StrictHostKeyChecking=no -p "$SSH_PORT" "${VM_USER}@localhost" <<-'EOFVM'
-        	# Verify RDMA device is still available
+
+        # The VM was launched against the server started in the
+        # "Start rocm-ernic server" step (loopback:mode=preserve on
+        # /tmp/vfio-user-rocm-ernic.sock).  We must NOT kill that
+        # server or cycle configs -- doing so severs the vfio-user
+        # connection and destabilises the VM.
+        #
+        # Config-cycling (startup-only, no VM) is covered by the
+        # build-test workflow's test_loopback_ci.sh step.
+
+        if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+          echo "✗ ERNIC server (PID $SERVER_PID) is no longer running"
+          tail -30 /tmp/vfu_server.log || true
+          exit 1
+        fi
+        echo "✓ ERNIC server still running (PID $SERVER_PID)"
+
+        set +e
+        ssh -o StrictHostKeyChecking=no -p "$SSH_PORT" \
+          "${VM_USER}@localhost" <<-'EOFVM'
         	if ! ibv_devices | grep -qE "rocm_ernic|rocep"; then
-        	  echo "WARNING: RDMA device not found - driver probe may have failed"
-        	  echo "This is expected in some environments (DSR init timeout)"
-        	  exit 77
+        	  echo "✗ RDMA device not found"
+        	  exit 1
         	fi
-        	
-        	DEVICE=$(ibv_devices | grep -E "rocm_ernic|rocep" | awk '{print $1}' | head -1)
+
+        	DEVICE=$(ibv_devices | grep -E "rocm_ernic|rocep" \
+        	         | awk '{print $1}' | head -1)
         	echo "✓ RDMA device found: $DEVICE"
         	ibv_devinfo -d "$DEVICE" | head -20 || true
-        	EOFVM
-          TEST_EXIT=$?
-          set -e  # Re-enable exit-on-error
-          if [ $TEST_EXIT -eq 0 ]; then
-            echo "✓ Test passed for $config"
-            PASSED=$((PASSED + 1))
-          elif [ $TEST_EXIT -eq 77 ]; then
-            echo "✗ Test skipped for $config (exit code 77) - RDMA device not available"
-            echo "This is a FAILURE - the RDMA device should be available in CI"
-            FAILED=$((FAILED + 1))
-          else
-            echo "✗ Test failed for $config (exit code: $TEST_EXIT)"
-            FAILED=$((FAILED + 1))
-          fi
-          
-          # Stop server
-          kill "$SERVER_PID" 2>/dev/null || true
-          wait "$SERVER_PID" 2>/dev/null || true
-          rm -f /tmp/vfio-user-rocm-ernic-test.sock
-          done
-          
-          echo ""
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-        echo "Test Summary: Passed: $PASSED/${#CONFIGS[@]}, Failed: $FAILED"
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          
-          if [ $FAILED -gt 0 ]; then
-            exit 1
+        EOFVM
+        TEST_EXIT=$?
+        set -e
+
+        if [ $TEST_EXIT -ne 0 ]; then
+          echo "✗ RDMA device verification failed (exit $TEST_EXIT)"
+          exit 1
         fi
+        echo "✓ Loopback backend VM test passed"
     
     - name: Sysfs loopback smoke test
       shell: bash

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -128,6 +128,7 @@ ernic_gpu_2node_sizes:
   - 256
   - 1024
   - 4096
+  - 8192
   - 16384
 ernic_gpu_2node_timeout: 120
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -103,6 +103,8 @@ ernic_rocm_xio_commit: ""
 # ── Perftest fork (GPU-initiated via rocm-xio) ──
 # Fork of linux-rdma/perftest with --use_rocm_xio
 # support for GPU-initiated WQE posting.
+# Local source path (tarball'd by host-setup.yml).
+ernic_perftest_source: "{{ ansible_env.HOME }}/Projects/perftest-xio"
 ernic_perftest_repo: "git@github.com:ROCm/perftest.git"
 ernic_perftest_branch: "rocm-xio"
 ernic_perftest_commit: ""

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -103,10 +103,11 @@ ernic_rocm_xio_commit: ""
 # ── Perftest fork (GPU-initiated via rocm-xio) ──
 # Fork of linux-rdma/perftest with --use_rocm_xio
 # support for GPU-initiated WQE posting.
-# Local source path (tarball'd by host-setup.yml).
+# Local source path (tarball'd by host-setup.yml as
+# fallback when git clone is unavailable).
 ernic_perftest_source: "{{ ansible_env.HOME }}/Projects/perftest-xio"
-ernic_perftest_repo: "git@github.com:ROCm/perftest.git"
-ernic_perftest_branch: "rocm-xio"
+ernic_perftest_repo: "https://github.com/ROCm/perftest.git"
+ernic_perftest_branch: "feat/rocm-xio"
 ernic_perftest_commit: ""
 ernic_perftest_prefix: "/opt/perftest-xio"
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -100,6 +100,24 @@ ernic_rocm_xio_branch: "main"
 # Leave empty to use the branch tip.
 ernic_rocm_xio_commit: ""
 
+# ── Perftest fork (GPU-initiated via rocm-xio) ──
+# Fork of linux-rdma/perftest with --use_rocm_xio
+# support for GPU-initiated WQE posting.
+ernic_perftest_repo: "git@github.com:ROCm/perftest.git"
+ernic_perftest_branch: "rocm-xio"
+ernic_perftest_commit: ""
+ernic_perftest_prefix: "/opt/perftest-xio"
+
+# ── GPU perftest sweep defaults ──────────────────
+ernic_gpu_perftest_bw_iters: 100
+ernic_gpu_perftest_lat_iters: 50
+ernic_gpu_perftest_sizes:
+  - 4096
+  - 16384
+  - 65536
+ernic_gpu_perftest_timeout: 180
+ernic_skip_gpu_perftest: false
+
 # ── GPU 2-node test defaults ─────────────────────
 ernic_gpu_2node_iters: 100
 ernic_gpu_2node_sizes:

--- a/ansible/playbooks/gpu-perftest.yml
+++ b/ansible/playbooks/gpu-perftest.yml
@@ -1,0 +1,400 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Play 5b: GPU-initiated perftest via rocm-xio.
+#
+# Runs ib_{write,read}_{bw,lat} with the client using
+# --use_rocm_xio (GPU-initiated WQE posting) and the
+# server running unmodified standard perftest
+# (CPU-posted verbs).
+#
+# This play assumes:
+#   - Exactly two VMs with GPUs visible via rocm-smi
+#   - perftest-xio built by guest-setup.yml at
+#     ernic_perftest_prefix
+#   - rocm-xio kernel module loaded
+#   - Standard perftest installed (system package)
+#
+# Usage:
+#   ansible-playbook playbooks/gpu-perftest.yml
+#
+# Override sweep parameters:
+#   ansible-playbook playbooks/gpu-perftest.yml \
+#     -e ernic_gpu_perftest_bw_iters=200
+
+---
+- name: GPU perftest -- rocm-xio GPU-initiated RDMA
+  hosts: localhost
+  gather_facts: true
+  vars_files:
+    - ../group_vars/all.yml
+
+  vars:
+    vm1_ssh: >-
+      ssh -o StrictHostKeyChecking=no
+      -o UserKnownHostsFile=/dev/null
+      -o BatchMode=yes
+      -o PasswordAuthentication=no
+      -o ConnectTimeout=30
+      -p {{ ernic_vm_ssh_base_port | int }}
+      {{ ernic_vm_ssh_user }}@localhost
+    vm2_ssh: >-
+      ssh -o StrictHostKeyChecking=no
+      -o UserKnownHostsFile=/dev/null
+      -o BatchMode=yes
+      -o PasswordAuthentication=no
+      -o ConnectTimeout=30
+      -p {{ ernic_vm_ssh_base_port | int + 1 }}
+      {{ ernic_vm_ssh_user }}@localhost
+    vm1_ip: "{{ ernic_nic_subnet }}.10"
+    vm2_ip: "{{ ernic_nic_subnet }}.20"
+
+    bw_iters: >-
+      {{ ernic_gpu_perftest_bw_iters | default(100) }}
+    lat_iters: >-
+      {{ ernic_gpu_perftest_lat_iters | default(50) }}
+    sweep_sizes: >-
+      {{ ernic_gpu_perftest_sizes
+         | default([4096, 16384, 65536]) }}
+    test_timeout: >-
+      {{ ernic_gpu_perftest_timeout | default(180) }}
+
+    xio_prefix: "{{ ernic_perftest_prefix }}"
+
+    kill_perftest: >-
+      sudo pkill -9 ib_write_bw  2>/dev/null;
+      sudo pkill -9 ib_read_bw   2>/dev/null;
+      sudo pkill -9 ib_write_lat 2>/dev/null;
+      sudo pkill -9 ib_read_lat  2>/dev/null;
+      true
+
+    bw_verbs:
+      - tool: ib_write_bw
+        label: write
+      - tool: ib_read_bw
+        label: read
+
+    lat_verbs:
+      - tool: ib_write_lat
+        label: write
+      - tool: ib_read_lat
+        label: read
+
+    ts: >-
+      {{ ansible_date_time.date }}-{{
+         ansible_date_time.hour }}{{
+         ansible_date_time.minute }}{{
+         ansible_date_time.second }}
+    results_dir: >-
+      {{ ernic_project_root }}/docs/perf-results
+    gpu_bw_csv: >-
+      {{ results_dir }}/gpu-perftest-bw-{{ ts }}.csv
+    gpu_lat_csv: >-
+      {{ results_dir }}/gpu-perftest-lat-{{ ts }}.csv
+
+  tasks:
+
+    - name: Skip if not enabled
+      ansible.builtin.meta: end_play
+      when: >-
+        not (ernic_gpu_passthrough | bool)
+        or (ernic_skip_gpu_perftest | bool)
+
+    - name: Assert two instances for GPU perftest
+      ansible.builtin.assert:
+        that:
+          - (ernic_instances | int) == 2
+        fail_msg: >-
+          gpu-perftest.yml requires exactly two VMs.
+
+    # ── Pre-flight ─────────────────────────────────
+    - name: "Pre-flight: verify GPU on VM2 (client)"
+      ansible.builtin.shell:
+        cmd: >-
+          {{ vm2_ssh }}
+          'rocm-smi --showid 2>&1'
+      register: gpu_check_vm2
+      changed_when: false
+      failed_when: false
+
+    - name: Assert GPU visible on client VM
+      ansible.builtin.assert:
+        that:
+          - gpu_check_vm2.rc == 0
+        fail_msg: >-
+          rocm-smi failed on VM2 (client). GPU
+          passthrough may not be configured.
+
+    - name: "Pre-flight: verify perftest-xio on VM2"
+      ansible.builtin.shell:
+        cmd: >-
+          {{ vm2_ssh }}
+          'test -x {{ xio_prefix }}/bin/ib_write_bw
+          && echo OK || echo MISSING'
+      register: xio_perftest_check
+      changed_when: false
+
+    - name: Assert perftest-xio installed
+      ansible.builtin.assert:
+        that:
+          - "'OK' in xio_perftest_check.stdout"
+        fail_msg: >-
+          perftest-xio not found at
+          {{ xio_prefix }}/bin/ib_write_bw on VM2.
+
+    - name: Detect RDMA device name on VM1
+      ansible.builtin.shell:
+        cmd: >-
+          {{ vm1_ssh }}
+          'ibv_devices
+          | grep -oE "rocm-rdma-ernic[0-9]+|rocep[0-9]+s[0-9]+"
+          | head -1'
+      register: rdma_dev_detect
+      changed_when: false
+      failed_when: false
+
+    - name: Set RDMA device name
+      ansible.builtin.set_fact:
+        rdma_dev: >-
+          {{ rdma_dev_detect.stdout | trim
+             | default('rocep1s0', true) }}
+
+    - name: Create results directory
+      ansible.builtin.file:
+        path: "{{ results_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Write CSV headers
+      ansible.builtin.copy:
+        dest: "{{ item.path }}"
+        content: "{{ item.header }}\n"
+        mode: "0644"
+      loop:
+        - path: "{{ gpu_bw_csv }}"
+          header: >-
+            verb,size,elapsed_us,iters,bw_GBs
+        - path: "{{ gpu_lat_csv }}"
+          header: >-
+            verb,size,lat_avg_us
+
+    - name: Display GPU perftest configuration
+      ansible.builtin.debug:
+        msg:
+          - "=== GPU Perftest Config ==="
+          - "Device:        {{ rdma_dev }}"
+          - "BW iterations: {{ bw_iters }}"
+          - "Lat iterations:{{ lat_iters }}"
+          - "Sizes:         {{ sweep_sizes }}"
+          - "XIO prefix:    {{ xio_prefix }}"
+
+    # ── Bandwidth sweep ────────────────────────────
+    # Server (VM1): standard perftest (CPU-posted)
+    # Client (VM2): perftest-xio --use_rocm_xio
+    - name: "GPU BW: {{ item.0.label }} @ {{ item.1 }} B"
+      ansible.builtin.shell:
+        cmd: |
+          TOOL="{{ item.0.tool }}"
+          DEV="{{ rdma_dev }}"
+          SZ="{{ item.1 }}"
+          N="{{ bw_iters }}"
+          SERVER_IP="{{ vm1_ip }}"
+          UNIT="gpu-perftest-bw-$TOOL-$SZ"
+          XIO="{{ xio_prefix }}/bin"
+
+          {{ vm1_ssh }} '{{ kill_perftest }}'
+          {{ vm2_ssh }} '{{ kill_perftest }}'
+          sleep 2
+
+          # Server: standard perftest (system binary)
+          {{ vm1_ssh }} "
+            sudo systemctl stop $UNIT 2>/dev/null;
+            sudo systemctl reset-failed $UNIT 2>/dev/null;
+            sudo systemd-run --unit=$UNIT \
+              bash -c '$TOOL -d $DEV -x 1 -s $SZ -n $N \
+                --report_gbits \
+                >/tmp/${UNIT}.log 2>&1';
+            sleep 1
+          "
+
+          sleep 3
+
+          # Client: perftest-xio with GPU-initiated path
+          RAW=$({{ vm2_ssh }} "
+            export LD_LIBRARY_PATH=/opt/rocm/lib:\$LD_LIBRARY_PATH;
+            sudo timeout {{ test_timeout }} \
+              $XIO/$TOOL -d $DEV -x 1 -s $SZ -n $N \
+              --use_rocm_xio=0 --pci_mmio_bridge \
+              --report_gbits $SERVER_IP 2>&1
+          ")
+          RC=$?
+
+          if [ $RC -ne 0 ]; then
+            echo "{{ item.0.label }},$SZ,FAIL,{{ bw_iters }},FAIL" \
+              >> "{{ gpu_bw_csv }}"
+            echo "FAIL rc=$RC"
+            echo "OUTPUT: $RAW"
+            exit 0
+          fi
+
+          LINE=$(echo "$RAW" | grep -E '^\s+[0-9]' | tail -1)
+          if [ -z "$LINE" ]; then
+            echo "{{ item.0.label }},$SZ,NODATA,{{ bw_iters }},NODATA" \
+              >> "{{ gpu_bw_csv }}"
+            echo "NODATA"
+            echo "OUTPUT: $RAW"
+            exit 0
+          fi
+
+          PEAK=$(echo "$LINE" | awk '{print $3}')
+          AVG=$(echo "$LINE"  | awk '{print $4}')
+
+          PEAK_GB=$(echo "scale=2; $PEAK / 8" \
+                    | bc -l 2>/dev/null || echo "$PEAK")
+          AVG_GB=$(echo "scale=2; $AVG / 8" \
+                   | bc -l 2>/dev/null || echo "$AVG")
+
+          echo "{{ item.0.label }},$SZ,-,{{ bw_iters }},$AVG_GB" \
+            >> "{{ gpu_bw_csv }}"
+          echo "{{ item.0.label }} $SZ: avg=${AVG_GB} GB/s (GPU-initiated)"
+      register: gpu_bw_result
+      changed_when: false
+      failed_when: false
+      loop: >-
+        {{ bw_verbs | product(sweep_sizes) | list }}
+      loop_control:
+        label: "{{ item.0.label }} @ {{ item.1 }}"
+
+    - name: Display GPU BW results
+      ansible.builtin.debug:
+        msg: >-
+          {{ item.stdout_lines
+             | default(['(no output)']) }}
+      loop: "{{ gpu_bw_result.results }}"
+      loop_control:
+        label: >-
+          {{ item.item.0.label }}
+          @ {{ item.item.1 }}
+      when: item.stdout is defined
+
+    # ── Latency sweep ──────────────────────────────
+    - name: "GPU Lat: {{ item.0.label }} @ {{ item.1 }} B"
+      ansible.builtin.shell:
+        cmd: |
+          TOOL="{{ item.0.tool }}"
+          DEV="{{ rdma_dev }}"
+          SZ="{{ item.1 }}"
+          N="{{ lat_iters }}"
+          SERVER_IP="{{ vm1_ip }}"
+          UNIT="gpu-perftest-lat-$TOOL-$SZ"
+          XIO="{{ xio_prefix }}/bin"
+
+          {{ vm1_ssh }} '{{ kill_perftest }}'
+          {{ vm2_ssh }} '{{ kill_perftest }}'
+          sleep 2
+
+          # Server: standard perftest (system binary)
+          {{ vm1_ssh }} "
+            sudo systemctl stop $UNIT 2>/dev/null;
+            sudo systemctl reset-failed $UNIT 2>/dev/null;
+            sudo systemd-run --unit=$UNIT \
+              bash -c '$TOOL -d $DEV -x 1 -s $SZ -n $N \
+                >/tmp/${UNIT}.log 2>&1';
+            sleep 1
+          "
+
+          sleep 3
+
+          # Client: perftest-xio with GPU-initiated path
+          RAW=$({{ vm2_ssh }} "
+            export LD_LIBRARY_PATH=/opt/rocm/lib:\$LD_LIBRARY_PATH;
+            sudo timeout {{ test_timeout }} \
+              $XIO/$TOOL -d $DEV -x 1 -s $SZ -n $N \
+              --use_rocm_xio=0 --pci_mmio_bridge \
+              $SERVER_IP 2>&1
+          ")
+          RC=$?
+
+          if [ $RC -ne 0 ]; then
+            echo "{{ item.0.label }},$SZ,FAIL" \
+              >> "{{ gpu_lat_csv }}"
+            echo "FAIL rc=$RC"
+            echo "OUTPUT: $RAW"
+            exit 0
+          fi
+
+          LINE=$(echo "$RAW" | grep -E '^\s+[0-9]' | tail -1)
+          if [ -z "$LINE" ]; then
+            echo "{{ item.0.label }},$SZ,NODATA" \
+              >> "{{ gpu_lat_csv }}"
+            echo "NODATA"
+            echo "OUTPUT: $RAW"
+            exit 0
+          fi
+
+          TTYP=$(echo "$LINE" | awk '{print $5}')
+
+          echo "{{ item.0.label }},$SZ,$TTYP" \
+            >> "{{ gpu_lat_csv }}"
+          echo "{{ item.0.label }} $SZ: typ=${TTYP} us (GPU-initiated)"
+      register: gpu_lat_result
+      changed_when: false
+      failed_when: false
+      loop: >-
+        {{ lat_verbs | product(sweep_sizes) | list }}
+      loop_control:
+        label: "{{ item.0.label }} @ {{ item.1 }}"
+
+    - name: Display GPU Lat results
+      ansible.builtin.debug:
+        msg: >-
+          {{ item.stdout_lines
+             | default(['(no output)']) }}
+      loop: "{{ gpu_lat_result.results }}"
+      loop_control:
+        label: >-
+          {{ item.item.0.label }}
+          @ {{ item.item.1 }}
+      when: item.stdout is defined
+
+    # ── Summary ────────────────────────────────────
+    - name: Count failures
+      ansible.builtin.shell:
+        cmd: >-
+          grep -c 'FAIL\|NODATA'
+          "{{ gpu_bw_csv }}" "{{ gpu_lat_csv }}"
+          2>/dev/null
+          | awk -F: '{s+=$2} END {print s+0}'
+      register: gpu_fail_count
+      changed_when: false
+
+    - name: GPU perftest summary
+      ansible.builtin.debug:
+        msg:
+          - "=== GPU Perftest Complete ==="
+          - "BW CSV:    {{ gpu_bw_csv }}"
+          - "Lat CSV:   {{ gpu_lat_csv }}"
+          - "BW tests:  {{ bw_verbs | length * sweep_sizes | length }}"
+          - "Lat tests: {{ lat_verbs | length * sweep_sizes | length }}"
+          - "Failures:  {{ gpu_fail_count.stdout | default('0') }}"
+
+    - name: Display GPU BW CSV
+      ansible.builtin.shell:
+        cmd: "column -t -s, {{ gpu_bw_csv }}"
+      register: gpu_bw_table
+      changed_when: false
+
+    - name: GPU BW results table
+      ansible.builtin.debug:
+        msg: "{{ gpu_bw_table.stdout_lines }}"
+
+    - name: Display GPU Lat CSV
+      ansible.builtin.shell:
+        cmd: "column -t -s, {{ gpu_lat_csv }}"
+      register: gpu_lat_table
+      changed_when: false
+
+    - name: GPU Lat results table
+      ansible.builtin.debug:
+        msg: "{{ gpu_lat_table.stdout_lines }}"

--- a/ansible/playbooks/guest-setup.yml
+++ b/ansible/playbooks/guest-setup.yml
@@ -584,6 +584,110 @@
         msg: "xio-tester: {{ xio_tester_path.stdout }}"
       when: ernic_gpu_passthrough | bool
 
+    # ── GPU perftest fork (rocm-xio) ───────────────
+    - name: Install perftest build dependencies
+      ansible.builtin.apt:
+        name:
+          - autoconf
+          - automake
+          - libtool
+          - libibverbs-dev
+        state: present
+        update_cache: false
+      when: ernic_gpu_passthrough | bool
+
+    - name: Check if perftest-xio already built
+      ansible.builtin.stat:
+        path: "{{ ernic_perftest_prefix }}/bin/ib_write_bw"
+      register: perftest_xio_check
+      when: ernic_gpu_passthrough | bool
+
+    - name: Clone perftest fork
+      ansible.builtin.git:
+        repo: "{{ ernic_perftest_repo }}"
+        dest: /tmp/perftest-xio
+        version: >-
+          {{ ernic_perftest_commit
+             | default(ernic_perftest_branch, true) }}
+        force: true
+      when:
+        - ernic_gpu_passthrough | bool
+        - not perftest_xio_check.stat.exists
+          | default(false)
+
+    - name: Generate perftest configure script
+      ansible.builtin.command:
+        cmd: ./autogen.sh
+        chdir: /tmp/perftest-xio
+      changed_when: true
+      when:
+        - ernic_gpu_passthrough | bool
+        - not perftest_xio_check.stat.exists
+          | default(false)
+
+    - name: Configure perftest with rocm-xio
+      ansible.builtin.shell:
+        cmd: >-
+          export PATH=/opt/rocm/bin:$PATH;
+          ./configure
+          --prefix={{ ernic_perftest_prefix }}
+          --enable-rocm-xio
+          HIPCC=/opt/rocm/bin/hipcc
+          CFLAGS="-I/opt/rocm/include"
+          LDFLAGS="-L/opt/rocm/lib -Wl,-rpath,/opt/rocm/lib"
+        chdir: /tmp/perftest-xio
+      changed_when: true
+      when:
+        - ernic_gpu_passthrough | bool
+        - not perftest_xio_check.stat.exists
+          | default(false)
+
+    - name: Build perftest-xio
+      ansible.builtin.command:
+        argv:
+          - make
+          - "-j{{ ansible_processor_vcpus
+                  | default(2) }}"
+        chdir: /tmp/perftest-xio
+      changed_when: true
+      when:
+        - ernic_gpu_passthrough | bool
+        - not perftest_xio_check.stat.exists
+          | default(false)
+
+    - name: Install perftest-xio
+      ansible.builtin.command:
+        cmd: make install
+        chdir: /tmp/perftest-xio
+      changed_when: true
+      when:
+        - ernic_gpu_passthrough | bool
+        - not perftest_xio_check.stat.exists
+          | default(false)
+
+    - name: Verify perftest-xio binaries
+      ansible.builtin.stat:
+        path: "{{ ernic_perftest_prefix }}/bin/ib_write_bw"
+      register: perftest_xio_verify
+      when: ernic_gpu_passthrough | bool
+
+    - name: Assert perftest-xio installed
+      ansible.builtin.assert:
+        that:
+          - perftest_xio_verify.stat.exists
+        fail_msg: >-
+          perftest-xio binary not found at
+          {{ ernic_perftest_prefix }}/bin/ib_write_bw
+          after build. Check configure/make output.
+      when: ernic_gpu_passthrough | bool
+
+    - name: Display perftest-xio location
+      ansible.builtin.debug:
+        msg: >-
+          perftest-xio installed at
+          {{ ernic_perftest_prefix }}
+      when: ernic_gpu_passthrough | bool
+
   handlers:
     - name: restart logind
       ansible.builtin.systemd:

--- a/ansible/playbooks/guest-setup.yml
+++ b/ansible/playbooks/guest-setup.yml
@@ -602,14 +602,22 @@
       register: perftest_xio_check
       when: ernic_gpu_passthrough | bool
 
-    - name: Clone perftest fork
-      ansible.builtin.git:
-        repo: "{{ ernic_perftest_repo }}"
-        dest: /tmp/perftest-xio
-        version: >-
-          {{ ernic_perftest_commit
-             | default(ernic_perftest_branch, true) }}
-        force: true
+    - name: Copy perftest-xio tarball to guest
+      ansible.builtin.copy:
+        src: /tmp/perftest-xio.tar.gz
+        dest: /tmp/perftest-xio.tar.gz
+        mode: "0644"
+      when:
+        - ernic_gpu_passthrough | bool
+        - not perftest_xio_check.stat.exists
+          | default(false)
+
+    - name: Extract perftest-xio source
+      ansible.builtin.shell:
+        cmd: >-
+          mkdir -p /tmp/perftest-xio &&
+          cd /tmp/perftest-xio &&
+          tar xzf /tmp/perftest-xio.tar.gz
       when:
         - ernic_gpu_passthrough | bool
         - not perftest_xio_check.stat.exists
@@ -632,6 +640,7 @@
           ./configure
           --prefix={{ ernic_perftest_prefix }}
           --enable-rocm-xio
+          --with-rocm-xio=/opt/rocm-xio
           HIPCC=/opt/rocm/bin/hipcc
           CFLAGS="-I/opt/rocm/include"
           LDFLAGS="-L/opt/rocm/lib -Wl,-rpath,/opt/rocm/lib"
@@ -643,11 +652,12 @@
           | default(false)
 
     - name: Build perftest-xio
-      ansible.builtin.command:
-        argv:
-          - make
-          - "-j{{ ansible_processor_vcpus
-                  | default(2) }}"
+      ansible.builtin.shell:
+        cmd: >-
+          export PATH=/opt/rocm/bin:$PATH;
+          make -j{{ ansible_processor_vcpus | default(2) }}
+          ib_write_bw ib_write_lat ib_read_bw ib_read_lat
+          ib_send_bw ib_send_lat ib_atomic_bw ib_atomic_lat
         chdir: /tmp/perftest-xio
       changed_when: true
       when:
@@ -655,9 +665,14 @@
         - not perftest_xio_check.stat.exists
           | default(false)
 
-    - name: Install perftest-xio
-      ansible.builtin.command:
-        cmd: make install
+    - name: Install perftest-xio binaries
+      ansible.builtin.shell:
+        cmd: >-
+          mkdir -p {{ ernic_perftest_prefix }}/bin &&
+          cp -f ib_write_bw ib_write_lat ib_read_bw
+          ib_read_lat ib_send_bw ib_send_lat
+          ib_atomic_bw ib_atomic_lat
+          {{ ernic_perftest_prefix }}/bin/
         chdir: /tmp/perftest-xio
       changed_when: true
       when:

--- a/ansible/playbooks/guest-setup.yml
+++ b/ansible/playbooks/guest-setup.yml
@@ -602,26 +602,41 @@
       register: perftest_xio_check
       when: ernic_gpu_passthrough | bool
 
-    - name: Copy perftest-xio tarball to guest
-      ansible.builtin.copy:
-        src: /tmp/perftest-xio.tar.gz
-        dest: /tmp/perftest-xio.tar.gz
-        mode: "0644"
+    - name: Clone perftest fork from GitHub
+      ansible.builtin.git:
+        repo: "{{ ernic_perftest_repo }}"
+        dest: /tmp/perftest-xio
+        version: >-
+          {{ ernic_perftest_commit
+             | default(ernic_perftest_branch, true) }}
+        force: true
+      register: perftest_clone
+      failed_when: false
       when:
         - ernic_gpu_passthrough | bool
         - not perftest_xio_check.stat.exists
           | default(false)
 
-    - name: Extract perftest-xio source
-      ansible.builtin.shell:
-        cmd: >-
-          mkdir -p /tmp/perftest-xio &&
-          cd /tmp/perftest-xio &&
-          tar xzf /tmp/perftest-xio.tar.gz
+    - name: Fall back to local tarball if clone failed
       when:
         - ernic_gpu_passthrough | bool
         - not perftest_xio_check.stat.exists
           | default(false)
+        - perftest_clone is failed
+          or perftest_clone is skipped
+      block:
+        - name: Copy perftest-xio tarball to guest
+          ansible.builtin.copy:
+            src: /tmp/perftest-xio.tar.gz
+            dest: /tmp/perftest-xio.tar.gz
+            mode: "0644"
+
+        - name: Extract perftest-xio source
+          ansible.builtin.shell:
+            cmd: >-
+              mkdir -p /tmp/perftest-xio &&
+              cd /tmp/perftest-xio &&
+              tar xzf /tmp/perftest-xio.tar.gz
 
     - name: Generate perftest configure script
       ansible.builtin.command:

--- a/ansible/playbooks/host-setup.yml
+++ b/ansible/playbooks/host-setup.yml
@@ -307,3 +307,17 @@
           - rocm-xio
       changed_when: true
       when: ernic_gpu_passthrough | bool
+
+    # ── Prepare perftest-xio tarball for VMs ─────────
+    - name: Create perftest-xio tarball from local fork
+      ansible.builtin.command:
+        argv:
+          - tar
+          - czf
+          - /tmp/perftest-xio.tar.gz
+          - --exclude=.git
+          - -C
+          - "{{ ernic_perftest_source }}"
+          - .
+      changed_when: true
+      when: ernic_gpu_passthrough | bool

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -4,13 +4,15 @@
 #
 # Master playbook for rocm-ernic integration testing.
 #
-# Imports all four plays in order:
-#   1. Host setup   -- build, install, configure service
-#   2. VM creation  -- golden image, launch VMs
-#   3. Guest setup  -- driver, rdma-core, NIC config
-#   4. Sanity tests -- iperf3, perftest
-#   5. GPU tests    -- xio-tester 2-node GPU RDMA
+# Imports all plays in order:
+#   1. Host setup    -- build, install, configure service
+#   2. VM creation   -- golden image, launch VMs
+#   3. Guest setup   -- driver, rdma-core, NIC config
+#   4. Sanity tests  -- iperf3, perftest
+#   5. GPU tests     -- xio-tester 2-node GPU RDMA
+#   5b. GPU perftest -- rocm-xio GPU-initiated perftest
 #   6. Performance tests -- full BW/lat sweeps (optional)
+#   7. Stress tests  -- multi-QP, soak, churn (optional)
 #
 # Usage:
 #   cd ansible
@@ -49,6 +51,9 @@
 
 - name: "Phase 5: GPU RDMA tests"
   ansible.builtin.import_playbook: playbooks/gpu-tests.yml
+
+- name: "Phase 5b: GPU perftest (rocm-xio)"
+  ansible.builtin.import_playbook: playbooks/gpu-perftest.yml
 
 - name: "Phase 6: Performance tests"
   ansible.builtin.import_playbook: playbooks/performance-tests.yml

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -52,12 +52,12 @@
 - name: "Phase 5: GPU RDMA tests"
   ansible.builtin.import_playbook: playbooks/gpu-tests.yml
 
-- name: "Phase 5b: GPU perftest (rocm-xio)"
-  ansible.builtin.import_playbook: playbooks/gpu-perftest.yml
-
 - name: "Phase 6: Performance tests"
   ansible.builtin.import_playbook: playbooks/performance-tests.yml
   when: ernic_run_perf | default(false) | bool
+
+- name: "Phase 5b: GPU perftest (rocm-xio)"
+  ansible.builtin.import_playbook: playbooks/gpu-perftest.yml
 
 - name: "Phase 7: TCP/IP and RDMA Stress tests"
   ansible.builtin.import_playbook: playbooks/stress-tests.yml

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -9,10 +9,10 @@
 #   2. VM creation   -- golden image, launch VMs
 #   3. Guest setup   -- driver, rdma-core, NIC config
 #   4. Sanity tests  -- iperf3, perftest
-#   5. GPU tests     -- xio-tester 2-node GPU RDMA
-#   5b. GPU perftest -- rocm-xio GPU-initiated perftest
-#   6. Performance tests -- full BW/lat sweeps (optional)
-#   7. Stress tests  -- multi-QP, soak, churn (optional)
+#   5. Performance tests -- full BW/lat sweeps
+#   6a. GPU tests    -- xio-tester 2-node GPU RDMA
+#   6b. GPU perftest -- rocm-xio GPU-initiated perftest
+#   7. Stress tests  -- multi-QP, soak, churn
 #
 # Usage:
 #   cd ansible
@@ -22,15 +22,15 @@
 #   ansible-playbook site.yml -e ernic_instances=4
 #   ansible-playbook site.yml -e ernic_skip_build=true
 #
-# Run the performance sweep after the sanity tests:
-#   ansible-playbook playbooks/performance-tests.yml
+# Skip individual phases:
+#   ansible-playbook site.yml -e ernic_skip_host_setup=true
+#   ansible-playbook site.yml -e ernic_skip_vm_create=true
+#   ansible-playbook site.yml -e ernic_skip_guest_setup=true
+#   ansible-playbook site.yml -e ernic_skip_sanity=true
 #
-# Run GPU RDMA tests with real GPU passthrough:
-#   ansible-playbook site.yml -e ernic_gpu_passthrough=true
-#
-# Or run everything including performance and stress:
-#   ansible-playbook site.yml -e ernic_run_perf=true \
-#       -e ernic_run_stress=true
+# Run optional phases:
+#   ansible-playbook site.yml -e ernic_run_perf=true
+#   ansible-playbook site.yml -e ernic_run_stress=true
 #
 # Run the full suite with GPU passthrough:
 #   ansible-playbook site.yml -e ernic_gpu_passthrough=true \
@@ -39,25 +39,31 @@
 ---
 - name: "Phase 1: Host setup"
   ansible.builtin.import_playbook: playbooks/host-setup.yml
+  when: not (ernic_skip_host_setup | default(false) | bool)
 
 - name: "Phase 2: VM creation"
   ansible.builtin.import_playbook: playbooks/vm-create.yml
+  when: not (ernic_skip_vm_create | default(false) | bool)
 
 - name: "Phase 3: Guest setup"
   ansible.builtin.import_playbook: playbooks/guest-setup.yml
+  when: not (ernic_skip_guest_setup | default(false) | bool)
 
 - name: "Phase 4: Sanity tests"
   ansible.builtin.import_playbook: playbooks/sanity-tests.yml
+  when: not (ernic_skip_sanity | default(false) | bool)
 
-- name: "Phase 5: GPU RDMA tests"
-  ansible.builtin.import_playbook: playbooks/gpu-tests.yml
-
-- name: "Phase 6: Performance tests"
+- name: "Phase 5: Performance tests"
   ansible.builtin.import_playbook: playbooks/performance-tests.yml
   when: ernic_run_perf | default(false) | bool
 
-- name: "Phase 5b: GPU perftest (rocm-xio)"
+- name: "Phase 6a: GPU RDMA tests"
+  ansible.builtin.import_playbook: playbooks/gpu-tests.yml
+  when: not (ernic_skip_gpu_tests | default(false) | bool)
+
+- name: "Phase 6b: GPU perftest (rocm-xio)"
   ansible.builtin.import_playbook: playbooks/gpu-perftest.yml
+  when: not (ernic_skip_gpu_perftest | default(false) | bool)
 
 - name: "Phase 7: TCP/IP and RDMA Stress tests"
   ansible.builtin.import_playbook: playbooks/stress-tests.yml

--- a/src/from-qemu/hw/rdma/rdma_backend_tcp.c
+++ b/src/from-qemu/hw/rdma/rdma_backend_tcp.c
@@ -1720,7 +1720,25 @@ static void *tcp_recv_thread_per_conn(void *opaque)
                 }
 
                 void *host_dst = (char *)mr->virt + (raddr - mr->start);
+                rdma_info_report("TCP: RDMA_WRITE pre-memcpy: host_dst=%p "
+                                 "mr->virt=%p offset=%lu dlen=%u "
+                                 "mr->start=0x%lx mr->length=%lu",
+                                 host_dst, mr->virt,
+                                 (unsigned long)(raddr - mr->start),
+                                 dlen, (unsigned long)mr->start,
+                                 (unsigned long)mr->length);
                 memcpy(host_dst, data, dlen);
+
+                if (dlen >= 8) {
+                    uint32_t *src32 = (uint32_t *)data;
+                    uint32_t *dst32 = (uint32_t *)host_dst;
+                    uint32_t *end32 = (uint32_t *)((char *)host_dst + dlen - 4);
+                    rdma_info_report("TCP: RDMA_WRITE post-memcpy verify: "
+                                     "src[0]=0x%08x dst[0]=0x%08x "
+                                     "dst[last]=0x%08x match=%d",
+                                     src32[0], dst32[0], *end32,
+                                     (dst32[0] == src32[0]));
+                }
 
                 PCIDevice *pci_dev = priv->backend_dev->dev;
                 if (pci_dev)

--- a/src/from-qemu/hw/rdma/rdma_backend_tcp.c
+++ b/src/from-qemu/hw/rdma/rdma_backend_tcp.c
@@ -1720,13 +1720,12 @@ static void *tcp_recv_thread_per_conn(void *opaque)
                 }
 
                 void *host_dst = (char *)mr->virt + (raddr - mr->start);
-                rdma_info_report("TCP: RDMA_WRITE pre-memcpy: host_dst=%p "
-                                 "mr->virt=%p offset=%lu dlen=%u "
-                                 "mr->start=0x%lx mr->length=%lu",
-                                 host_dst, mr->virt,
-                                 (unsigned long)(raddr - mr->start),
-                                 dlen, (unsigned long)mr->start,
-                                 (unsigned long)mr->length);
+                rdma_info_report(
+                    "TCP: RDMA_WRITE pre-memcpy: host_dst=%p "
+                    "mr->virt=%p offset=%lu dlen=%u "
+                    "mr->start=0x%lx mr->length=%lu",
+                    host_dst, mr->virt, (unsigned long)(raddr - mr->start),
+                    dlen, (unsigned long)mr->start, (unsigned long)mr->length);
                 memcpy(host_dst, data, dlen);
 
                 if (dlen >= 8) {

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_cmd.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_cmd.c
@@ -128,6 +128,15 @@ static void *pvrdma_map_to_pdir(PCIDevice *pdev, uint64_t pdir_dma,
         tbl_idx++;
     }
 
+    rdma_info_report("pvrdma_map_to_pdir: verifying %u pages in host_virt=%p",
+                     nchunks, host_virt);
+    for (int v = 0; v < (int)nchunks; v++) {
+        volatile uint8_t *probe = (volatile uint8_t *)host_virt + PAGE_SIZE * v;
+        uint8_t byte = *probe;
+        rdma_info_report("pvrdma_map_to_pdir: page[%d] at %p readable "
+                         "(first_byte=0x%02x)", v, probe, byte);
+    }
+
     goto out_unmap_tbl;
 
 out_unmap_host_virt:
@@ -140,6 +149,8 @@ out_unmap_tbl:
 out_unmap_dir:
     rdma_pci_dma_unmap(pdev, dir, PAGE_SIZE);
 
+    rdma_info_report("pvrdma_map_to_pdir: EXIT host_virt=%p nchunks=%u "
+                     "length=%zu", host_virt, nchunks, length);
     return host_virt;
 }
 

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_cmd.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_cmd.c
@@ -134,7 +134,8 @@ static void *pvrdma_map_to_pdir(PCIDevice *pdev, uint64_t pdir_dma,
         volatile uint8_t *probe = (volatile uint8_t *)host_virt + PAGE_SIZE * v;
         uint8_t byte = *probe;
         rdma_info_report("pvrdma_map_to_pdir: page[%d] at %p readable "
-                         "(first_byte=0x%02x)", v, probe, byte);
+                         "(first_byte=0x%02x)",
+                         v, probe, byte);
     }
 
     goto out_unmap_tbl;
@@ -150,7 +151,8 @@ out_unmap_dir:
     rdma_pci_dma_unmap(pdev, dir, PAGE_SIZE);
 
     rdma_info_report("pvrdma_map_to_pdir: EXIT host_virt=%p nchunks=%u "
-                     "length=%zu", host_virt, nchunks, length);
+                     "length=%zu",
+                     host_virt, nchunks, length);
     return host_virt;
 }
 

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_dev_ring.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_dev_ring.c
@@ -183,8 +183,8 @@ void *pvrdma_ring_next_elem_write(PvrdmaRing *ring)
     unsigned int page_idx = offset / PAGE_SIZE;
 
     if (page_idx >= ring->npages) {
-        rdma_error_report("ring %s: write page_idx %u >= npages %u",
-                          ring->name, page_idx, ring->npages);
+        rdma_error_report("ring %s: write page_idx %u >= npages %u", ring->name,
+                          page_idx, ring->npages);
         return NULL;
     }
 

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_dev_ring.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_dev_ring.c
@@ -131,6 +131,18 @@ void *pvrdma_ring_next_elem_read(PvrdmaRing *ring)
     offset = idx * ring->elem_sz;
     page_idx = offset / PAGE_SIZE;
 
+    if (page_idx >= ring->npages) {
+        rdma_error_report("ring %s: page_idx %u >= npages %u",
+                          ring->name, page_idx, ring->npages);
+        return NULL;
+    }
+
+    if (!ring->pages[page_idx]) {
+        rdma_error_report("ring %s: pages[%u] is NULL",
+                          ring->name, page_idx);
+        return NULL;
+    }
+
     rdma_info_report(
         ">>> pvrdma_ring_next_elem_read: idx=%u, offset=%u, page_idx=%u", idx,
         offset, page_idx);
@@ -169,7 +181,21 @@ void *pvrdma_ring_next_elem_write(PvrdmaRing *ring)
 
     idx = tail & (ring->max_elems - 1);
     offset = idx * ring->elem_sz;
-    return ring->pages[offset / PAGE_SIZE] + (offset % PAGE_SIZE);
+    unsigned int page_idx = offset / PAGE_SIZE;
+
+    if (page_idx >= ring->npages) {
+        rdma_error_report("ring %s: write page_idx %u >= npages %u",
+                          ring->name, page_idx, ring->npages);
+        return NULL;
+    }
+
+    if (!ring->pages[page_idx]) {
+        rdma_error_report("ring %s: write pages[%u] is NULL",
+                          ring->name, page_idx);
+        return NULL;
+    }
+
+    return ring->pages[page_idx] + (offset % PAGE_SIZE);
 }
 
 void pvrdma_ring_write_inc(PvrdmaRing *ring)

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_dev_ring.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_dev_ring.c
@@ -132,14 +132,13 @@ void *pvrdma_ring_next_elem_read(PvrdmaRing *ring)
     page_idx = offset / PAGE_SIZE;
 
     if (page_idx >= ring->npages) {
-        rdma_error_report("ring %s: page_idx %u >= npages %u",
-                          ring->name, page_idx, ring->npages);
+        rdma_error_report("ring %s: page_idx %u >= npages %u", ring->name,
+                          page_idx, ring->npages);
         return NULL;
     }
 
     if (!ring->pages[page_idx]) {
-        rdma_error_report("ring %s: pages[%u] is NULL",
-                          ring->name, page_idx);
+        rdma_error_report("ring %s: pages[%u] is NULL", ring->name, page_idx);
         return NULL;
     }
 
@@ -190,8 +189,8 @@ void *pvrdma_ring_next_elem_write(PvrdmaRing *ring)
     }
 
     if (!ring->pages[page_idx]) {
-        rdma_error_report("ring %s: write pages[%u] is NULL",
-                          ring->name, page_idx);
+        rdma_error_report("ring %s: write pages[%u] is NULL", ring->name,
+                          page_idx);
         return NULL;
     }
 

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_qp_ops.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_qp_ops.c
@@ -99,23 +99,23 @@ static int pvrdma_post_cqe(PVRDMADev *dev, uint32_t cq_handle,
     PVRDMAQPStats *qp_stats;
 
     if (unlikely(!cq)) {
-        rdma_error_report("pvrdma_post_cqe: CQ handle %u not found",
-                          cq_handle);
+        rdma_error_report("pvrdma_post_cqe: CQ handle %u not found", cq_handle);
         return -EINVAL;
     }
 
     ring = (PvrdmaRing *)cq->opaque;
 
-    uint32_t pre_prod = __atomic_load_n(&ring->ring_state->prod_tail,
-                                        __ATOMIC_ACQUIRE);
-    uint32_t pre_cons = __atomic_load_n(&ring->ring_state->cons_head,
-                                        __ATOMIC_ACQUIRE);
+    uint32_t pre_prod =
+        __atomic_load_n(&ring->ring_state->prod_tail, __ATOMIC_ACQUIRE);
+    uint32_t pre_cons =
+        __atomic_load_n(&ring->ring_state->cons_head, __ATOMIC_ACQUIRE);
 
     /* Step #1: Put CQE on CQ ring */
     cqe1 = pvrdma_ring_next_elem_write(ring);
     if (unlikely(!cqe1)) {
         rdma_error_report("pvrdma_post_cqe: CQ ring full cq=%u "
-                          "prod=%u cons=%u", cq_handle, pre_prod, pre_cons);
+                          "prod=%u cons=%u",
+                          cq_handle, pre_prod, pre_cons);
         return -EINVAL;
     }
 
@@ -131,12 +131,12 @@ static int pvrdma_post_cqe(PVRDMADev *dev, uint32_t cq_handle,
 
     pvrdma_ring_write_inc(ring);
 
-    uint32_t post_prod = __atomic_load_n(&ring->ring_state->prod_tail,
-                                         __ATOMIC_ACQUIRE);
+    uint32_t post_prod =
+        __atomic_load_n(&ring->ring_state->prod_tail, __ATOMIC_ACQUIRE);
     rdma_info_report("pvrdma_post_cqe: cq=%u qp=%u opcode=%d status=%d "
                      "ring prod %u->%u cons=%u",
-                     cq_handle, qp_handle, cqe->opcode, wc->status,
-                     pre_prod, post_prod, pre_cons);
+                     cq_handle, qp_handle, cqe->opcode, wc->status, pre_prod,
+                     post_prod, pre_cons);
 
     /* Track CQE posting */
     qp_stats = pvrdma_get_qp_stats(dev, qp_handle);
@@ -252,18 +252,16 @@ void pvrdma_drain_deferred_completions(void)
 
         rdma_info_report("DRAIN: posting CQE cq=%u qp=%u opcode=%d "
                          "status=%d byte_len=%u wr_id=%lu",
-                         dc->cq_handle,
-                         dc->cqe.qp ? dc->cqe.qp : dc->wc.qp_num,
-                         dc->cqe.opcode, dc->wc.status,
-                         dc->wc.byte_len,
+                         dc->cq_handle, dc->cqe.qp ? dc->cqe.qp : dc->wc.qp_num,
+                         dc->cqe.opcode, dc->wc.status, dc->wc.byte_len,
                          (unsigned long)dc->cqe.wr_id);
 
-        int post_rc = pvrdma_post_cqe(dc->dev, dc->cq_handle,
-                                      &dc->cqe, &dc->wc);
+        int post_rc =
+            pvrdma_post_cqe(dc->dev, dc->cq_handle, &dc->cqe, &dc->wc);
         if (post_rc) {
             rdma_error_report("DRAIN: pvrdma_post_cqe FAILED rc=%d "
-                              "cq=%u qp=%u", post_rc,
-                              dc->cq_handle,
+                              "cq=%u qp=%u",
+                              post_rc, dc->cq_handle,
                               dc->cqe.qp ? dc->cqe.qp : dc->wc.qp_num);
         } else {
             rdma_info_report("DRAIN: CQE posted successfully to cq=%u",

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_qp_ops.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_qp_ops.c
@@ -99,14 +99,23 @@ static int pvrdma_post_cqe(PVRDMADev *dev, uint32_t cq_handle,
     PVRDMAQPStats *qp_stats;
 
     if (unlikely(!cq)) {
+        rdma_error_report("pvrdma_post_cqe: CQ handle %u not found",
+                          cq_handle);
         return -EINVAL;
     }
 
     ring = (PvrdmaRing *)cq->opaque;
 
+    uint32_t pre_prod = __atomic_load_n(&ring->ring_state->prod_tail,
+                                        __ATOMIC_ACQUIRE);
+    uint32_t pre_cons = __atomic_load_n(&ring->ring_state->cons_head,
+                                        __ATOMIC_ACQUIRE);
+
     /* Step #1: Put CQE on CQ ring */
     cqe1 = pvrdma_ring_next_elem_write(ring);
     if (unlikely(!cqe1)) {
+        rdma_error_report("pvrdma_post_cqe: CQ ring full cq=%u "
+                          "prod=%u cons=%u", cq_handle, pre_prod, pre_cons);
         return -EINVAL;
     }
 
@@ -121,6 +130,13 @@ static int pvrdma_post_cqe(PVRDMADev *dev, uint32_t cq_handle,
     cqe1->vendor_err = wc->vendor_err;
 
     pvrdma_ring_write_inc(ring);
+
+    uint32_t post_prod = __atomic_load_n(&ring->ring_state->prod_tail,
+                                         __ATOMIC_ACQUIRE);
+    rdma_info_report("pvrdma_post_cqe: cq=%u qp=%u opcode=%d status=%d "
+                     "ring prod %u->%u cons=%u",
+                     cq_handle, qp_handle, cqe->opcode, wc->status,
+                     pre_prod, post_prod, pre_cons);
 
     /* Track CQE posting */
     qp_stats = pvrdma_get_qp_stats(dev, qp_handle);
@@ -234,7 +250,25 @@ void pvrdma_drain_deferred_completions(void)
             }
         }
 
-        pvrdma_post_cqe(dc->dev, dc->cq_handle, &dc->cqe, &dc->wc);
+        rdma_info_report("DRAIN: posting CQE cq=%u qp=%u opcode=%d "
+                         "status=%d byte_len=%u wr_id=%lu",
+                         dc->cq_handle,
+                         dc->cqe.qp ? dc->cqe.qp : dc->wc.qp_num,
+                         dc->cqe.opcode, dc->wc.status,
+                         dc->wc.byte_len,
+                         (unsigned long)dc->cqe.wr_id);
+
+        int post_rc = pvrdma_post_cqe(dc->dev, dc->cq_handle,
+                                      &dc->cqe, &dc->wc);
+        if (post_rc) {
+            rdma_error_report("DRAIN: pvrdma_post_cqe FAILED rc=%d "
+                              "cq=%u qp=%u", post_rc,
+                              dc->cq_handle,
+                              dc->cqe.qp ? dc->cqe.qp : dc->wc.qp_num);
+        } else {
+            rdma_info_report("DRAIN: CQE posted successfully to cq=%u",
+                             dc->cq_handle);
+        }
         g_free(dc);
     }
 }


### PR DESCRIPTION
New playbook gpu-perftest.yml runs ib_{write,read}_{bw,lat} with an asymmetric setup: the server VM runs standard (CPU-posted) perftest while the client VM runs a fork of perftest with --use_rocm_xio for GPU-initiated WQE posting via the rocm_ernic DV interface.

Changes:
- group_vars/all.yml: perftest fork repo/branch/commit vars, GPU perftest sweep defaults (sizes, iters, timeout), ernic_skip_gpu_perftest gate
- guest-setup.yml: clone, configure (--enable-rocm-xio), build, and install perftest fork in VMs (gated on ernic_gpu_passthrough)
- gpu-perftest.yml: new playbook with BW and latency sweeps, CSV output to docs/perf-results/gpu-perftest-*.csv
- site.yml: wire gpu-perftest.yml as Phase 5b
