### PR TITLE
Harden TCP backend integer parsing against overflow and garbage

### DIFF
--- a/src/from-qemu/hw/rdma/rdma_backend_tcp.c
+++ b/src/from-qemu/hw/rdma/rdma_backend_tcp.c
@@ -20,6 +20,7 @@
 #include "vmw/pvrdma.h"
 #include "../../utils/dhcp_server.h"
 #include "../../utils/eth_rx_inject.h"
+#include "../../utils/parse_int.h"
 #include <errno.h>
 #include <string.h>
 #include <glib.h>
@@ -66,8 +67,8 @@ static int tcp_env_int(const char *name, int fallback)
 {
     const char *val = getenv(name);
     if (val) {
-        int v = atoi(val);
-        if (v > 0) {
+        int v;
+        if (ernic_parse_int(val, &v) && v > 0) {
             return v;
         }
     }
@@ -763,7 +764,9 @@ static int parse_tcp_config_manager(const char *config, char **manager_host,
             rdma_error_report("TCP manager: missing port for listen mode");
             return -EINVAL;
         }
-        port_val = (uint16_t)atoi(token);
+        if (!ernic_parse_port(token, &port_val)) {
+            port_val = 0; /* rejected below by the port_val == 0 check */
+        }
         host_str = g_strdup("0.0.0.0");
     } else {
         host_str = g_strdup(token);
@@ -774,7 +777,9 @@ static int parse_tcp_config_manager(const char *config, char **manager_host,
             rdma_error_report("TCP manager: missing port");
             return -EINVAL;
         }
-        port_val = (uint16_t)atoi(token);
+        if (!ernic_parse_port(token, &port_val)) {
+            port_val = 0; /* rejected below by the port_val == 0 check */
+        }
     }
 
     if (port_val == 0) {
@@ -827,7 +832,9 @@ static int parse_tcp_config_worker(const char *config, char **manager_host,
         rdma_error_report("TCP worker: missing manager port");
         return -EINVAL;
     }
-    port_val = (uint16_t)atoi(token);
+    if (!ernic_parse_port(token, &port_val)) {
+        port_val = 0; /* rejected below by the port_val == 0 check */
+    }
 
     if (port_val == 0) {
         g_free(config_copy);

--- a/src/from-qemu/utils/parse_int.h
+++ b/src/from-qemu/utils/parse_int.h
@@ -1,0 +1,66 @@
+/*
+ * Strict integer parsing helpers.
+ *
+ * strtol-based replacements for atoi() that reject empty input, trailing
+ * garbage, and out-of-range values instead of silently truncating or
+ * returning 0. Header-only so they can be unit-tested directly.
+ *
+ * Copyright (C) 2025 Advanced Micro Devices, Inc.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#ifndef ERNIC_PARSE_INT_H
+#define ERNIC_PARSE_INT_H
+
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/*
+ * Parse a base-10 int. Rejects NULL/empty input, trailing non-numeric
+ * characters, and values outside [INT_MIN, INT_MAX]. On success stores the
+ * value in *out and returns true; otherwise leaves *out untouched and
+ * returns false.
+ */
+static inline bool ernic_parse_int(const char *s, int *out)
+{
+    if (!s || *s == '\0') {
+        return false;
+    }
+
+    errno = 0;
+    char *end = NULL;
+    long v = strtol(s, &end, 10);
+
+    if (errno != 0 || end == s || *end != '\0') {
+        return false;
+    }
+    if (v < INT_MIN || v > INT_MAX) {
+        return false;
+    }
+
+    *out = (int)v;
+    return true;
+}
+
+/*
+ * Parse a TCP port in [1, 65535]. Returns true on success (value in *out),
+ * false for anything out of range, non-numeric, or zero.
+ */
+static inline bool ernic_parse_port(const char *s, uint16_t *out)
+{
+    int v;
+    if (!ernic_parse_int(s, &v)) {
+        return false;
+    }
+    if (v < 1 || v > 65535) {
+        return false;
+    }
+
+    *out = (uint16_t)v;
+    return true;
+}
+
+#endif /* ERNIC_PARSE_INT_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -143,6 +143,15 @@ if(CMOCKA_FOUND)
         ${CMOCKA_LIBRARIES}
     )
 endif()
+# Strict integer parser (parse_int.h) unit test (header-only). The ported
+# header dir is a SYSTEM include so its warnings stay quiet while the test
+# source itself is still warning-checked.
+add_executable(test_parse_int test_parse_int.c)
+target_include_directories(test_parse_int SYSTEM PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/utils
+)
+target_compile_options(test_parse_int PRIVATE ${ERNIC_UNIT_TEST_SAN})
+target_link_options(test_parse_int PRIVATE ${ERNIC_UNIT_TEST_SAN_LINK})
 
 # ---------------------------------------------------------------
 # Register tests with CTest
@@ -200,3 +209,9 @@ if(CMOCKA_FOUND)
         RUN_SERIAL TRUE
     )
 endif()
+# Strict integer/port parser unit test
+add_test(
+    NAME parse-int-unit
+    COMMAND $<TARGET_FILE:test_parse_int>
+)
+set_tests_properties(parse-int-unit PROPERTIES TIMEOUT 30)

--- a/tests/test_parse_int.c
+++ b/tests/test_parse_int.c
@@ -1,0 +1,106 @@
+/*
+ * Unit tests for the strict integer parsers in parse_int.h.
+ *
+ * These replace atoi() in the TCP backend's env and port parsing. Unlike
+ * atoi(), they must reject empty input, trailing garbage, and out-of-range
+ * values rather than truncating or returning 0.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "parse_int.h"
+
+struct int_case {
+    const char *name;
+    const char *input; /* NULL exercises the NULL path */
+    bool expect_ok;
+    int expect_val; /* checked only when expect_ok */
+};
+
+struct port_case {
+    const char *name;
+    const char *input;
+    bool expect_ok;
+    uint16_t expect_val;
+};
+
+static int run_int(const struct int_case *tc)
+{
+    int v = 0xDEAD;
+    bool ok = ernic_parse_int(tc->input, &v);
+    if (ok != tc->expect_ok) {
+        printf("FAIL int %-16s: ok=%d expected %d\n", tc->name, ok,
+               tc->expect_ok);
+        return 1;
+    }
+    if (ok && v != tc->expect_val) {
+        printf("FAIL int %-16s: val=%d expected %d\n", tc->name, v,
+               tc->expect_val);
+        return 1;
+    }
+    return 0;
+}
+
+static int run_port(const struct port_case *tc)
+{
+    uint16_t p = 0xBEEF;
+    bool ok = ernic_parse_port(tc->input, &p);
+    if (ok != tc->expect_ok) {
+        printf("FAIL port %-16s: ok=%d expected %d\n", tc->name, ok,
+               tc->expect_ok);
+        return 1;
+    }
+    if (ok && p != tc->expect_val) {
+        printf("FAIL port %-16s: val=%u expected %u\n", tc->name, (unsigned)p,
+               (unsigned)tc->expect_val);
+        return 1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    static const struct int_case int_cases[] = {
+        {"null", NULL, false, 0},
+        {"empty", "", false, 0},
+        {"valid", "1234", true, 1234},
+        {"zero", "0", true, 0},
+        {"negative", "-5", true, -5},
+        {"trailing-garbage", "123abc", false, 0},
+        {"non-numeric", "abc", false, 0},
+        {"trailing-space", "123 ", false, 0},
+        {"overflow", "99999999999999999999", false, 0},
+        {"int-max", "2147483647", true, INT_MAX},
+    };
+
+    static const struct port_case port_cases[] = {
+        {"valid", "8080", true, 8080},    {"min", "1", true, 1},
+        {"max", "65535", true, 65535},    {"zero", "0", false, 0},
+        {"too-large", "65536", false, 0}, {"way-too-large", "99999", false, 0},
+        {"negative", "-1", false, 0},     {"garbage", "80x", false, 0},
+        {"empty", "", false, 0},
+    };
+
+    int failures = 0;
+    size_t ni = sizeof(int_cases) / sizeof(int_cases[0]);
+    size_t np = sizeof(port_cases) / sizeof(port_cases[0]);
+    for (size_t i = 0; i < ni; i++) {
+        failures += run_int(&int_cases[i]);
+    }
+    for (size_t i = 0; i < np; i++) {
+        failures += run_port(&port_cases[i]);
+    }
+
+    if (failures) {
+        printf("parse_int: %d case(s) FAILED\n", failures);
+        return 1;
+    }
+    printf("parse_int: all %zu cases passed\n", ni + np);
+    return 0;
+}


### PR DESCRIPTION
A small hardening change: strict integer parsing in the TCP backend, with a test.

### The issue

The TCP backend parsed env tunables and manager/worker ports with `atoi()`, which silently truncates on overflow and returns 0 for non-numeric input:

```c
static int tcp_env_int(const char *name, int fallback) {
    const char *val = getenv(name);
    if (val) { int v = atoi(val); if (v > 0) return v; }
    return fallback;
}
...
port_val = (uint16_t)atoi(token);
```

So `"65536"` wrapped to `0` and `"123abc"` was accepted as `123`. semgrep flags the `atoi` calls (`atoi-atol-usage`). `getenv()` was already NULL-checked at both sites, so that part is fine.

### The change

Add a small header-only helper `parse_int.h` with `ernic_parse_int` and `ernic_parse_port` (strtol-based), which reject empty input, trailing garbage, and out-of-range values. Use them in `tcp_env_int` and the three port parses; the existing `port == 0` checks still reject bad ports, so control flow is unchanged.

### Test

`tests/test_parse_int.c` is table-driven — valid, empty, negative, zero, non-numeric, trailing garbage, overflow, and port-range rejection — built with AddressSanitizer + UBSan and registered with CTest as `parse-int-unit`.

This is a hardening change rather than a live bug (the callers all pass a sane fallback / reject port 0), so no rush — happy to adjust the strictness if you'd prefer to keep accepting, say, trailing whitespace.

Thanks! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)
