### PR TITLE
emulator: add missing hw/pci/pci.h include to TCP backend

### DIFF
--- a/src/from-qemu/hw/rdma/rdma_backend_tcp.c
+++ b/src/from-qemu/hw/rdma/rdma_backend_tcp.c
@@ -18,6 +18,7 @@
 #include "rdma_utils.h"
 #include "standard-headers/rdma/vmw_pvrdma-abi.h"
 #include "vmw/pvrdma.h"
+#include "hw/pci/pci.h" /* For pci_dma_map/unmap/sync */
 #include "../../utils/dhcp_server.h"
 #include "../../utils/eth_rx_inject.h"
 #include <errno.h>


### PR DESCRIPTION
The TCP backend calls pci_dma_map(), pci_dma_unmap() and pci_dma_sync() without including the header that declares them, hw/pci/pci.h. Nothing in the file's include chain provides those declarations, so every call is compiled against an implicit declaration that assumes int return; for pci_dma_map(), whose real return type is void *, that is the wrong prototype on 64-bit systems.

On GCC 13 (Ubuntu 24.04) the implicit-function-declaration warnings are hidden because the CMake build applies -w to all QEMU-ported sources. GCC 14 promotes this diagnostic to an error by default, which -w cannot suppress, so on newer toolchains the TCP backend fails to build. On Rocky Linux 10 with GCC 14.3.1, main fails with:

```
rdma_backend_tcp.c:596:26: error: implicit declaration of function 'pci_dma_map'
rdma_backend_tcp.c:632:13: error: implicit declaration of function 'pci_dma_unmap'
rdma_backend_tcp.c:1915:21: error: implicit declaration of function 'pci_dma_sync'
```

The loopback backend already includes hw/pci/pci.h directly for pci_dma_sync().

### The fix

Add the missing include to rdma_backend_tcp.c, matching how rdma_backend_loopback.c handles it.

### Testing

Built on Rocky Linux 10 (GCC 14.3.1): main fails with the three implicit-declaration errors above; with the header included the rocm-ernic target builds and links. clang-format check passes on the touched file.