### PR TITLE
Clear qp_handle on send error paths before send_in_flight accounting

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -674,6 +674,58 @@ jobs:
         fi
         echo "✓ DC guest smoke passed or skipped cleanly"
 
+    - name: DC error path guest smoke (build and run test_dc_error_paths)
+      shell: bash
+      run: |
+        echo "=== DC error path guest smoke (send_in_flight accounting) ==="
+        SSH_PORT="$SSH_PORT"
+        VM_USER="$VM_USER"
+        ssh -o StrictHostKeyChecking=no -p "$SSH_PORT" \
+          "${VM_USER}@localhost" "mkdir -p /tmp/dc-err-smoke"
+        scp -o StrictHostKeyChecking=no -P "$SSH_PORT" \
+          tests/test_dc_error_paths.c \
+          rdma-core/providers/rocm_ernic/rocm_ernic_dc.h \
+          "${VM_USER}@localhost:/tmp/dc-err-smoke/"
+        set +e
+        ssh -o StrictHostKeyChecking=no -p "$SSH_PORT" "${VM_USER}@localhost" 'bash -s' <<'EOFVM'
+        set -e
+        cd /tmp/dc-err-smoke
+        ROCM_LIBDIR=""
+        for d in /usr/lib/x86_64-linux-gnu/libibverbs /usr/lib/libibverbs; do
+          if [ -d "$d" ] && ls "$d"/librocm_ernic*.so >/dev/null 2>&1; then
+            ROCM_LIBDIR="$d"
+            break
+          fi
+        done
+        if [ -z "$ROCM_LIBDIR" ]; then
+          echo "librocm_ernic not found; skipping DC error path smoke"
+          exit 0
+        fi
+        gcc -O2 -Wall -Wextra -I. \
+          -o test_dc_error_paths test_dc_error_paths.c \
+          $(pkg-config --cflags --libs libibverbs) \
+          -L"$ROCM_LIBDIR" -lrocm_ernic -Wl,-rpath,"$ROCM_LIBDIR"
+        set +e
+        timeout 120 ./test_dc_error_paths
+        DCE_EXIT=$?
+        if [ "$DCE_EXIT" -eq 124 ]; then
+          echo "test_dc_error_paths timed out after 120s"
+        fi
+        set -e
+        if [ "$DCE_EXIT" -eq 77 ]; then
+          echo "No rocm_ernic device found; skipping DC error path smoke"
+          exit 0
+        fi
+        exit $DCE_EXIT
+        EOFVM
+        DCE_EXIT=$?
+        set -e
+        if [ "$DCE_EXIT" -ne 0 ]; then
+          echo "✗ DC error path guest smoke failed (exit $DCE_EXIT)"
+          exit 1
+        fi
+        echo "✓ DC error path guest smoke passed or skipped cleanly"
+
     - name: Sysfs loopback smoke test
       shell: bash
       run: |

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_qp_ops.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_qp_ops.c
@@ -487,6 +487,12 @@ static gboolean continue_qp_send_processing(gpointer user_data)
             if (!sgid) {
                 rdma_error_report("Failed to get gid for idx %d",
                                   wqe->hdr.wr.ud.av.gid_index);
+                /*
+                 * This work request failed validation before the
+                 * send_in_flight increment below; clear the handle so
+                 * the deferred drain does not decrement it.
+                 */
+                comp_ctx->qp_handle = 0;
                 complete_with_error(VENDOR_ERR_INV_GID_IDX, comp_ctx);
                 pvrdma_ring_read_inc(ring);
                 wqe = pvrdma_ring_next_elem_read(ring);
@@ -500,6 +506,7 @@ static gboolean continue_qp_send_processing(gpointer user_data)
             if ((int8_t)sgid_idx < 0) {
                 rdma_error_report("Failed to get bk sgid_idx for sgid_idx %d",
                                   wqe->hdr.wr.ud.av.gid_index);
+                comp_ctx->qp_handle = 0;
                 complete_with_error(VENDOR_ERR_INV_GID_IDX, comp_ctx);
                 pvrdma_ring_read_inc(ring);
                 wqe = pvrdma_ring_next_elem_read(ring);
@@ -532,6 +539,7 @@ static gboolean continue_qp_send_processing(gpointer user_data)
                 uint64_t wire_key = (uint64_t)wqe->hdr.wr.dc.dc_access_key;
 
                 if (!dct) {
+                    comp_ctx->qp_handle = 0;
                     complete_with_error(VENDOR_ERR_INV_DCT, comp_ctx);
                     pvrdma_ring_read_inc(ring);
                     wqe = pvrdma_ring_next_elem_read(ring);
@@ -539,6 +547,7 @@ static gboolean continue_qp_send_processing(gpointer user_data)
                     continue;
                 }
                 if (dct->dct_access_key != wire_key) {
+                    comp_ctx->qp_handle = 0;
                     complete_with_error(VENDOR_ERR_DC_KEY, comp_ctx);
                     pvrdma_ring_read_inc(ring);
                     wqe = pvrdma_ring_next_elem_read(ring);
@@ -546,6 +555,7 @@ static gboolean continue_qp_send_processing(gpointer user_data)
                     continue;
                 }
                 if (!dct->is_srq) {
+                    comp_ctx->qp_handle = 0;
                     complete_with_error(VENDOR_ERR_INV_DCT, comp_ctx);
                     pvrdma_ring_read_inc(ring);
                     wqe = pvrdma_ring_next_elem_read(ring);
@@ -555,6 +565,7 @@ static gboolean continue_qp_send_processing(gpointer user_data)
                 RdmaRmSRQ *srq_rm =
                     rdma_rm_get_srq(&dev->rdma_dev_res, dct->bound_srq_handle);
                 if (!srq_rm) {
+                    comp_ctx->qp_handle = 0;
                     complete_with_error(VENDOR_ERR_INV_DCT, comp_ctx);
                     pvrdma_ring_read_inc(ring);
                     wqe = pvrdma_ring_next_elem_read(ring);
@@ -573,6 +584,7 @@ static gboolean continue_qp_send_processing(gpointer user_data)
             } else {
                 rdma_error_report("Unsupported opcode %u on DCI QP",
                                   pvrdma_opcode);
+                comp_ctx->qp_handle = 0;
                 complete_with_error(VENDOR_ERR_INV_QP_TYPE, comp_ctx);
                 pvrdma_ring_read_inc(ring);
                 wqe = pvrdma_ring_next_elem_read(ring);
@@ -586,6 +598,7 @@ static gboolean continue_qp_send_processing(gpointer user_data)
             dqkey = 0;
         } else {
             rdma_error_report("Unsupported QP type %d for send", qp->qp_type);
+            comp_ctx->qp_handle = 0;
             complete_with_error(VENDOR_ERR_INV_QP_TYPE, comp_ctx);
             pvrdma_ring_read_inc(ring);
             wqe = pvrdma_ring_next_elem_read(ring);
@@ -596,6 +609,7 @@ static gboolean continue_qp_send_processing(gpointer user_data)
         if (wqe->hdr.num_sge > dev->dev_attr.max_sge) {
             rdma_error_report("Invalid num_sge=%d (max %d)", wqe->hdr.num_sge,
                               dev->dev_attr.max_sge);
+            comp_ctx->qp_handle = 0;
             complete_with_error(VENDOR_ERR_INV_NUM_SGE, comp_ctx);
             pvrdma_ring_read_inc(ring);
             wqe = pvrdma_ring_next_elem_read(ring);
@@ -807,6 +821,12 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
             if (!sgid) {
                 rdma_error_report("Failed to get gid for idx %d",
                                   wqe->hdr.wr.ud.av.gid_index);
+                /*
+                 * This work request failed validation before the
+                 * send_in_flight increment below; clear the handle so
+                 * the deferred drain does not decrement it.
+                 */
+                comp_ctx->qp_handle = 0;
                 complete_with_error(VENDOR_ERR_INV_GID_IDX, comp_ctx);
                 pvrdma_ring_read_inc(ring);
                 qp->wqe_state.send_wqes_processed++;
@@ -820,6 +840,7 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
             if ((int8_t)sgid_idx < 0) {
                 rdma_error_report("Failed to get bk sgid_idx for sgid_idx %d",
                                   wqe->hdr.wr.ud.av.gid_index);
+                comp_ctx->qp_handle = 0;
                 complete_with_error(VENDOR_ERR_INV_GID_IDX, comp_ctx);
                 pvrdma_ring_read_inc(ring);
                 qp->wqe_state.send_wqes_processed++;
@@ -852,6 +873,7 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
                 uint64_t wire_key = (uint64_t)wqe->hdr.wr.dc.dc_access_key;
 
                 if (!dct) {
+                    comp_ctx->qp_handle = 0;
                     complete_with_error(VENDOR_ERR_INV_DCT, comp_ctx);
                     pvrdma_ring_read_inc(ring);
                     wqe = pvrdma_ring_next_elem_read(ring);
@@ -859,6 +881,7 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
                     continue;
                 }
                 if (dct->dct_access_key != wire_key) {
+                    comp_ctx->qp_handle = 0;
                     complete_with_error(VENDOR_ERR_DC_KEY, comp_ctx);
                     pvrdma_ring_read_inc(ring);
                     wqe = pvrdma_ring_next_elem_read(ring);
@@ -866,6 +889,7 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
                     continue;
                 }
                 if (!dct->is_srq) {
+                    comp_ctx->qp_handle = 0;
                     complete_with_error(VENDOR_ERR_INV_DCT, comp_ctx);
                     pvrdma_ring_read_inc(ring);
                     wqe = pvrdma_ring_next_elem_read(ring);
@@ -875,6 +899,7 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
                 RdmaRmSRQ *srq_rm =
                     rdma_rm_get_srq(&dev->rdma_dev_res, dct->bound_srq_handle);
                 if (!srq_rm) {
+                    comp_ctx->qp_handle = 0;
                     complete_with_error(VENDOR_ERR_INV_DCT, comp_ctx);
                     pvrdma_ring_read_inc(ring);
                     wqe = pvrdma_ring_next_elem_read(ring);
@@ -893,6 +918,7 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
             } else {
                 rdma_error_report("Unsupported opcode %u on DCI QP",
                                   pvrdma_opcode);
+                comp_ctx->qp_handle = 0;
                 complete_with_error(VENDOR_ERR_INV_QP_TYPE, comp_ctx);
                 pvrdma_ring_read_inc(ring);
                 wqe = pvrdma_ring_next_elem_read(ring);
@@ -906,6 +932,7 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
             dqkey = 0;
         } else {
             rdma_error_report("Unsupported QP type %d for send", qp->qp_type);
+            comp_ctx->qp_handle = 0;
             complete_with_error(VENDOR_ERR_INV_QP_TYPE, comp_ctx);
             pvrdma_ring_read_inc(ring);
             qp->wqe_state.send_wqes_processed++;
@@ -916,6 +943,7 @@ void pvrdma_qp_send(PVRDMADev *dev, uint32_t qp_handle)
         if (wqe->hdr.num_sge > dev->dev_attr.max_sge) {
             rdma_error_report("Invalid num_sge=%d (max %d)", wqe->hdr.num_sge,
                               dev->dev_attr.max_sge);
+            comp_ctx->qp_handle = 0;
             complete_with_error(VENDOR_ERR_INV_NUM_SGE, comp_ctx);
             pvrdma_ring_read_inc(ring);
             qp->wqe_state.send_wqes_processed++;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,6 +125,36 @@ if(ERNIC_RDMA_CORE_BUILD)
         RUN_SERIAL TRUE
         SKIP_RETURN_CODE 77
     )
+
+    add_executable(test_dc_error_paths
+        test_dc_error_paths.c
+    )
+    target_compile_definitions(test_dc_error_paths PRIVATE
+        _POSIX_C_SOURCE=200809L
+    )
+    target_include_directories(test_dc_error_paths PRIVATE
+        ${IBVERBS_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}/rdma-core/providers/rocm_ernic
+        ${RDMA_CORE_INCLUDE_DIR}
+    )
+    target_link_directories(test_dc_error_paths PRIVATE
+        ${IBVERBS_LIBRARY_DIRS}
+        ${RDMA_CORE_LIB_DIR}
+    )
+    target_link_libraries(test_dc_error_paths PRIVATE
+        ${IBVERBS_LIBRARIES}
+        rocm_ernic
+    )
+
+    add_test(
+        NAME dc-error-paths-test
+        COMMAND $<TARGET_FILE:test_dc_error_paths>
+    )
+    set_tests_properties(dc-error-paths-test PROPERTIES
+        TIMEOUT 60
+        RUN_SERIAL TRUE
+        SKIP_RETURN_CODE 77
+    )
 endif()
 
 # -- test_ernic_dc_uapi (cmocka + driver ABI header) --------------

--- a/tests/test_dc_error_paths.c
+++ b/tests/test_dc_error_paths.c
@@ -1,0 +1,268 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) Gluesys Inc. and Jihyeon Gim. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Guest-side regression test for the send error path accounting:
+ * a work request that fails validation before the send_in_flight
+ * increment must not decrement it when its error completion drains,
+ * and the QP must stay usable afterwards.  Posts a plain SEND on a
+ * DCI QP, which the device rejects with an unsupported-opcode error
+ * completion, then posts a second plain SEND and requires it to be
+ * answered as well.  Requires librocm_ernic and the rocm_ernic char
+ * device.  Intended to run inside the VM used by system-tests
+ * after the custom provider is installed.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <infiniband/rocm_ernic_dc.h>
+#include <infiniband/verbs.h>
+
+#define SEND_BYTES    64
+#define RECV_BYTES    64
+#define SKEY          0xc001d00dULL
+#define CQ_POLL_LOOPS 500000U
+
+static struct ibv_device *find_rocm_ernic(struct ibv_device **list, int n)
+{
+    int i;
+    const char *name;
+
+    for (i = 0; i < n; i++) {
+        if (!list[i])
+            continue;
+        name = ibv_get_device_name(list[i]);
+        /* PCI-topology (rocep0s4), driver (rocm-rdma-ernic0), or raw
+         * (rocm_ernic0) naming depending on the guest udev rules. */
+        if (strstr(name, "rocm_ernic") || strstr(name, "rocep") ||
+            strstr(name, "ernic"))
+            return list[i];
+    }
+    return NULL;
+}
+
+static int poll_one(struct ibv_cq *cq, struct ibv_wc *wc)
+{
+    unsigned poll_i;
+
+    for (poll_i = 0; poll_i < CQ_POLL_LOOPS; poll_i++) {
+        int n = ibv_poll_cq(cq, 1, wc);
+
+        if (n < 0)
+            return -1;
+        if (n == 1)
+            return 1;
+        {
+            struct timespec ts = {0, 1000};
+
+            (void)nanosleep(&ts, NULL);
+        }
+    }
+    return 0; /* timed out */
+}
+
+int main(void)
+{
+    struct ibv_device **dev_list = NULL;
+    struct ibv_device *ibdev;
+    struct ibv_context *ctx = NULL;
+    struct ibv_pd *pd = NULL;
+    struct ibv_cq *send_cq = NULL;
+    struct ibv_cq *recv_cq = NULL;
+    struct ibv_qp *dci = NULL;
+    struct ibv_mr *mr = NULL;
+    void *buf = NULL;
+    struct ibv_qp_init_attr qp_attr = {};
+    struct rocm_ernic_dc_dci_init dci_init = {};
+    struct ibv_qp_attr mod_attr = {};
+    struct ibv_wc wc;
+    int mod_mask;
+    int ndev;
+    int ret = 1;
+
+    dev_list = ibv_get_device_list(&ndev);
+    if (!dev_list || ndev < 1) {
+        fprintf(stderr, "No IB devices\n");
+        if (dev_list) {
+            ibv_free_device_list(dev_list);
+            return 77; /* CTest skip code */
+        }
+        goto out;
+    }
+
+    ibdev = find_rocm_ernic(dev_list, ndev);
+    if (!ibdev) {
+        fprintf(stderr, "No rocm_ernic device found - skipping test\n");
+        ibv_free_device_list(dev_list);
+        return 77; /* CTest skip code */
+    }
+
+    ctx = ibv_open_device(ibdev);
+    if (!ctx) {
+        perror("ibv_open_device");
+        goto out;
+    }
+
+    pd = ibv_alloc_pd(ctx);
+    if (!pd) {
+        perror("ibv_alloc_pd");
+        goto out;
+    }
+
+    send_cq = ibv_create_cq(ctx, 8, NULL, NULL, 0);
+    recv_cq = ibv_create_cq(ctx, 8, NULL, NULL, 0);
+    if (!send_cq || !recv_cq) {
+        fprintf(stderr, "ibv_create_cq failed\n");
+        goto out;
+    }
+
+    buf = calloc(1, SEND_BYTES + RECV_BYTES);
+    if (!buf) {
+        perror("calloc");
+        goto out;
+    }
+
+    mr = ibv_reg_mr(pd, buf, SEND_BYTES + RECV_BYTES, IBV_ACCESS_LOCAL_WRITE);
+    if (!mr) {
+        perror("ibv_reg_mr");
+        goto out;
+    }
+
+    memset(&qp_attr, 0, sizeof(qp_attr));
+    qp_attr.send_cq = send_cq;
+    qp_attr.recv_cq = recv_cq;
+    qp_attr.qp_type = IBV_QPT_DRIVER;
+    qp_attr.srq = NULL;
+    qp_attr.cap.max_send_wr = 8;
+    qp_attr.cap.max_recv_wr = 1;
+    qp_attr.cap.max_send_sge = 1;
+    qp_attr.cap.max_recv_sge = 1;
+
+    memset(&dci_init, 0, sizeof(dci_init));
+    dci = rocm_ernic_dc_create_dci(pd, &qp_attr, &dci_init);
+    if (!dci) {
+        fprintf(stderr, "rocm_ernic_dc_create_dci failed errno=%d\n", errno);
+        goto out;
+    }
+
+    /* DCI: RESET -> INIT -> RTS */
+    memset(&mod_attr, 0, sizeof(mod_attr));
+    mod_attr.qp_state = IBV_QPS_INIT;
+    mod_attr.port_num = 1;
+    mod_attr.pkey_index = 0;
+    mod_attr.qp_access_flags = IBV_ACCESS_LOCAL_WRITE;
+    mod_mask =
+        IBV_QP_STATE | IBV_QP_PORT | IBV_QP_PKEY_INDEX | IBV_QP_ACCESS_FLAGS;
+    if (ibv_modify_qp(dci, &mod_attr, mod_mask)) {
+        fprintf(stderr, "DCI RESET->INIT failed errno=%d\n", errno);
+        goto out;
+    }
+
+    memset(&mod_attr, 0, sizeof(mod_attr));
+    mod_attr.qp_state = IBV_QPS_RTS;
+    mod_attr.sq_psn = 0;
+    mod_mask = IBV_QP_STATE | IBV_QP_SQ_PSN;
+    if (ibv_modify_qp(dci, &mod_attr, mod_mask)) {
+        fprintf(stderr, "DCI INIT->RTS failed errno=%d\n", errno);
+        goto out;
+    }
+
+    {
+        struct ibv_sge sge = {};
+        struct ibv_send_wr swr = {};
+        struct ibv_send_wr *bad = NULL;
+
+        sge.addr = (uint64_t)(uintptr_t)buf;
+        sge.length = SEND_BYTES;
+        sge.lkey = mr->lkey;
+
+        /* Phase 1: a plain SEND on a DCI QP.  The device rejects it
+         * with an unsupported-opcode error completion; the error path
+         * must not touch the in-flight accounting. */
+        swr.wr_id = 0xdead;
+        swr.opcode = IBV_WR_SEND;
+        swr.sg_list = &sge;
+        swr.num_sge = 1;
+        if (ibv_post_send(dci, &swr, &bad)) {
+            fprintf(stderr, "plain post_send errno=%d\n", errno);
+            goto out;
+        }
+
+        ret = poll_one(send_cq, &wc);
+        if (ret != 1) {
+            fprintf(stderr, "no completion for plain SEND\n");
+            ret = 1;
+            goto out;
+        }
+        if (wc.status == IBV_WC_SUCCESS) {
+            fprintf(stderr, "plain SEND on DCI unexpectedly succeeded\n");
+            ret = 1;
+            goto out;
+        }
+        if (wc.wr_id != 0xdead) {
+            fprintf(stderr, "error completion wr_id=%llu != 0xdead\n",
+                    (unsigned long long)wc.wr_id);
+            ret = 1;
+            goto out;
+        }
+        fprintf(stderr, "phase 1 OK: error completion status=%d\n", wc.status);
+
+        /* Phase 2: another plain SEND on the same QP.  Before the fix
+         * the error completion above decremented send_in_flight
+         * without a matching increment, wrapping it to UINT32_MAX;
+         * the send loop then refuses every further work request and
+         * no completion ever arrives (stall).  After the fix the
+         * second work request is processed and answered, even though
+         * it fails for the same reason as the first. */
+        swr.wr_id = 0xbeef;
+        if (ibv_post_send(dci, &swr, &bad)) {
+            fprintf(stderr, "second post_send errno=%d\n", errno);
+            ret = 1;
+            goto out;
+        }
+
+        ret = poll_one(send_cq, &wc);
+        if (ret != 1) {
+            fprintf(stderr, "no completion for second send - QP stalled after "
+                            "error completion\n");
+            ret = 1;
+            goto out;
+        }
+        if (wc.wr_id != 0xbeef) {
+            fprintf(stderr, "second completion wr_id=%llu != 0xbeef\n",
+                    (unsigned long long)wc.wr_id);
+            ret = 1;
+            goto out;
+        }
+        fprintf(stderr, "phase 2 OK: QP processed a second work request "
+                        "after the error completion\n");
+    }
+
+    fprintf(stderr, "DC error accounting OK\n");
+    ret = 0;
+
+out:
+    if (dci)
+        ibv_destroy_qp(dci);
+    if (mr)
+        ibv_dereg_mr(mr);
+    free(buf);
+    if (send_cq)
+        ibv_destroy_cq(send_cq);
+    if (recv_cq)
+        ibv_destroy_cq(recv_cq);
+    if (pd)
+        ibv_dealloc_pd(pd);
+    if (ctx)
+        ibv_close_device(ctx);
+    if (dev_list)
+        ibv_free_device_list(dev_list);
+    return ret;
+}


### PR DESCRIPTION
Fixes #75.

Several validation error paths in the two send processing loops (`continue_qp_send_processing` and `pvrdma_qp_send`) call `complete_with_error()` before the `send_in_flight` increment at the bottom of the loop. The deferred completion handler copies the completion context's `qp_handle`, and the drain unconditionally decrements `send_in_flight` whenever that handle is non-zero, so a work request that failed validation before the increment triggers a decrement that was never matched by an increment. The counter is unsigned, so the first occurrence wraps it to `UINT32_MAX` and every later send on that QP hits the `send_in_flight >= MAX_SEND_IN_FLIGHT` gate, stalling the QP permanently.

This clears `comp_ctx->qp_handle` before `complete_with_error()` in all eighteen error paths that run before the increment: the two UD gid failures (`VENDOR_ERR_INV_GID_IDX`), the four DCI validation failures (`VENDOR_ERR_INV_DCT` / `VENDOR_ERR_DC_KEY`), the unsupported opcode and QP type rejections (`VENDOR_ERR_INV_QP_TYPE`), and the `num_sge` overflow check (`VENDOR_ERR_INV_NUM_SGE`), in both loops. This is the pattern the receive paths already use when building their completion contexts, and the one the DCI `WRITE_WITH_IMM` rejection in #74 uses. The CQE still carries the QP number through `comp_ctx->cqe.qp`, so completions remain attributed to the right QP.

`tests/test_dc_error_paths.c` reproduces the stall on unmodified `main` and verifies the fix: it creates a DCI QP, posts a plain `SEND` that the device answers with an error completion, then posts a second work request on the same QP. Before the fix the second send never completes (the counter has wrapped); after the fix it is processed and answered. The reproduction details and measurements are on #75. The test is registered as a CTest case (exit code 77 skips it when no `rocm_ernic` device is present) and as a guest smoke step in the system test workflow, mirroring the DC loopback smoke.

Built and verified on the QEMU 10.1 (vfio-user-pci) host with an Ubuntu 24.04 guest running the kernel driver and custom rdma-core: unmodified `main` exhibits the permanent QP stall after a single failed work request, and this branch keeps the QP usable across repeated error completions.
