### PR TITLE
Fix out-of-bounds read in rdma_cm_process_message debug dump

### DIFF
--- a/src/from-qemu/utils/rdma_cm_proto.c
+++ b/src/from-qemu/utils/rdma_cm_proto.c
@@ -25,6 +25,7 @@
 #include "rdma_cm_proto.h"
 #include "from-qemu/hw/rdma/rdma_utils.h"
 #include "net_headers.h"
+#include <stdio.h>
 #include <string.h>
 
 /* InfiniBand SA (Subnet Administration) header format
@@ -111,29 +112,24 @@ size_t rdma_cm_process_message(const void *tcp_payload, size_t payload_len,
 
     rdma_info_report("rdma_cm: Received message: payload_len=%zu", payload_len);
 
-    /* Log first 32 bytes of message for debugging */
-    rdma_info_report(
-        "rdma_cm: Message bytes (first 32): "
-        "%02x %02x %02x %02x %02x %02x %02x %02x "
-        "%02x %02x %02x %02x %02x %02x %02x %02x "
-        "%02x %02x %02x %02x %02x %02x %02x %02x "
-        "%02x %02x %02x %02x %02x %02x %02x %02x",
-        ((const uint8_t *)tcp_payload)[0], ((const uint8_t *)tcp_payload)[1],
-        ((const uint8_t *)tcp_payload)[2], ((const uint8_t *)tcp_payload)[3],
-        ((const uint8_t *)tcp_payload)[4], ((const uint8_t *)tcp_payload)[5],
-        ((const uint8_t *)tcp_payload)[6], ((const uint8_t *)tcp_payload)[7],
-        ((const uint8_t *)tcp_payload)[8], ((const uint8_t *)tcp_payload)[9],
-        ((const uint8_t *)tcp_payload)[10], ((const uint8_t *)tcp_payload)[11],
-        ((const uint8_t *)tcp_payload)[12], ((const uint8_t *)tcp_payload)[13],
-        ((const uint8_t *)tcp_payload)[14], ((const uint8_t *)tcp_payload)[15],
-        ((const uint8_t *)tcp_payload)[16], ((const uint8_t *)tcp_payload)[17],
-        ((const uint8_t *)tcp_payload)[18], ((const uint8_t *)tcp_payload)[19],
-        ((const uint8_t *)tcp_payload)[20], ((const uint8_t *)tcp_payload)[21],
-        ((const uint8_t *)tcp_payload)[22], ((const uint8_t *)tcp_payload)[23],
-        ((const uint8_t *)tcp_payload)[24], ((const uint8_t *)tcp_payload)[25],
-        ((const uint8_t *)tcp_payload)[26], ((const uint8_t *)tcp_payload)[27],
-        ((const uint8_t *)tcp_payload)[28], ((const uint8_t *)tcp_payload)[29],
-        ((const uint8_t *)tcp_payload)[30], ((const uint8_t *)tcp_payload)[31]);
+    /* Log up to the first 32 bytes of the message for debugging. The dump
+     * is bounded by payload_len so a short message is never read past its
+     * end (a payload of 4..31 bytes previously caused an out-of-bounds
+     * read here). */
+    {
+        const uint8_t *bytes = (const uint8_t *)tcp_payload;
+        size_t dump_len = payload_len < 32 ? payload_len : 32;
+        char hexbuf[32 * 3 + 1];
+        size_t i;
+
+        for (i = 0; i < dump_len; i++) {
+            snprintf(hexbuf + i * 3, sizeof(hexbuf) - i * 3, "%02x ", bytes[i]);
+        }
+        hexbuf[dump_len ? dump_len * 3 - 1 : 0] = '\0';
+
+        rdma_info_report("rdma_cm: Message bytes (first %zu): %s", dump_len,
+                         hexbuf);
+    }
 
     /* Try SA protocol format first */
     if (payload_len >= sizeof(struct ib_sa_hdr) &&

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -143,6 +143,36 @@ if(CMOCKA_FOUND)
         ${CMOCKA_LIBRARIES}
     )
 endif()
