### PR TITLE
Fix NULL-pointer dereference in TCP/UDP checksum helpers

### DIFF
--- a/src/from-qemu/utils/net_headers.h
+++ b/src/from-qemu/utils/net_headers.h
@@ -237,6 +237,12 @@ static inline uint16_t udp_checksum(const struct ip_header *ip_hdr,
     uint32_t sum = 0;
     uint16_t udp_len = ntohs(udp_hdr->len);
 
+    /* A NULL payload means "no payload"; treat it as zero-length so the
+     * pseudo-header length and the summation stay consistent. */
+    if (payload == NULL) {
+        payload_len = 0;
+    }
+
     /* Pseudo-header: src IP, dst IP, protocol, UDP length */
     sum += (ntohl(ip_hdr->src_ip) >> 16) & 0xFFFF;
     sum += ntohl(ip_hdr->src_ip) & 0xFFFF;
@@ -260,7 +266,7 @@ static inline uint16_t udp_checksum(const struct ip_header *ip_hdr,
 
     /* Add odd byte if present */
     if (payload_len % 2) {
-        sum += ((uint8_t *)payload)[payload_len - 1] << 8;
+        sum += ((const uint8_t *)payload)[payload_len - 1] << 8;
     }
 
     /* Add carry bits */
@@ -279,6 +285,13 @@ static inline uint16_t tcp_checksum(const struct ip_header *ip_hdr,
                                     const void *payload, size_t payload_len)
 {
     uint32_t sum = 0;
+
+    /* A NULL payload means "no payload"; treat it as zero-length so the
+     * pseudo-header length and the summation stay consistent. */
+    if (payload == NULL) {
+        payload_len = 0;
+    }
+
     uint16_t tcp_len = (tcp_hdr->data_off >> 4) * 4 + payload_len;
 
     /* Pseudo-header: src IP, dst IP, protocol, TCP length */
@@ -310,7 +323,7 @@ static inline uint16_t tcp_checksum(const struct ip_header *ip_hdr,
 
     /* Add odd byte if present */
     if (payload_len % 2) {
-        sum += ((uint8_t *)payload)[payload_len - 1] << 8;
+        sum += ((const uint8_t *)payload)[payload_len - 1] << 8;
     }
 
     /* Add carry bits */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,10 @@ target_link_libraries(test_rdma_cm PRIVATE
 # is already built with ThreadSanitizer, which is incompatible). Flag set
 # matches cmake/ErnicSanitizers.cmake; -fno-omit-frame-pointer is
 # compile-only.
+# is already built with ThreadSanitizer, which is incompatible) so a NULL
+# deref, leak, or out-of-bounds read fails the test even when the rest of
+# the project is built without sanitizers. Flag set matches
+# cmake/ErnicSanitizers.cmake; -fno-omit-frame-pointer is compile-only.
 set(ERNIC_UNIT_TEST_SAN)
 set(ERNIC_UNIT_TEST_SAN_LINK)
 if(NOT ERNIC_USE_THREAD_SANITIZER)
@@ -143,6 +147,15 @@ if(CMOCKA_FOUND)
         ${CMOCKA_LIBRARIES}
     )
 endif()
+# net_headers.h checksum helpers are header-only and self-contained. The
+# ported header is a SYSTEM include so its warnings stay quiet while the
+# test source itself is still warning-checked.
+add_executable(test_net_checksum test_net_checksum.c)
+target_include_directories(test_net_checksum SYSTEM PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/utils
+)
+target_compile_options(test_net_checksum PRIVATE ${ERNIC_UNIT_TEST_SAN})
+target_link_options(test_net_checksum PRIVATE ${ERNIC_UNIT_TEST_SAN_LINK})
 
 # ---------------------------------------------------------------
 # Register tests with CTest
@@ -200,3 +213,9 @@ if(CMOCKA_FOUND)
         RUN_SERIAL TRUE
     )
 endif()
+# TCP/UDP checksum helper unit test (table-driven, ASan-instrumented)
+add_test(
+    NAME net-checksum-unit
+    COMMAND $<TARGET_FILE:test_net_checksum>
+)
+set_tests_properties(net-checksum-unit PROPERTIES TIMEOUT 30 RUN_SERIAL TRUE)

--- a/tests/test_net_checksum.c
+++ b/tests/test_net_checksum.c
@@ -1,0 +1,192 @@
+/*
+ * Unit tests for tcp_checksum() / udp_checksum() in net_headers.h.
+ *
+ * Regression coverage for a NULL-pointer dereference: both helpers summed
+ * the payload without checking it, so a NULL payload dereferenced NULL.
+ * The payload buffers here are exact-size heap allocations, so when the
+ * test is built with AddressSanitizer any over-read also fails the test.
+ *
+ * Table-driven: negative (NULL payload, zero length), positive (even and
+ * odd payload lengths, exercising the odd-byte path), and a determinism
+ * check that a NULL payload yields the same result as an empty buffer.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "net_headers.h"
+
+#define NULL_PAYLOAD ((size_t) - 1)
+
+static void fill_ip(struct ip_header *ip)
+{
+    memset(ip, 0, sizeof(*ip));
+    ip->version_ihl = 0x45;
+    ip->ttl = 64;
+    ip->protocol = 6; /* TCP; udp test overrides to 17 */
+    ip->src_ip = htonl(0x0a000001);
+    ip->dst_ip = htonl(0x0a000002);
+}
+
+static void fill_tcp(struct tcp_header *tcp)
+{
+    memset(tcp, 0, sizeof(*tcp));
+    tcp->src_port = htons(1234);
+    tcp->dst_port = htons(5678);
+    tcp->data_off = (5 << 4); /* 20-byte header */
+}
+
+static void fill_udp(struct udp_header *udp, size_t payload_len)
+{
+    memset(udp, 0, sizeof(*udp));
+    udp->src_port = htons(1234);
+    udp->dst_port = htons(5678);
+    udp->len = htons((uint16_t)(sizeof(struct udp_header) + payload_len));
+}
+
+/* Allocate an exact-size payload so ASan brackets any over-read. */
+static uint8_t *make_payload(size_t len)
+{
+    uint8_t *p = malloc(len ? len : 1);
+    if (p) {
+        for (size_t i = 0; i < len; i++) {
+            p[i] = (uint8_t)(0xA0 + (i & 0x0F));
+        }
+    }
+    return p;
+}
+
+struct testcase {
+    const char *name;
+    size_t payload_len; /* NULL_PAYLOAD => pass a NULL pointer */
+    int odd;            /* informational: exercises the odd-byte branch */
+};
+
+static int run_tcp(const struct testcase *tc)
+{
+    struct ip_header ip;
+    struct tcp_header tcp;
+    fill_ip(&ip);
+    ip.protocol = 6;
+    fill_tcp(&tcp);
+
+    if (tc->payload_len == NULL_PAYLOAD) {
+        /* Must not dereference NULL even with a nonzero length, and a NULL
+         * payload must be treated as "no payload" regardless of the length
+         * argument. */
+        uint16_t a = tcp_checksum(&ip, &tcp, NULL, 8);
+        uint16_t b = tcp_checksum(&ip, &tcp, NULL, 0);
+        uint8_t empty[1] = {0};
+        uint16_t c = tcp_checksum(&ip, &tcp, empty, 0);
+        if (a != b) {
+            printf("FAIL tcp %-18s: NULL len-8 != NULL len-0 %#x != %#x\n",
+                   tc->name, (unsigned)a, (unsigned)b);
+            return 1;
+        }
+        if (b != c) {
+            printf("FAIL tcp %-18s: NULL/empty len-0 mismatch %#x != %#x\n",
+                   tc->name, (unsigned)b, (unsigned)c);
+            return 1;
+        }
+        return 0;
+    }
+
+    uint8_t *p = make_payload(tc->payload_len);
+    if (!p) {
+        printf("FAIL tcp %-18s: allocation failed\n", tc->name);
+        return 1;
+    }
+    uint16_t r1 = tcp_checksum(&ip, &tcp, p, tc->payload_len);
+    uint16_t r2 = tcp_checksum(&ip, &tcp, p, tc->payload_len);
+    free(p);
+    if (r1 != r2) {
+        printf("FAIL tcp %-18s: not deterministic %#x != %#x\n", tc->name,
+               (unsigned)r1, (unsigned)r2);
+        return 1;
+    }
+    if (r1 == 0) {
+        printf("FAIL tcp %-18s: checksum is zero (should be 0xFFFF form)\n",
+               tc->name);
+        return 1;
+    }
+    return 0;
+}
+
+static int run_udp(const struct testcase *tc)
+{
+    struct ip_header ip;
+    struct udp_header udp;
+    fill_ip(&ip);
+    ip.protocol = 17;
+
+    if (tc->payload_len == NULL_PAYLOAD) {
+        fill_udp(&udp, 0);
+        uint16_t a = udp_checksum(&ip, &udp, NULL, 8);
+        uint16_t b = udp_checksum(&ip, &udp, NULL, 0);
+        uint8_t empty[1] = {0};
+        uint16_t c = udp_checksum(&ip, &udp, empty, 0);
+        if (a != b) {
+            printf("FAIL udp %-18s: NULL len-8 != NULL len-0 %#x != %#x\n",
+                   tc->name, (unsigned)a, (unsigned)b);
+            return 1;
+        }
+        if (b != c) {
+            printf("FAIL udp %-18s: NULL/empty len-0 mismatch %#x != %#x\n",
+                   tc->name, (unsigned)b, (unsigned)c);
+            return 1;
+        }
+        return 0;
+    }
+
+    fill_udp(&udp, tc->payload_len);
+    uint8_t *p = make_payload(tc->payload_len);
+    if (!p) {
+        printf("FAIL udp %-18s: allocation failed\n", tc->name);
+        return 1;
+    }
+    uint16_t r1 = udp_checksum(&ip, &udp, p, tc->payload_len);
+    uint16_t r2 = udp_checksum(&ip, &udp, p, tc->payload_len);
+    free(p);
+    if (r1 != r2) {
+        printf("FAIL udp %-18s: not deterministic %#x != %#x\n", tc->name,
+               (unsigned)r1, (unsigned)r2);
+        return 1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    static const struct testcase cases[] = {
+        /* negative / regression */
+        {"null-payload", NULL_PAYLOAD, 0},
+        {"zero-length", 0, 0},
+        /* positive: even and odd lengths (odd exercises the odd-byte path) */
+        {"len-1-odd", 1, 1},
+        {"len-2-even", 2, 0},
+        {"len-3-odd", 3, 1},
+        {"len-16-even", 16, 0},
+        {"len-31-odd", 31, 1},
+        {"len-64-even", 64, 0},
+        {"len-255-odd", 255, 1},
+    };
+
+    int failures = 0;
+    size_t n = sizeof(cases) / sizeof(cases[0]);
+    for (size_t i = 0; i < n; i++) {
+        failures += run_tcp(&cases[i]);
+        failures += run_udp(&cases[i]);
+    }
+
+    if (failures) {
+        printf("net_checksum: %d check(s) FAILED\n", failures);
+        return 1;
+    }
+    printf("net_checksum: all %zu cases passed (tcp+udp)\n", n);
+    return 0;
+}


### PR DESCRIPTION
A small NULL-pointer-dereference fix in the TCP/UDP checksum helpers, with a test.

### The bug

`tcp_checksum()` and `udp_checksum()` in `net_headers.h` sum the payload without checking it:

```c
const uint16_t *payload_words = (const uint16_t *)payload;
for (i = 0; i < payload_len / 2; i++)
    sum += ntohs(payload_words[i]);
if (payload_len % 2)
    sum += ((uint8_t *)payload)[payload_len - 1] << 8;
```

The caller in `tcp_conn.c` guards the payload copy with `if (payload && payload_len > 0)` but calls `tcp_checksum(..., payload, payload_len)` unconditionally, so a NULL payload with a nonzero `payload_len` dereferences NULL.

### The fix

Guard the payload summation with `if (payload)` in both helpers, so a NULL payload is treated as no payload. Non-NULL payloads are unaffected.

### Test

`tests/test_net_checksum.c` is table-driven — NULL payload, zero length, and even/odd payload lengths across both helpers — built with AddressSanitizer + UBSan and registered with CTest as `net-checksum-unit`, so the NULL dereference fails the test.

Flagged by both clang-analyzer (`core.NullDereference`) and cppcheck (`nullPointerRedundantCheck`) at the same line.

Thanks! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)
