### PR TITLE
Remove unreachable SGE-index guards in loopback backend

### DIFF
--- a/src/from-qemu/hw/rdma/rdma_backend_loopback.c
+++ b/src/from-qemu/hw/rdma/rdma_backend_loopback.c
@@ -377,9 +377,6 @@ static int loopback_copy_sge_data(PCIDevice *pci_dev, struct ibv_sge *src_sge,
                 rdma_pci_dma_unmap(pci_dev, src_host, src_mapped_len);
                 src_host = NULL;
             }
-            if (src_idx >= num_src_sge) {
-                break;
-            }
             src_mapped_len = src_sge[src_idx].length;
             src_host = rdma_pci_dma_map(pci_dev, src_sge[src_idx].addr,
                                         src_mapped_len);
@@ -403,9 +400,6 @@ static int loopback_copy_sge_data(PCIDevice *pci_dev, struct ibv_sge *src_sge,
                              dst_mapped_len);
                 rdma_pci_dma_unmap(pci_dev, dst_host, dst_mapped_len);
                 dst_host = NULL;
-            }
-            if (dst_idx >= num_dst_sge) {
-                break;
             }
             dst_mapped_len = dst_sge[dst_idx].length;
             dst_host = rdma_pci_dma_map(pci_dev, dst_sge[dst_idx].addr,
@@ -517,9 +511,6 @@ static int loopback_copy_to_remote_addr(
     while (src_idx < num_src_sge && remote_offset < total_len) {
         if (!src_host || src_offset >= src_mapped_len) {
             src_host = NULL;
-            if (src_idx >= num_src_sge) {
-                break;
-            }
             src_mapped_len = src_sge[src_idx].length;
             src_host = loopback_translate_addr(pci_dev, src_sge[src_idx].addr,
                                                src_mapped_len);
@@ -614,9 +605,6 @@ static int loopback_copy_from_remote_addr(
     while (dst_idx < num_dst_sge && remote_offset < total_len) {
         if (!dst_host || dst_offset >= dst_mapped_len) {
             dst_host = NULL;
-            if (dst_idx >= num_dst_sge) {
-                break;
-            }
             dst_mapped_len = dst_sge[dst_idx].length;
             dst_host = loopback_translate_addr(pci_dev, dst_sge[dst_idx].addr,
                                                dst_mapped_len);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -293,6 +293,30 @@ target_include_directories(test_parse_int SYSTEM PRIVATE
 target_compile_options(test_parse_int PRIVATE ${ERNIC_UNIT_TEST_SAN})
 target_link_options(test_parse_int PRIVATE ${ERNIC_UNIT_TEST_SAN_LINK})
 
+# Loopback SGE-copy test. It #includes the loopback translation unit to
+# reach its static helpers and stubs the DMA layer with an identity
+# mapping, so no RDMA subsystem link is needed.
+add_executable(test_loopback_sge_copy test_loopback_sge_copy.c)
+target_include_directories(test_loopback_sge_copy PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/from-qemu
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/include/qemu-extra
+    ${GLIB2_INCLUDE_DIRS}
+    ${IBVERBS_INCLUDE_DIRS}
+)
+target_compile_definitions(test_loopback_sge_copy PRIVATE
+    _GNU_SOURCE TARGET_PAGE_SIZE=4096)
+# -w: this test #includes the ported loopback translation unit, so warnings
+# would come from that ported C rather than the test itself; suppress them
+# to match how the ported sources are compiled in the main build.
+target_compile_options(test_loopback_sge_copy PRIVATE
+    -w ${ERNIC_UNIT_TEST_SAN})
+target_link_options(test_loopback_sge_copy PRIVATE ${ERNIC_UNIT_TEST_SAN_LINK})
+target_link_directories(test_loopback_sge_copy PRIVATE
+    ${GLIB2_LIBRARY_DIRS} ${IBVERBS_LIBRARY_DIRS})
+target_link_libraries(test_loopback_sge_copy PRIVATE
+    ${GLIB2_LIBRARIES} ${IBVERBS_LIBRARIES})
+
 # ---------------------------------------------------------------
 # Register tests with CTest
 # ---------------------------------------------------------------
@@ -401,3 +425,10 @@ add_test(
     COMMAND $<TARGET_FILE:test_parse_int>
 )
 set_tests_properties(parse-int-unit PROPERTIES TIMEOUT 30)
+
+# Loopback SGE-copy boundary-walking unit test
+add_test(
+    NAME loopback-sge-copy-unit
+    COMMAND $<TARGET_FILE:test_loopback_sge_copy>
+)
+set_tests_properties(loopback-sge-copy-unit PROPERTIES TIMEOUT 30 RUN_SERIAL TRUE)

--- a/tests/test_loopback_sge_copy.c
+++ b/tests/test_loopback_sge_copy.c
@@ -1,0 +1,265 @@
+/*
+ * Unit tests for the loopback SGE copy helpers in rdma_backend_loopback.c.
+ *
+ * These functions walk source/destination scatter-gather lists, mapping
+ * one SGE at a time and advancing through partial buffers. They previously
+ * carried inner "if (idx >= num_sge) break;" guards that the enclosing
+ * while-condition already made unreachable; this test exercises the
+ * boundary-walking logic (single/multi/partial/mismatched SGEs) to show
+ * the copy still transfers the right bytes with those dead guards removed.
+ *
+ * The static helpers are reached by #including the translation unit; the
+ * DMA layer is stubbed with an identity mapping (an SGE addr is just a host
+ * pointer), so copies run in-process under AddressSanitizer.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Pull in the code under test (including its static functions). */
+#include "hw/rdma/rdma_backend_loopback.c"
+
+/* ---- Stubs for the TU's external symbols -------------------------------
+ * rdma_pci_dma_map is an identity mapping: the SGE "guest address" is a
+ * real host pointer, so map returns it unchanged and unmap/sync are no-ops.
+ */
+void *rdma_pci_dma_map(void *dev, uint64_t addr, uint64_t len)
+{
+    (void)dev;
+    (void)len;
+    return (void *)(uintptr_t)addr;
+}
+void rdma_pci_dma_unmap(void *dev, void *buffer, uint64_t len)
+{
+    (void)dev;
+    (void)buffer;
+    (void)len;
+}
+int pci_dma_sync(PCIDevice *dev, uint64_t guest_addr, uint64_t len)
+{
+    (void)dev;
+    (void)guest_addr;
+    (void)len;
+    return 0;
+}
+void *PVRDMA_DEV(void *obj)
+{
+    return obj;
+}
+PVRDMAQPStats *pvrdma_get_qp_stats(PVRDMADev *dev, uint32_t qp_handle)
+{
+    (void)dev;
+    (void)qp_handle;
+    return NULL;
+}
+void rdma_backend_complete_work(enum ibv_wc_status status, uint32_t vendor_err,
+                                uint32_t byte_len, uint32_t qp_num,
+                                enum ibv_wc_opcode opcode, void *ctx)
+{
+    (void)status;
+    (void)vendor_err;
+    (void)byte_len;
+    (void)qp_num;
+    (void)opcode;
+    (void)ctx;
+}
+void error_report(const char *fmt, ...)
+{
+    (void)fmt;
+}
+void warn_report(const char *fmt, ...)
+{
+    (void)fmt;
+}
+void info_report(const char *fmt, ...)
+{
+    (void)fmt;
+}
+/* Receive-completion helpers live in pvrdma_qp_ops.c, which this test does
+ * not link; the SGE-copy paths under test never depend on their effect. */
+void pvrdma_queue_recv_work_completion(PVRDMADev *dev, uint32_t recv_cq_handle,
+                                       uint64_t recv_guest_wr_id,
+                                       uint32_t byte_len, uint32_t src_qp_num)
+{
+    (void)dev;
+    (void)recv_cq_handle;
+    (void)recv_guest_wr_id;
+    (void)byte_len;
+    (void)src_qp_num;
+}
+void pvrdma_queue_recv_imm_work_completion(
+    PVRDMADev *dev, uint32_t recv_cq_handle, uint32_t recv_qp_handle,
+    uint64_t recv_guest_wr_id, uint32_t byte_len, uint32_t src_qp_num,
+    uint32_t imm_data)
+{
+    (void)dev;
+    (void)recv_cq_handle;
+    (void)recv_qp_handle;
+    (void)recv_guest_wr_id;
+    (void)byte_len;
+    (void)src_qp_num;
+    (void)imm_data;
+}
+
+/* ---- Test helpers ------------------------------------------------------ */
+
+static PCIDevice *dummy_pci(void)
+{
+    static uint8_t dummy;
+    return (PCIDevice *)&dummy;
+}
+
+/* Fill a buffer with a recognisable, position-dependent pattern. */
+static void fill_seq(uint8_t *buf, size_t len, uint8_t base)
+{
+    for (size_t i = 0; i < len; i++) {
+        buf[i] = (uint8_t)(base + i);
+    }
+}
+
+/*
+ * Build an SGE list over freshly-allocated exact-size buffers and seed the
+ * source bytes into a linear reference stream. Returns total bytes.
+ */
+static uint32_t build_sges(struct ibv_sge *sges, const uint32_t *sizes,
+                           uint32_t n, uint8_t *ref, int seed_source)
+{
+    uint32_t total = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        uint8_t *buf = malloc(sizes[i] ? sizes[i] : 1);
+        sges[i].addr = (uint64_t)(uintptr_t)buf;
+        sges[i].length = sizes[i];
+        sges[i].lkey = 0;
+        if (seed_source) {
+            fill_seq(buf, sizes[i], (uint8_t)(0x10 * (i + 1)));
+            memcpy(ref + total, buf, sizes[i]);
+        } else {
+            memset(buf, 0, sizes[i]);
+        }
+        total += sizes[i];
+    }
+    return total;
+}
+
+static void free_sges(struct ibv_sge *sges, uint32_t n)
+{
+    for (uint32_t i = 0; i < n; i++) {
+        free((void *)(uintptr_t)sges[i].addr);
+    }
+}
+
+/* Concatenate destination SGE contents into a linear buffer. */
+static void gather_dst(const struct ibv_sge *sges, uint32_t n, uint8_t *out)
+{
+    uint32_t off = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        memcpy(out + off, (void *)(uintptr_t)sges[i].addr, sges[i].length);
+        off += sges[i].length;
+    }
+}
+
+static int check_sge_copy(const char *name, const uint32_t *src_sizes,
+                          uint32_t nsrc, const uint32_t *dst_sizes,
+                          uint32_t ndst)
+{
+    struct ibv_sge src[8], dst[8];
+    uint8_t src_ref[4096] = {0};
+    uint8_t dst_ref[4096] = {0};
+
+    uint32_t src_total = build_sges(src, src_sizes, nsrc, src_ref, 1);
+    uint32_t dst_total = build_sges(dst, dst_sizes, ndst, dst_ref, 0);
+
+    int copied = loopback_copy_sge_data(dummy_pci(), src, nsrc, dst, ndst,
+                                        LOOPBACK_DATA_PATTERN_PRESERVE);
+
+    uint32_t expect = src_total < dst_total ? src_total : dst_total;
+    int fail = 0;
+    if (copied != (int)expect) {
+        printf("FAIL %-22s: copied=%d expected=%u\n", name, copied, expect);
+        fail = 1;
+    } else {
+        gather_dst(dst, ndst, dst_ref);
+        if (memcmp(src_ref, dst_ref, expect) != 0) {
+            printf("FAIL %-22s: copied bytes differ from source\n", name);
+            fail = 1;
+        }
+    }
+
+    free_sges(src, nsrc);
+    free_sges(dst, ndst);
+    return fail;
+}
+
+static int check_remote_roundtrip(const char *name, const uint32_t *sizes,
+                                  uint32_t n)
+{
+    struct ibv_sge src[8], dst[8];
+    uint8_t src_ref[4096] = {0};
+    uint8_t dst_ref[4096] = {0};
+
+    uint32_t total = build_sges(src, sizes, n, src_ref, 1);
+    (void)build_sges(dst, sizes, n, dst_ref, 0);
+
+    /* remote address is an identity-mapped scratch buffer of size total */
+    uint8_t *remote = calloc(total ? total : 1, 1);
+    uint64_t remote_addr = (uint64_t)(uintptr_t)remote;
+
+    int w = loopback_copy_to_remote_addr(dummy_pci(), src, n, remote_addr,
+                                         total, LOOPBACK_DATA_PATTERN_PRESERVE);
+    int r = loopback_copy_from_remote_addr(dummy_pci(), remote_addr, total, dst,
+                                           n, LOOPBACK_DATA_PATTERN_PRESERVE);
+
+    int fail = 0;
+    if (w != (int)total || r != (int)total) {
+        printf("FAIL %-22s: write=%d read=%d expected=%u\n", name, w, r, total);
+        fail = 1;
+    } else {
+        gather_dst(dst, n, dst_ref);
+        if (memcmp(src_ref, dst_ref, total) != 0) {
+            printf("FAIL %-22s: round-trip bytes differ\n", name);
+            fail = 1;
+        }
+    }
+
+    free(remote);
+    free_sges(src, n);
+    free_sges(dst, n);
+    return fail;
+}
+
+int main(void)
+{
+    int failures = 0;
+
+    /* loopback_copy_sge_data: single, multi, partial, mismatched */
+    failures += check_sge_copy("single->single", (uint32_t[]){64}, 1,
+                               (uint32_t[]){64}, 1);
+    failures +=
+        check_sge_copy("multi-src->single-dst", (uint32_t[]){10, 20, 30}, 3,
+                       (uint32_t[]){60}, 1);
+    failures += check_sge_copy("single-src->multi-dst", (uint32_t[]){60}, 1,
+                               (uint32_t[]){10, 20, 30}, 3);
+    failures += check_sge_copy("mismatched-boundaries", (uint32_t[]){10, 20}, 2,
+                               (uint32_t[]){5, 5, 20}, 3);
+    failures += check_sge_copy("more-src-than-dst", (uint32_t[]){40, 40}, 2,
+                               (uint32_t[]){40}, 1);
+    failures += check_sge_copy("more-dst-than-src", (uint32_t[]){40}, 1,
+                               (uint32_t[]){40, 40}, 2);
+
+    /* remote copy helpers (RDMA write/read paths) */
+    failures += check_remote_roundtrip("remote-single", (uint32_t[]){100}, 1);
+    failures +=
+        check_remote_roundtrip("remote-multi", (uint32_t[]){16, 48, 80}, 3);
+
+    if (failures) {
+        printf("loopback_sge_copy: %d check(s) FAILED\n", failures);
+        return 1;
+    }
+    printf("loopback_sge_copy: all checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
A small dead-code cleanup in the loopback backend, with new test coverage for the path.

### The issue

Each loopback SGE-copy helper runs a loop bounded by the SGE index:

```c
while (src_idx < num_src_sge && dst_idx < num_dst_sge) {
    if (!src_host || src_offset >= src_mapped_len) {
        ...
        if (src_idx >= num_src_sge) {   /* can never be true here */
            break;
        }
        src_mapped_len = src_sge[src_idx].length;
```

The inner `if (idx >= num_sge) break;` re-checks a condition the enclosing `while` already guarantees, and the index isn't modified in between — so it's unreachable. cppcheck flags these as `oppositeInnerCondition` (dead code). There are four such guards across `loopback_copy_sge_data`, `loopback_copy_to_remote_addr`, and `loopback_copy_from_remote_addr`.

### The change

Remove the four redundant guards. The copy behaviour is unchanged (the index is bounded by the loop condition, and re-checked there each iteration after it advances).

### Test

`tests/test_loopback_sge_copy.c` exercises the SGE boundary-walking logic — single, multi, partial, and mismatched scatter-gather lists, plus a remote write/read round-trip — using an identity-mapped DMA stub, built with AddressSanitizer + UBSan and registered as `loopback-sge-copy-unit`. This path had no unit coverage before; the test passes identically with and without the guards, confirming the removal is behavior-preserving.

Thanks! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)