+# -- Parser unit tests -------------------------------------------
+# These link the QEMU-ported wire parsers directly and are built with
+# AddressSanitizer + UBSan (unless the project is already built with
+# ThreadSanitizer, which is incompatible), so an out-of-bounds read fails
+# the test even when the rest of the project is built without sanitizers.
+set(ERNIC_PARSER_TEST_SAN "")
+if(NOT ERNIC_USE_THREAD_SANITIZER)
+    set(ERNIC_PARSER_TEST_SAN
+        -fsanitize=address,undefined -fno-omit-frame-pointer)
+endif()
+
+add_executable(test_rdma_cm_proto
+    test_rdma_cm_proto.c
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/utils/rdma_cm_proto.c
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/utils/error-report.c
+)
+target_include_directories(test_rdma_cm_proto PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/from-qemu
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/utils
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/include/qemu-extra
+    ${GLIB2_INCLUDE_DIRS}
+)
+target_compile_definitions(test_rdma_cm_proto PRIVATE _GNU_SOURCE)
+# QEMU-ported sources are compiled -w here, matching the main build.
+target_compile_options(test_rdma_cm_proto PRIVATE
+    -w ${ERNIC_PARSER_TEST_SAN})
+target_link_options(test_rdma_cm_proto PRIVATE ${ERNIC_PARSER_TEST_SAN})
+target_link_directories(test_rdma_cm_proto PRIVATE ${GLIB2_LIBRARY_DIRS})
+target_link_libraries(test_rdma_cm_proto PRIVATE ${GLIB2_LIBRARIES})
 
 # ---------------------------------------------------------------
 # Register tests with CTest
@@ -200,3 +230,9 @@ if(CMOCKA_FOUND)
         RUN_SERIAL TRUE
     )
 endif()
+# rdma_cm protocol parser unit test (table-driven, ASan-instrumented)
+add_test(
+    NAME rdma-cm-proto-unit
+    COMMAND $<TARGET_FILE:test_rdma_cm_proto>
+)
+set_tests_properties(rdma-cm-proto-unit PROPERTIES TIMEOUT 30)

