### PR TITLE
Fix DHCP server memory leaks at shutdown

### DIFF
--- a/src/from-qemu/utils/dhcp_server.c
+++ b/src/from-qemu/utils/dhcp_server.c
@@ -42,8 +42,11 @@ DhcpServer *dhcp_server_create(uint32_t server_ip, uint32_t subnet_mask,
     server->lease_time = lease_time;
     server->next_ip = ip_pool_start;
 
+    /* Both key (MAC copy) and value (allocated-IP copy) are heap-allocated,
+     * so the table owns and frees both. Previously the value destructor was
+     * NULL, leaking one IP copy per lease. */
     server->allocations =
-        g_hash_table_new_full(mac_hash, mac_equal, g_free, NULL);
+        g_hash_table_new_full(mac_hash, mac_equal, g_free, g_free);
     server->leases = g_hash_table_new_full(mac_hash, mac_equal, g_free, g_free);
     qemu_mutex_init(&server->lock);
 

--- a/src/rocm_ernic_compat.c
+++ b/src/rocm_ernic_compat.c
@@ -296,6 +296,13 @@ void pvrdma_device_destroy(pvrdma_handle_t handle)
         pvrdma->tcp_connections = NULL;
     }
 
+    /* Free the DHCP server (created in pvrdma_device_realize for loopback
+     * and TCP-manager modes). Without this it leaks at shutdown. */
+    if (pvrdma->dhcp_server) {
+        dhcp_server_destroy((DhcpServer *)pvrdma->dhcp_server);
+        pvrdma->dhcp_server = NULL;
+    }
+
     free(pvrdma);
 
     rdma_info_report("PVRDMA device destroyed");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -143,6 +143,39 @@ if(CMOCKA_FOUND)
         ${CMOCKA_LIBRARIES}
     )
 endif()
+# -- DHCP server lifecycle / leak test ---------------------------
+# Built with AddressSanitizer + LeakSanitizer + UBSan (unless the project
+# is built with ThreadSanitizer, which is incompatible) so a leak in the
+# DHCP server's create/destroy path fails the test. Flag set matches
+# cmake/ErnicSanitizers.cmake; -fno-omit-frame-pointer is compile-only.
+set(ERNIC_LEAK_TEST_SAN)
+set(ERNIC_LEAK_TEST_SAN_LINK)
+if(NOT ERNIC_USE_THREAD_SANITIZER)
+    set(ERNIC_LEAK_TEST_SAN
+        -fsanitize=address,undefined,leak -fno-omit-frame-pointer)
+    set(ERNIC_LEAK_TEST_SAN_LINK -fsanitize=address,undefined,leak)
+endif()
+
+add_executable(test_dhcp_server_lifecycle
+    test_dhcp_server_lifecycle.c
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/utils/dhcp_server.c
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/utils/error-report.c
+)
+target_include_directories(test_dhcp_server_lifecycle PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/from-qemu
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/utils
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/include/qemu-extra
+    ${GLIB2_INCLUDE_DIRS}
+)
+target_compile_definitions(test_dhcp_server_lifecycle PRIVATE _GNU_SOURCE)
+# QEMU-ported sources are compiled -w here, matching the main build.
+target_compile_options(test_dhcp_server_lifecycle PRIVATE
+    -w ${ERNIC_LEAK_TEST_SAN})
+target_link_options(test_dhcp_server_lifecycle PRIVATE ${ERNIC_LEAK_TEST_SAN_LINK})
+target_link_directories(test_dhcp_server_lifecycle PRIVATE
+    ${GLIB2_LIBRARY_DIRS})
+target_link_libraries(test_dhcp_server_lifecycle PRIVATE ${GLIB2_LIBRARIES})
 
 # ---------------------------------------------------------------
 # Register tests with CTest
@@ -200,3 +233,9 @@ if(CMOCKA_FOUND)
         RUN_SERIAL TRUE
     )
 endif()
+# DHCP server lifecycle / leak test (table-driven, ASan+LSan)
+add_test(
+    NAME dhcp-server-lifecycle-unit
+    COMMAND $<TARGET_FILE:test_dhcp_server_lifecycle>
+)
+set_tests_properties(dhcp-server-lifecycle-unit PROPERTIES TIMEOUT 30 RUN_SERIAL TRUE)

