### PR TITLE
chore(repo): prepare repo for public consumption

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @sbates130272 @gaoikawa
+

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: Performance Benchmark
 
 on:
@@ -14,6 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     container:
+      # TODO: move to ghcr.io/rocm/... once the image is published under the ROCm org
       image: >-
         sbates130272/batesste-ci-images-ubuntu-qemu-libvfio-user:latest
 
@@ -71,6 +73,7 @@ jobs:
       run: |
         SIZES="4096 8192 16384 32768 65536 131072"
         SIZES="$SIZES 262144 524288 1048576 2097152"
+        # rocep1s0 is the RDMA device name as seen inside the CI container image
         echo "size,send_bw,write_bw,read_bw" > bw.csv
         for sz in $SIZES; do
           sbw=$(ib_send_bw -s $sz -n 100 \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: Build Test
 
 on:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: docs-check
 
 on:

--- a/.github/workflows/driver-build.yml
+++ b/.github/workflows/driver-build.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: Driver Build
 
 on:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: Lint
 
 on:

--- a/.github/workflows/service-test.yml
+++ b/.github/workflows/service-test.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: Service Tooling Tests
 
 on:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: Spell Check
 
 on:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -1,8 +1,9 @@
+# SPDX-License-Identifier: MIT
 name: System Tests
 
 on:
   pull_request:
-    branches: [ main, dev/stephen/tcp-ip-backend ]
+    branches: [ main ]
   workflow_dispatch:
 
 # Container image with QEMU and libvfio-user pre-built
@@ -15,12 +16,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     container:
+      # TODO: move to ghcr.io/rocm/... once the image is published under the ROCm org
       image: sbates130272/batesste-ci-images-ubuntu-qemu-libvfio-user:latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
     - name: Display environment
       run: |
         echo "=== Environment ==="
@@ -57,14 +59,14 @@ jobs:
         
         # Extract values using jq or python
         if command -v jq &> /dev/null; then
-          VM_USER=$(jq -r '.username // "batesste"' /output/vm-info.json)
+          VM_USER=$(jq -r '.username // "ci"' /output/vm-info.json)
           VM_DISK=$(jq -r '.image_path' /output/vm-info.json)
           SSH_KEY=$(jq -r '.ssh_key // ""' /output/vm-info.json)
           SSH_KEY_PRIVATE=$(jq -r '.ssh_keys.private_key_path // ""' /output/vm-info.json)
           SSH_KEY_PUBLIC=$(jq -r '.ssh_keys.public_key_path // ""' /output/vm-info.json)
         else
           # Fallback to python if jq not available
-          VM_USER=$(python3 -c "import json; print(json.load(open('/output/vm-info.json')).get('username', 'batesste'))")
+          VM_USER=$(python3 -c "import json; print(json.load(open('/output/vm-info.json')).get('username', 'ci'))")
           VM_DISK=$(python3 -c "import json; print(json.load(open('/output/vm-info.json')).get('image_path', ''))")
           SSH_KEY=$(python3 -c "import json; print(json.load(open('/output/vm-info.json')).get('ssh_key', ''))")
           SSH_KEY_PRIVATE=$(python3 -c "import json; d=json.load(open('/output/vm-info.json')); print(d.get('ssh_keys', {}).get('private_key_path', ''))")
@@ -757,8 +759,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     container:
+      # TODO: move to ghcr.io/rocm/... once the image is published under the ROCm org
       image: sbates130272/batesste-ci-images-ubuntu-qemu-libvfio-user:latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -830,14 +833,14 @@ jobs:
         
         # Extract values using jq or python
         if command -v jq &> /dev/null; then
-          VM_USER=$(jq -r '.username // "batesste"' /output/vm-info.json)
+          VM_USER=$(jq -r '.username // "ci"' /output/vm-info.json)
           VM_DISK=$(jq -r '.image_path' /output/vm-info.json)
           SSH_KEY=$(jq -r '.ssh_key // ""' /output/vm-info.json)
           SSH_KEY_PRIVATE=$(jq -r '.ssh_keys.private_key_path // ""' /output/vm-info.json)
           SSH_KEY_PUBLIC=$(jq -r '.ssh_keys.public_key_path // ""' /output/vm-info.json)
         else
           # Fallback to python if jq not available
-          VM_USER=$(python3 -c "import json; print(json.load(open('/output/vm-info.json')).get('username', 'batesste'))")
+          VM_USER=$(python3 -c "import json; print(json.load(open('/output/vm-info.json')).get('username', 'ci'))")
           VM_DISK=$(python3 -c "import json; print(json.load(open('/output/vm-info.json')).get('image_path', ''))")
           SSH_KEY=$(python3 -c "import json; print(json.load(open('/output/vm-info.json')).get('ssh_key', ''))")
           SSH_KEY_PRIVATE=$(python3 -c "import json; d=json.load(open('/output/vm-info.json')); print(d.get('ssh_keys', {}).get('private_key_path', ''))")
@@ -897,7 +900,7 @@ jobs:
         VM_DISK_1="${{ steps.vm_info.outputs.vm_disk }}"
         
         # Create second VM disk name by inserting .2 before .qcow2 extension
-        # e.g., /output/batesste-ci-vm.qcow2 -> /output/batesste-ci-vm.2.qcow2
+        # e.g., /output/ci-vm.qcow2 -> /output/ci-vm.2.qcow2
         VM_DISK_DIR=$(dirname "$VM_DISK_1")
         VM_DISK_BASENAME=$(basename "$VM_DISK_1")
         VM_DISK_NAME="${VM_DISK_BASENAME%.qcow2}"

--- a/driver/rocm_ernic.h
+++ b/driver/rocm_ernic.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2012-2016 VMware, Inc.  All rights reserved.
  *

--- a/driver/rocm_ernic_cmd.c
+++ b/driver/rocm_ernic_cmd.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2012-2016 VMware, Inc.  All rights reserved.
  *

--- a/driver/rocm_ernic_cq.c
+++ b/driver/rocm_ernic_cq.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2012-2016 VMware, Inc.  All rights reserved.
  *

--- a/driver/rocm_ernic_dev_api.h
+++ b/driver/rocm_ernic_dev_api.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2012-2016 VMware, Inc.  All rights reserved.
  *

--- a/driver/rocm_ernic_doorbell.c
+++ b/driver/rocm_ernic_doorbell.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2012-2016 VMware, Inc.  All rights reserved.
  *

--- a/driver/rocm_ernic_main.c
+++ b/driver/rocm_ernic_main.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2012-2016 VMware, Inc.  All rights reserved.
  *

--- a/driver/rocm_ernic_misc.c
+++ b/driver/rocm_ernic_misc.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2012-2016 VMware, Inc.  All rights reserved.
  *

--- a/driver/rocm_ernic_mr.c
+++ b/driver/rocm_ernic_mr.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2012-2016 VMware, Inc.  All rights reserved.
  *

--- a/driver/rocm_ernic_pci_ids.h
+++ b/driver/rocm_ernic_pci_ids.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * PCI IDs for ROCm ERNIC. Must match src/rocm_ernic_server.c
  * (vfu_pci_set_id). AMD vendor ID; device ID 0x8000 for ROCm ERNIC.

--- a/driver/rocm_ernic_qp.c
+++ b/driver/rocm_ernic_qp.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2012-2016 VMware, Inc.  All rights reserved.
  *

--- a/driver/rocm_ernic_ring.h
+++ b/driver/rocm_ernic_ring.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2012-2016 VMware, Inc.  All rights reserved.
  *

--- a/driver/rocm_ernic_srq.c
+++ b/driver/rocm_ernic_srq.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2016-2017 VMware, Inc.  All rights reserved.
  *

--- a/driver/rocm_ernic_verbs.c
+++ b/driver/rocm_ernic_verbs.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2012-2016 VMware, Inc.  All rights reserved.
  *

--- a/driver/rocm_ernic_verbs.h
+++ b/driver/rocm_ernic_verbs.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2012-2016 VMware, Inc.  All rights reserved.
  *

--- a/scripts/local-vm-test.sh
+++ b/scripts/local-vm-test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 #
 # local-vm-test.sh
 #

--- a/scripts/run-local-tests.sh
+++ b/scripts/run-local-tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 #
 # Run tests locally against built binaries
 #

--- a/scripts/test-tcp-local.sh
+++ b/scripts/test-tcp-local.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 # Test script for running multiple TCP servers locally
 
 set -e

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 #
 # Test runner for rocm-ernic
 #

--- a/tests/test_data_transfer.c
+++ b/tests/test_data_transfer.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /**
  * Comprehensive Data Transfer Test
  *

--- a/tests/test_loopback_ci.sh
+++ b/tests/test_loopback_ci.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 # Comprehensive loopback backend testing for CI
 # Tests multiple loopback configurations by verifying server startup
 # Note: Loopback backend doesn't expose RDMA devices directly to host.

--- a/tests/test_loopback_configs.sh
+++ b/tests/test_loopback_configs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 # Test multiple loopback backend configurations.
 # Uses TEST_BIN for client test (default: test_rdma_cm). CI may set
 # TEST_BIN=$BUILD_DIR/tests/test_data_transfer. Override SERVER_BIN/BUILD_DIR as needed.

--- a/tests/test_loopback_with_vm.sh
+++ b/tests/test_loopback_with_vm.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 # Loopback backend testing with VM from Docker image
 # This script runs loopback backend tests using a VM extracted from a Docker image
 #

--- a/tests/test_rdma_cm.c
+++ b/tests/test_rdma_cm.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
  * Test RDMA Connection Manager (rdma_cm) emulation support
  *


### PR DESCRIPTION
- Add .github/CODEOWNERS with @sbates130272 as wildcard owner
- Add SPDX-License-Identifier headers to all first-party files that were missing them: driver/ (GPL-2.0-only), tests/, scripts/, and .github/workflows/ (MIT)
- Remove personal dev branch dev/stephen/tcp-ip-backend from system-tests.yml PR trigger; leave only main
- Replace hardcoded "batesste" VM username fallback with "ci" in system-tests.yml (4 occurrences across both jobs)
- Add TODO comments flagging the sbates130272 Docker Hub image in system-tests.yml and benchmark.yml for future migration to ghcr.io
- Add clarifying comment in benchmark.yml explaining rocep1s0 is the device name baked into the CI container image