### PR TITLE
Fix NULL-pointer dereference in rdma_backend_query_port

### DIFF
--- a/src/from-qemu/hw/rdma/rdma_backend.c
+++ b/src/from-qemu/hw/rdma/rdma_backend.c
@@ -347,6 +347,10 @@ int rdma_backend_query_port(RdmaBackendDev *backend_dev,
 {
     int rc;
 
+    if (!backend_dev) {
+        return -EINVAL;
+    }
+
     /* Prefer backend-specific implementation (e.g., TCP/loopback) */
     if (backend_dev && backend_dev->backend_ops &&
         backend_dev->backend_ops->query_port) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,52 @@ target_link_libraries(test_rdma_cm PRIVATE
     ${IBVERBS_LIBRARIES}
 )
 
+# -- Unit tests --------------------------------------------------
+# Built with AddressSanitizer + LeakSanitizer + UBSan (unless the project
+# is already built with ThreadSanitizer, which is incompatible). Flag set
+# matches cmake/ErnicSanitizers.cmake; -fno-omit-frame-pointer is
+# compile-only.
+set(ERNIC_UNIT_TEST_SAN)
+set(ERNIC_UNIT_TEST_SAN_LINK)
+if(NOT ERNIC_USE_THREAD_SANITIZER)
+    set(ERNIC_UNIT_TEST_SAN
+        -fsanitize=address,undefined,leak -fno-omit-frame-pointer)
+    set(ERNIC_UNIT_TEST_SAN_LINK -fsanitize=address,undefined,leak)
+endif()
+
+# rdma_backend_query_port test. Links the backend TU plus the utility /
+# resource-manager / qemu-stub sources it depends on; the query_port paths
+# under test never reach libibverbs or the DMA layer.
+add_executable(test_rdma_backend_query_port
+    test_rdma_backend_query_port.c
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/hw/rdma/rdma_backend.c
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/hw/rdma/rdma_utils.c
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/hw/rdma/rdma_rm.c
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/utils/error-report.c
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/qemu-stubs/qemu_stubs.c
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/qemu-stubs/qemu_type_stubs.c
+)
+target_include_directories(test_rdma_backend_query_port PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/from-qemu
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/hw/rdma
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/include/qemu-extra
+    ${GLIB2_INCLUDE_DIRS}
+    ${IBVERBS_INCLUDE_DIRS}
+)
+target_compile_definitions(test_rdma_backend_query_port PRIVATE
+    _GNU_SOURCE TARGET_PAGE_SIZE=4096)
+# -w: this test links the ported RDMA-backend translation units, so warnings
+# would come from that ported C rather than the test itself; suppress them
+# to match how the ported sources are compiled in the main build.
+target_compile_options(test_rdma_backend_query_port PRIVATE
+    -w ${ERNIC_UNIT_TEST_SAN})
+target_link_options(test_rdma_backend_query_port PRIVATE ${ERNIC_UNIT_TEST_SAN_LINK})
+target_link_directories(test_rdma_backend_query_port PRIVATE
+    ${GLIB2_LIBRARY_DIRS} ${IBVERBS_LIBRARY_DIRS})
+target_link_libraries(test_rdma_backend_query_port PRIVATE
+    ${GLIB2_LIBRARIES} ${IBVERBS_LIBRARIES} pthread)
+
 # ---------------------------------------------------------------
 # Register tests with CTest
 # ---------------------------------------------------------------
@@ -81,3 +127,10 @@ set_tests_properties(rdma-cm-test PROPERTIES
     RUN_SERIAL TRUE
     SKIP_RETURN_CODE 77
 )
+
+# rdma_backend_query_port NULL-guard / dispatch unit test
+add_test(
+    NAME rdma-backend-query-port-unit
+    COMMAND $<TARGET_FILE:test_rdma_backend_query_port>
+)
+set_tests_properties(rdma-backend-query-port-unit PROPERTIES TIMEOUT 30 RUN_SERIAL TRUE)

--- a/tests/test_rdma_backend_query_port.c
+++ b/tests/test_rdma_backend_query_port.c
@@ -1,0 +1,109 @@
+/*
+ * Unit tests for rdma_backend_query_port().
+ *
+ * Regression coverage for a NULL-pointer dereference: the function guarded
+ * the backend-ops path with "if (backend_dev && ...)" but the verbs
+ * fallback then dereferenced backend_dev->context unconditionally, so a
+ * NULL backend_dev crashed instead of returning an error. The fix returns
+ * -EINVAL up front.
+ *
+ * The backend-ops path is also exercised (via a stub vtable) to confirm the
+ * non-NULL path still dispatches correctly and never reaches the verbs
+ * fallback.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <infiniband/verbs.h>
+
+#include "rdma_backend_defs.h"
+#include "rdma_backend_ops.h"
+#include "rdma_backend.h"
+
+/* --- Stubs for symbols referenced by the backend TU but not provided by
+ * the linked qemu-stubs, and not exercised on the query_port paths under
+ * test. ---------------------------------------------------------------- */
+void *pci_dma_map(PCIDevice *dev, uint64_t addr, uint64_t *len, int dir)
+{
+    (void)dev;
+    (void)addr;
+    (void)len;
+    (void)dir;
+    return NULL;
+}
+void pci_dma_unmap(PCIDevice *dev, void *buffer, uint64_t len, int dir,
+                   uint64_t access_len)
+{
+    (void)dev;
+    (void)buffer;
+    (void)len;
+    (void)dir;
+    (void)access_len;
+}
+
+/* --- Stub backend vtable ------------------------------------------------ */
+static int g_stub_rc;
+static int g_stub_called;
+
+static int stub_query_port(RdmaBackendDev *backend_dev,
+                           struct ibv_port_attr *attr)
+{
+    (void)backend_dev;
+    g_stub_called++;
+    if (attr) {
+        memset(attr, 0, sizeof(*attr));
+        attr->state = IBV_PORT_ACTIVE;
+    }
+    return g_stub_rc;
+}
+
+static const RdmaBackendOps stub_ops = {
+    .name = "stub",
+    .query_port = stub_query_port,
+};
+
+int main(void)
+{
+    int failures = 0;
+    struct ibv_port_attr attr;
+
+    /* 1. NULL backend_dev must return an error, not crash. */
+    int rc = rdma_backend_query_port(NULL, &attr);
+    if (rc != -EINVAL) {
+        printf("FAIL null-backend: expected -EINVAL, got %d\n", rc);
+        failures++;
+    }
+
+    /* 2. Ops path dispatches and returns the backend's success code. */
+    RdmaBackendDev dev;
+    memset(&dev, 0, sizeof(dev));
+    dev.backend_ops = &stub_ops;
+    g_stub_rc = 0;
+    g_stub_called = 0;
+    rc = rdma_backend_query_port(&dev, &attr);
+    if (rc != 0 || g_stub_called != 1) {
+        printf("FAIL ops-success: rc=%d called=%d\n", rc, g_stub_called);
+        failures++;
+    }
+
+    /* 3. Ops path propagates a backend error code. */
+    g_stub_rc = -13;
+    g_stub_called = 0;
+    rc = rdma_backend_query_port(&dev, &attr);
+    if (rc != -13 || g_stub_called != 1) {
+        printf("FAIL ops-error: rc=%d called=%d\n", rc, g_stub_called);
+        failures++;
+    }
+
+    if (failures) {
+        printf("rdma_backend_query_port: %d case(s) FAILED\n", failures);
+        return 1;
+    }
+    printf("rdma_backend_query_port: all cases passed\n");
+    return 0;
+}


### PR DESCRIPTION
A NULL-pointer-dereference fix in the verbs query_port fallback, with a test.

### The bug

`rdma_backend_query_port()` guards the backend-ops path but not the verbs fallback:

```c
if (backend_dev && backend_dev->backend_ops &&
    backend_dev->backend_ops->query_port) {
    ...
    return 0;
}
/* Verbs backend fallback */
rc = ibv_query_port(backend_dev->context, backend_dev->port_num, port_attr);
```

If `backend_dev` is NULL, the first `if` short-circuits to false and the fallback dereferences `backend_dev->context` — a NULL dereference. The function's own guard establishes that `backend_dev` may be NULL, so the fallback shouldn't assume otherwise. Flagged by clang-analyzer (`core.NullDereference`).

### The fix

Return `-EINVAL` up front when `backend_dev` is NULL.

### Test

`tests/test_rdma_backend_query_port.c`: a NULL `backend_dev` returns `-EINVAL` without crashing, and the backend-ops path (via a stub vtable) still dispatches and propagates the backend's return code. Built with AddressSanitizer + UBSan and registered with CTest as `rdma-backend-query-port-unit`.

Thanks! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)