--- a/tests/test_dhcp_server_lifecycle.c
+++ b/tests/test_dhcp_server_lifecycle.c
@@ -1,0 +1,103 @@
+/*
+ * Lifecycle / leak tests for the DHCP server.
+ *
+ * The DHCP server is the object that leaked at shutdown (it was created in
+ * pvrdma_device_realize but never destroyed in pvrdma_device_destroy).
+ * This test exercises create -> allocate N leases -> destroy and is built
+ * with AddressSanitizer + LeakSanitizer, so any allocation the destroy path
+ * fails to release (the server struct, the allocation/lease hash tables and
+ * their heap keys/values) fails the test.
+ *
+ * Table-driven over the number of distinct clients that obtain a lease
+ * (zero, one, several, and a full pool), plus a destroy(NULL) corner case.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <arpa/inet.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dhcp_server.h"
+
+/* Small pool (10.0.0.2 .. 10.0.0.6) so "full pool" is cheap to fill. */
+static DhcpServer *make_server(void)
+{
+    return dhcp_server_create(htonl(0x0a000001), htonl(0xffffff00),
+                              htonl(0x0a000001), htonl(0x08080808),
+                              htonl(0x0a000002), htonl(0x0a000006), 3600);
+}
+
+static void build_discover(struct dhcp_packet *p, uint8_t client)
+{
+    memset(p, 0, sizeof(*p));
+    p->op = 1;
+    p->htype = 1;
+    p->hlen = 6;
+    p->xid = htonl(0x1000 + client);
+    const uint8_t mac[6] = {0x02, 0x00, 0x00, 0x00, 0x00, client};
+    memcpy(p->chaddr, mac, sizeof(mac));
+
+    uint8_t *o = p->options;
+    o[0] = 0x63;
+    o[1] = 0x82;
+    o[2] = 0x53;
+    o[3] = 0x63;
+    o[4] = DHCP_OPT_MSG_TYPE;
+    o[5] = 1;
+    o[6] = DHCP_MSG_DISCOVER;
+    o[7] = DHCP_OPT_END;
+}
+
+/* Create a server, hand out `clients` leases, then destroy it. */
+static int lease_and_destroy(const char *name, int clients)
+{
+    DhcpServer *server = make_server();
+    if (!server) {
+        printf("FAIL %-18s: create returned NULL\n", name);
+        return 1;
+    }
+
+    struct dhcp_packet request;
+    struct dhcp_packet response;
+    for (int i = 0; i < clients; i++) {
+        build_discover(&request, (uint8_t)(i + 1));
+        (void)dhcp_server_process(server, &request, sizeof(request), &response,
+                                  sizeof(response));
+    }
+
+    dhcp_server_destroy(server);
+    return 0;
+}
+
+int main(void)
+{
+    struct testcase {
+        const char *name;
+        int clients;
+    } cases[] = {
+        {"no-leases", 0}, /* create + destroy only */
+        {"one-lease", 1}, {"several-leases", 3},
+        {"full-pool", 5}, /* every pool address handed out */
+        {"over-pool", 7}, /* more clients than addresses */
+    };
+
+    int failures = 0;
+    size_t n = sizeof(cases) / sizeof(cases[0]);
+    for (size_t i = 0; i < n; i++) {
+        failures += lease_and_destroy(cases[i].name, cases[i].clients);
+    }
+
+    /* Corner case: destroying NULL must be a no-op. */
+    dhcp_server_destroy(NULL);
+
+    if (failures) {
+        printf("dhcp_server_lifecycle: %d/%zu case(s) FAILED\n", failures, n);
+        return 1;
+    }
+    printf("dhcp_server_lifecycle: all %zu cases passed\n", n);
+    return 0;
+}


### PR DESCRIPTION
A pair of related memory leaks in the DHCP server, with a test.

> Note on the path: both files here are rocm-ernic's own code (Copyright 2025 AMD) — the DHCP server under `from-qemu/utils/` and the `rocm_ernic_compat.c` bridge. Neither is ported from upstream QEMU, so there's nothing to forward there.

### Leak 1 — the server is never freed at shutdown

`pvrdma_device_realize()` creates a `DhcpServer` (loopback and TCP-manager modes), but `pvrdma_device_destroy()` never frees it, so it leaks at shutdown. Fix: call `dhcp_server_destroy()` in `pvrdma_device_destroy()`.

### Leak 2 — leased IPs are never freed

`dhcp_server_create()` builds the `allocations` table with a NULL value destructor:

```c
server->allocations = g_hash_table_new_full(mac_hash, mac_equal, g_free, NULL);
```

so the heap-allocated IP copy stored for each lease leaks even when the table is destroyed (the `leases` table right below already uses `g_free` for its value). Fix: use `g_free` for the value too.

### Test

`tests/test_dhcp_server_lifecycle.c` is table-driven — create → hand out N leases → destroy, for zero / one / several / full-pool / over-pool clients, plus a `destroy(NULL)` corner case — built with AddressSanitizer + LeakSanitizer and registered with CTest as `dhcp-server-lifecycle-unit`.

Happy to split this into two PRs if you'd prefer to review them separately. Thanks! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)
