### PR TITLE
Fix signed-shift undefined behaviour in ROCM_ERNIC_ETH_CTL_RESET

### DIFF
--- a/src/rocm_ernic_eth.h
+++ b/src/rocm_ernic_eth.h
@@ -32,10 +32,10 @@
 #define ROCM_ERNIC_ETH_MAC1    0x64 /* MAC Address bytes 4-5 (little-endian) */
 
 /* Ethernet Control Register bits */
-#define ROCM_ERNIC_ETH_CTL_ENABLE    (1 << 0)  /* Enable Ethernet */
-#define ROCM_ERNIC_ETH_CTL_TX_ENABLE (1 << 1)  /* Enable Transmit */
-#define ROCM_ERNIC_ETH_CTL_RX_ENABLE (1 << 2)  /* Enable Receive */
-#define ROCM_ERNIC_ETH_CTL_RESET     (1 << 31) /* Software Reset */
+#define ROCM_ERNIC_ETH_CTL_ENABLE    (1 << 0)   /* Enable Ethernet */
+#define ROCM_ERNIC_ETH_CTL_TX_ENABLE (1 << 1)   /* Enable Transmit */
+#define ROCM_ERNIC_ETH_CTL_RX_ENABLE (1 << 2)   /* Enable Receive */
+#define ROCM_ERNIC_ETH_CTL_RESET     (1u << 31) /* Software Reset */
 
 /* Ethernet Status Register bits */
 #define ROCM_ERNIC_ETH_STATUS_LINK_UP (1 << 0) /* Link Up */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -144,6 +144,13 @@ if(CMOCKA_FOUND)
     )
 endif()
 
+# ROCM_ERNIC_ETH_CTL_RESET bit-definition test (header-only, project header
+# so warnings stay enabled).
+add_executable(test_eth_ctl_reset test_eth_ctl_reset.c)
+target_include_directories(test_eth_ctl_reset PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_compile_options(test_eth_ctl_reset PRIVATE ${ERNIC_UNIT_TEST_SAN})
+target_link_options(test_eth_ctl_reset PRIVATE ${ERNIC_UNIT_TEST_SAN_LINK})
+
 # ---------------------------------------------------------------
 # Register tests with CTest
 # ---------------------------------------------------------------
@@ -200,3 +207,10 @@ if(CMOCKA_FOUND)
         RUN_SERIAL TRUE
     )
 endif()
+
+# Ethernet control reset-bit definition unit test
+add_test(
+    NAME eth-ctl-reset-unit
+    COMMAND $<TARGET_FILE:test_eth_ctl_reset>
+)
+set_tests_properties(eth-ctl-reset-unit PROPERTIES TIMEOUT 30 RUN_SERIAL TRUE)

--- a/tests/test_eth_ctl_reset.c
+++ b/tests/test_eth_ctl_reset.c
@@ -1,0 +1,59 @@
+/*
+ * Unit test for the ROCM_ERNIC_ETH_CTL_RESET bit definition.
+ *
+ * Regression coverage for signed-shift undefined behaviour: the macro was
+ * defined as (1 << 31), which shifts into the sign bit of a signed int
+ * (UB in C). The _Generic check below fails to build against the old
+ * signed form: (1 << 31) has type int, so it takes the "default" branch
+ * and the assertion fails. The fixed (1u << 31) has type unsigned int and
+ * the value 0x80000000.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "rocm_ernic_eth.h"
+
+/* Correct bit pattern regardless of signedness. */
+_Static_assert(ROCM_ERNIC_ETH_CTL_RESET == 0x80000000u,
+               "ROCM_ERNIC_ETH_CTL_RESET must be bit 31");
+
+/* Must be an unsigned constant: a signed (1 << 31) shifts into the sign
+ * bit (UB). Assert the type directly so this holds regardless of value and
+ * without tripping -Wtype-limits. */
+_Static_assert(_Generic(ROCM_ERNIC_ETH_CTL_RESET, unsigned int: 1, default: 0),
+               "ROCM_ERNIC_ETH_CTL_RESET must be unsigned (use 1u << 31)");
+
+int main(void)
+{
+    int failures = 0;
+
+    /* The reset bit sets bit 31 and nothing else. */
+    uint32_t ctl = 0;
+    ctl |= ROCM_ERNIC_ETH_CTL_RESET;
+    if (ctl != 0x80000000u) {
+        printf("FAIL: set reset bit => %#x\n", ctl);
+        failures++;
+    }
+    if (!(ctl & ROCM_ERNIC_ETH_CTL_RESET)) {
+        printf("FAIL: reset bit not detected\n");
+        failures++;
+    }
+
+    /* Clearing via ~MASK leaves the low bits and clears bit 31. */
+    ctl = 0xFFFFFFFFu;
+    ctl &= ~ROCM_ERNIC_ETH_CTL_RESET;
+    if (ctl != 0x7FFFFFFFu) {
+        printf("FAIL: clear reset bit => %#x\n", ctl);
+        failures++;
+    }
+
+    if (failures) {
+        printf("eth_ctl_reset: %d check(s) FAILED\n", failures);
+        return 1;
+    }
+    printf("eth_ctl_reset: all checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
A one-line undefined-behaviour fix in an Ethernet control-register bit, with a test.

### The bug

`ROCM_ERNIC_ETH_CTL_RESET` is defined as `(1 << 31)`:

```c
#define ROCM_ERNIC_ETH_CTL_RESET     (1 << 31) /* Software Reset */
```

`1 << 31` shifts a `1` into the sign bit of a signed `int`, which is undefined behaviour in C. cppcheck flags it as `shiftTooManyBitsSigned` at the two use sites in `pvrdma_eth.c`.

### The fix

Define it as `(1u << 31)` so the shift is on an unsigned value. The bit pattern (`0x80000000`) is unchanged, so behaviour is identical on current targets — this just removes the UB.

Note: the other `shiftTooManyBitsSigned` sites in `pvrdma_main.c` trace back to `1 << 31` in the imported VMware/Linux PVRDMA uAPI headers (`vmw_pvrdma-abi.h`, `pvrdma_dev_api.h`), which are left untouched to stay in sync with upstream.

### Test

`tests/test_eth_ctl_reset.c` asserts at compile time that the macro is bit 31 and is a non-negative (unsigned) constant — the assertion fails against the old signed `(1 << 31)` — plus runtime checks of the set/clear behaviour. Registered with CTest as `eth-ctl-reset-unit`.

Thanks! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)