--- a/tests/test_rdma_cm_proto.c
+++ b/tests/test_rdma_cm_proto.c
@@ -1,0 +1,112 @@
+/*
+ * Unit tests for rdma_cm_process_message().
+ *
+ * Regression coverage for an out-of-bounds read in the debug hex-dump: a
+ * payload of 4..31 bytes was previously read up to 32 bytes. Each payload
+ * is placed in an exact-size heap buffer, so when the test binary is built
+ * with AddressSanitizer any over-read fails the test.
+ *
+ * Table-driven: positive (small-message echo), negative (NULL / zero-length
+ * rejected), and boundary/corner cases around the 4- and 32-byte edges.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rdma_cm_proto.h"
+
+#define RESP_CAP     2048
+#define NULL_PAYLOAD ((size_t) - 1)
+
+struct testcase {
+    const char *name;
+    size_t payload_len; /* NULL_PAYLOAD => pass a NULL pointer */
+    int expect_echo;    /* small messages (<4B) are echoed back verbatim */
+};
+
+static int run_case(const struct testcase *tc)
+{
+    uint8_t response[RESP_CAP];
+
+    if (tc->payload_len == NULL_PAYLOAD) {
+        size_t ret = rdma_cm_process_message(NULL, 8, response, RESP_CAP);
+        if (ret != 0) {
+            printf("FAIL %-20s: NULL payload should return 0, got %zu\n",
+                   tc->name, ret);
+            return 1;
+        }
+        return 0;
+    }
+
+    /* Exact-size allocation so ASan brackets the payload precisely. */
+    uint8_t *payload = malloc(tc->payload_len ? tc->payload_len : 1);
+    if (!payload) {
+        printf("FAIL %-20s: allocation failed\n", tc->name);
+        return 1;
+    }
+    for (size_t i = 0; i < tc->payload_len; i++) {
+        payload[i] = (uint8_t)(0xA0 + (i & 0x0F));
+    }
+
+    size_t ret =
+        rdma_cm_process_message(payload, tc->payload_len, response, RESP_CAP);
+    free(payload);
+
+    int fail = 0;
+    if (ret > RESP_CAP) {
+        printf("FAIL %-20s: response %zu exceeds cap %d\n", tc->name, ret,
+               RESP_CAP);
+        fail = 1;
+    }
+    if (tc->payload_len == 0 && ret != 0) {
+        printf("FAIL %-20s: zero-length should return 0, got %zu\n", tc->name,
+               ret);
+        fail = 1;
+    }
+    if (tc->expect_echo && ret != tc->payload_len) {
+        printf("FAIL %-20s: expected echo of %zu bytes, got %zu\n", tc->name,
+               tc->payload_len, ret);
+        fail = 1;
+    }
+    return fail;
+}
+
+int main(void)
+{
+    static const struct testcase cases[] = {
+        /* negative */
+        {"null-payload", NULL_PAYLOAD, 0},
+        {"zero-length", 0, 0},
+        /* positive: small messages are echoed */
+        {"len-1-echo", 1, 1},
+        {"len-2-echo", 2, 1},
+        {"len-3-echo", 3, 1},
+        /* boundary/corner around the 4- and 32-byte dump edges */
+        {"len-4-corner", 4, 0}, /* the exact fuzzer crash length */
+        {"len-5", 5, 0},
+        {"len-16", 16, 0},
+        {"len-31-boundary", 31, 0}, /* one below the old 32-byte read */
+        {"len-32-boundary", 32, 0},
+        {"len-33", 33, 0},
+        {"len-64", 64, 0},
+        {"len-256", 256, 0},
+    };
+
+    int failures = 0;
+    size_t n = sizeof(cases) / sizeof(cases[0]);
+    for (size_t i = 0; i < n; i++) {
+        failures += run_case(&cases[i]);
+    }
+
+    if (failures) {
+        printf("rdma_cm_proto: %d/%zu case(s) FAILED\n", failures, n);
+        return 1;
+    }
+    printf("rdma_cm_proto: all %zu cases passed\n", n);
+    return 0;
+}


### PR DESCRIPTION
Thanks for building rocm-ernic — really neat project, and we'd love to help harden it a bit. This is a small out-of-bounds read fix, with a test.

> Note on the path: despite living under `from-qemu/utils/`, `rdma_cm_proto.c` is rocm-ernic's own code (Copyright 2025 AMD, the loopback-mode CM stub), not code ported from upstream QEMU — so there's nothing to forward there.

### The bug

In `rdma_cm_process_message()` the debug hex-dump reads the first 32 bytes of the payload whenever `payload_len >= 4`:

```c
/* Log first 32 bytes of message for debugging */
rdma_info_report("rdma_cm: Message bytes (first 32): ...",
    ((const uint8_t *)tcp_payload)[0], ... ((const uint8_t *)tcp_payload)[31]);
```

For a payload of 4..31 bytes this reads past the end of the buffer. It is reachable from untrusted wire data on the loopback / TCP-mesh path, so a truncated rdma_cm message can crash the server or read adjacent memory into the log.

### The fix

Bound the dump to `min(payload_len, 32)` bytes and format it with `snprintf`. Short messages are logged correctly, and the read never goes past the payload.

### Test

`tests/test_rdma_cm_proto.c` is a table-driven unit test — small-message echo, NULL / zero-length, and boundary/corner cases at the 4- and 32-byte edges — built with AddressSanitizer and registered with CTest as `rdma-cm-proto-unit`, so an out-of-bounds read fails the test.

Happy to adjust anything to fit your conventions. Thanks! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)
