### PR TITLE
fix(ci): repair the nightly, and gate the lab node behind manual dispatch

### DIFF
--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -14,20 +14,27 @@
 # SECURITY
 # --------
 # rocm-ernic is a public repository, so anyone can leave
-# a comment.  Three properties keep the lab node safe:
+# a comment.  Three properties keep this honest:
 #
 #   1. This dispatcher runs on ubuntu-latest, never on
 #      the self-hosted runner.  Untrusted comment text is
 #      never processed on the lab node.
 #   2. The commenter must have write access or above,
 #      checked against the API at trigger time.
-#   3. Only refs in this repository can be dispatched.
-#      Comments on fork pull requests are refused, so
-#      fork code cannot reach the lab node.
+#   3. The dispatch always targets the workflow file on the
+#      default branch, passing the pull request number as an
+#      input.  A fork supplies the code under test but cannot
+#      change what the workflow does with it.
 #
 # issue_comment always runs the workflow file from the
 # default branch, so this gate cannot be edited by a
 # pull request to weaken it.
+#
+# Fork pull requests ARE runnable, deliberately: a
+# maintainer asking for it is the gate.  Note that fork code
+# then executes as the runner's user on the lab node, so
+# treat "can run /run-ci on a fork PR" as equivalent to
+# shell access there.
 
 name: CI Command
 
@@ -139,7 +146,7 @@ jobs:
             echo '| `/run-ci full` | functional + performance sweeps |'
             echo '| `/run-ci full tcg` | run VMs under emulation (no valid perf) |'
             echo
-            echo 'Requires write access. Fork pull requests are not eligible.'
+            echo 'Requires write access. Fork pull requests are eligible: the run tests the fork'"'"'s code but always uses this repository'"'"'s workflow definition.'
           } > body.md
           gh api -X POST \
             "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
@@ -182,7 +189,7 @@ jobs:
           echo "::error::@${ACTOR} has role '${ROLE}'; write access or above is required."
           exit 1
 
-      - name: Resolve target ref
+      - name: Resolve target
         id: ref
         if: steps.perm.outputs.allowed == 'true'
         env:
@@ -191,66 +198,35 @@ jobs:
           set -euo pipefail
 
           if [ -z "${{ github.event.issue.pull_request.url || '' }}" ]; then
-            # Plain issue: nothing to check out but the
-            # default branch.
-            echo "ref=${{ github.event.repository.default_branch }}" >> "$GITHUB_OUTPUT"
+            # A plain issue has no code to test; run the
+            # default branch as-is.
             echo "target=default branch" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          # Pass the pull request number rather than a branch.
+          # The workflow checks out refs/pull/<n>/head, which
+          # resolves for forks too, while the workflow file
+          # itself still comes from the default branch.
           pr="${{ github.event.issue.number }}"
           head_repo="$(gh api \
             "repos/${{ github.repository }}/pulls/${pr}" \
             --jq '.head.repo.full_name')"
-          head_ref="$(gh api \
-            "repos/${{ github.repository }}/pulls/${pr}" \
-            --jq '.head.ref')"
 
-          # workflow_dispatch can only target a ref in this
-          # repository, so a fork head is not dispatchable
-          # anyway.  Refusing explicitly makes the reason
-          # visible instead of surfacing an opaque API error.
+          echo "pr=${pr}" >> "$GITHUB_OUTPUT"
           if [ "${head_repo}" != "${{ github.repository }}" ]; then
+            echo "target=PR #${pr} (fork: \`${head_repo}\`)" >> "$GITHUB_OUTPUT"
             echo "fork=true" >> "$GITHUB_OUTPUT"
-            echo "head_repo=${head_repo}" >> "$GITHUB_OUTPUT"
-            exit 0
+          else
+            echo "target=PR #${pr}" >> "$GITHUB_OUTPUT"
           fi
-
-          echo "ref=${head_ref}" >> "$GITHUB_OUTPUT"
-          echo "target=PR #${pr} (${head_ref})" >> "$GITHUB_OUTPUT"
-
-      - name: Refuse fork pull request
-        if: steps.ref.outputs.fork == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_REPO: ${{ steps.ref.outputs.head_repo }}
-        run: |
-          {
-            echo "Self-hosted CI cannot run against a fork."
-            echo
-            echo "This pull request's head is in \`${HEAD_REPO}\`."
-            echo "Running it on the lab node would execute"
-            echo "unreviewed code there, so it is refused by design."
-            echo
-            echo "Push the branch to this repository and re-run,"
-            echo "or dispatch the workflow manually against a"
-            echo "trusted ref."
-          } > body.md
-          gh api -X POST \
-            "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
-            -F body=@body.md --silent
-          gh api --silent -X POST \
-            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
-            -f content=-1 || true
-          echo "::error::Refused: fork pull request (${HEAD_REPO})."
-          exit 1
 
       - name: Dispatch workflow
         id: run
-        if: steps.perm.outputs.allowed == 'true' && steps.ref.outputs.fork != 'true'
+        if: steps.perm.outputs.allowed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REF: ${{ steps.ref.outputs.ref }}
+          PR: ${{ steps.ref.outputs.pr }}
           TIER: ${{ steps.parse.outputs.tier }}
           ACCEL: ${{ steps.parse.outputs.accel }}
         run: |
@@ -260,11 +236,14 @@ jobs:
           # check the repository out, so gh has no git remote to
           # infer the target from and would fail with
           # "not a git repository".
-          gh workflow run self-hosted-ci.yml \
-            --repo "${{ github.repository }}" \
-            --ref "${REF}" \
-            -f tier="${TIER}" \
-            -f accel="${ACCEL}"
+          # --ref is the default branch on purpose: the
+          # workflow definition must come from trusted code
+          # even when the code under test is a fork's.
+          args=(--repo "${{ github.repository }}"
+                --ref "${{ github.event.repository.default_branch }}"
+                -f tier="${TIER}" -f accel="${ACCEL}")
+          [ -n "${PR}" ] && args+=(-f pr="${PR}")
+          gh workflow run self-hosted-ci.yml "${args[@]}"
 
           # gh does not return the run id, so poll briefly
           # for the run this dispatch created.
@@ -275,12 +254,11 @@ jobs:
               --repo "${{ github.repository }}" \
               --workflow=self-hosted-ci.yml \
               --event=workflow_dispatch \
-              --branch "${REF}" \
               --limit 1 --json url --jq '.[0].url' 2>/dev/null || true)"
             [ -n "${url}" ] && break
           done
           echo "url=${url}" >> "$GITHUB_OUTPUT"
-          echo "dispatched ${TIER}/${ACCEL} on ${REF}: ${url:-<pending>}"
+          echo "dispatched ${TIER}/${ACCEL} pr=${PR:-none}: ${url:-<pending>}"
 
       - name: Report back
         if: steps.run.outcome == 'success'

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -8,18 +8,36 @@
 # real VMs over the emulated RDMA NIC and produce
 # functional and performance reports.
 #
-# SECURITY: rocm-ernic is a public repository, so a
-# pull_request trigger would let a fork's code run on the
-# lab node.  Every job therefore requires the pull request
-# to originate from a branch in this repository; a fork PR
-# resolves the condition to false and no job starts.
+# SECURITY
+# --------
+# rocm-ernic is public, and this workflow runs on a lab
+# machine rather than a throwaway GitHub runner, so nothing
+# reaches the node without a maintainer asking for it.
+# There is no pull_request trigger: the only ways in are a
+# manual dispatch and the nightly schedule.
 #
-# Belt and braces: keep *Settings, Actions, General,
-# Require approval for all external contributors* enabled,
-# so a fork run cannot even be queued without a maintainer
-# releasing it.
+# Fork pull requests ARE testable, via the pr input.  The
+# split that makes this safe is that dispatch runs the
+# workflow file from the branch given to --ref (normally
+# main) while checking out refs/pull/<pr>/head as the code
+# under test.  A fork therefore supplies code to compile
+# and run, but cannot alter what this workflow does, and
+# cannot start a run at all: workflow_dispatch requires
+# write access.
+#
+# What that does NOT protect is the node itself.  Fork code
+# runs as the runner's user, so anyone who can dispatch a
+# fork PR can execute arbitrary code there.  Treat the
+# ability to dispatch as equivalent to shell access on the
+# lab node, and see ci/README.md for the hardening that is
+# still outstanding.
 
 name: Self-Hosted CI
+
+run-name: >-
+  Self-Hosted CI
+  ${{ inputs.pr && format('- PR #{0}', inputs.pr) || '' }}
+  ${{ inputs.tier && format('({0})', inputs.tier) || '' }}
 
 on:
   workflow_dispatch:
@@ -41,21 +59,17 @@ on:
         options:
           - kvm
           - tcg            # emulation; functional only
+      pr:
+        description: >-
+          Pull request number to test. Works for forks:
+          refs/pull/<pr>/head is checked out as the code
+          under test. Leave empty to run the dispatched ref.
+        required: false
+        type: string
   schedule:
     # 02:30 UTC nightly.  Off the hour to avoid the
     # thundering herd of every cron job on the fleet.
     - cron: '37 2 * * *'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'service/**'
-      - 'ansible/**'
-      - 'ci/**'
-      - 'CMakeLists.txt'
-      - 'cmake/**'
-      - '.github/workflows/self-hosted-ci.yml'
 
 # One run at a time on the node: concurrent runs would
 # collide on VM ssh ports, the instance manifest and the
@@ -71,21 +85,26 @@ concurrency:
 env:
   CI_WORK: /var/tmp/ernic-ci-work
   CI_VM_ACCEL: ${{ inputs.accel || 'kvm' }}
+  # The code under test.  refs/pull/<n>/head resolves for
+  # fork pull requests too, which is what makes them
+  # testable without granting the fork any other reach.
+  CI_CHECKOUT_REF: >-
+    ${{ inputs.pr
+        && format('refs/pull/{0}/head', inputs.pr)
+        || github.ref }}
 
 jobs:
 
   preflight:
     name: Preflight
-    # Refuse fork pull requests: their code must never run
-    # on the lab node.  Non-PR events are unaffected.
-    if: >-
-      github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux, x64, rocm-ernic]
     outputs:
       tier: ${{ steps.plan.outputs.tier }}
       kvm: ${{ steps.plan.outputs.kvm }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CI_CHECKOUT_REF }}
 
       - name: Reset workspace results
         run: |
@@ -130,10 +149,6 @@ jobs:
 
   build:
     name: Build and unit tests
-    # Refuse fork pull requests: their code must never run
-    # on the lab node.  Non-PR events are unaffected.
-    if: >-
-      github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     needs: preflight
     runs-on: [self-hosted, linux, x64, rocm-ernic]
     strategy:
@@ -142,6 +157,8 @@ jobs:
         build_type: [Release, Debug]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CI_CHECKOUT_REF }}
 
       - name: Build and test (${{ matrix.build_type }})
         env:
@@ -161,14 +178,12 @@ jobs:
 
   loopback:
     name: Loopback functional
-    # Refuse fork pull requests: their code must never run
-    # on the lab node.  Non-PR events are unaffected.
-    if: >-
-      github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     needs: build
     runs-on: [self-hosted, linux, x64, rocm-ernic]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CI_CHECKOUT_REF }}
 
       - name: Loopback backend tests
         env:
@@ -178,10 +193,7 @@ jobs:
   vm-functional:
     name: 2-VM RDMA functional
     needs: [preflight, loopback]
-    # Refuse fork pull requests: their code must never run
-    # on the lab node.  Non-PR events are unaffected.
     if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       needs.preflight.outputs.tier != 'build'
     runs-on: [self-hosted, linux, x64, rocm-ernic, kvm]
     timeout-minutes: 90
@@ -189,6 +201,8 @@ jobs:
       CI_BUILD_DIR: /var/tmp/ernic-ci-work/build-Release
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CI_CHECKOUT_REF }}
 
       - name: Bring up VMs
         run: bash ci/jobs/vm-up.sh
@@ -211,10 +225,7 @@ jobs:
   perf:
     name: Performance sweeps
     needs: [preflight, vm-functional]
-    # Refuse fork pull requests: their code must never run
-    # on the lab node.  Non-PR events are unaffected.
     if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       needs.preflight.outputs.tier == 'full'
     runs-on: [self-hosted, linux, x64, rocm-ernic, kvm]
     timeout-minutes: 180
@@ -222,6 +233,8 @@ jobs:
       CI_BUILD_DIR: /var/tmp/ernic-ci-work/build-Release
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CI_CHECKOUT_REF }}
 
       - name: Bring up VMs
         run: bash ci/jobs/vm-up.sh
@@ -258,11 +271,12 @@ jobs:
     # Report on whatever actually ran, including when an
     # upstream tier was skipped or failed.  Still refuses
     # fork pull requests.
-    if: >-
-      always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: always()
     runs-on: [self-hosted, linux, x64, rocm-ernic]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CI_CHECKOUT_REF }}
 
       - name: Generate functional and performance report
         id: report

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -500,3 +500,5 @@ DCT
 ConnectX
 cmocka
 librocm
+passwordless
+runnable

--- a/ansible/playbooks/guest-setup.yml
+++ b/ansible/playbooks/guest-setup.yml
@@ -33,6 +33,26 @@
     # provider, NIC config, rocm-xio).
 
     # ── QEMU guest agent (QMP guest-get-load, etc.) ──
+    # A freshly booted guest runs unattended-upgrades, which
+    # holds the dpkg lock for the first minute or so.  Ansible's
+    # apt tasks race it and fail with "Could not get lock
+    # /var/lib/dpkg/lock-frontend".  In CI the guests are cloned
+    # and booted seconds before this play runs, so the race is
+    # hit routinely -- and only on whichever VM loses it, which
+    # makes it look like a random one-guest failure.
+    - name: Wait for unattended-upgrades to release the dpkg lock
+      ansible.builtin.shell: |
+        for _ in $(seq 1 60); do
+          fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || exit 0
+          sleep 5
+        done
+        echo "dpkg lock still held after 300s" >&2
+        fuser -v /var/lib/dpkg/lock-frontend >&2 || true
+        exit 1
+      args:
+        executable: /bin/bash
+      changed_when: false
+
     - name: Install qemu-guest-agent for QMP guest metrics
       ansible.builtin.apt:
         name: qemu-guest-agent

--- a/ci/README.md
+++ b/ci/README.md
@@ -133,35 +133,58 @@ journalctl --user -u rocm-ernic-runner -f
 
 ## Security
 
-`ROCm/rocm-ernic` is a public repository, and a
-self-hosted runner will execute whatever a pull request
-contains. `.github/workflows/self-hosted-ci.yml` runs on
-pull requests targeting `main`, on `workflow_dispatch`,
-and on a nightly schedule. It does not run on push.
+`ROCm/rocm-ernic` is public, and this workflow runs on a
+lab machine rather than a throwaway GitHub runner. Nothing
+reaches the node unless someone asks for it:
+`.github/workflows/self-hosted-ci.yml` has **no
+`pull_request` trigger and no `push` trigger**. The only
+ways in are `workflow_dispatch` and the nightly schedule.
 
-Because pull requests are in scope, **every job requires
-the pull request to come from a branch in this
-repository**:
+That is a deliberate trade. Pull requests get no automatic
+lab-node coverage; a maintainer runs `/run-ci` when they
+want it. The GitHub-hosted workflows still run on every
+pull request as usual, so contributors are not left
+without feedback.
 
-```yaml
-if: >-
-  github.event_name != 'pull_request' ||
-  github.event.pull_request.head.repo.full_name == github.repository
+### Testing fork pull requests
+
+Fork pull requests **are** runnable, via the `pr` input:
+
+```bash
+gh workflow run self-hosted-ci.yml --ref main -f pr=123
 ```
 
-A fork pull request resolves that to false and no job
-starts, so fork code never reaches the lab node.
-Schedule and dispatch runs are unaffected.
+or just `/run-ci` on the pull request.
 
-Keep *Settings, Actions, General, Require approval for
-all external contributors* enabled as a second layer, so
-a fork run cannot even be queued without a maintainer
-releasing it.
+What makes that acceptable is the split between the
+workflow and the code it tests. The dispatch targets the
+workflow file on the **default branch**, and passes only a
+pull request number. Each job then checks out
+`refs/pull/<pr>/head`, which resolves for forks. So a fork
+supplies code to compile and run, but cannot change what
+the workflow does with it, and cannot start a run at all:
+`workflow_dispatch` requires write access.
 
-Pull requests run the `functional` tier: build, loopback
-and the two-VM RDMA tests. The nightly runs `full` and
-adds the performance sweeps, which take too long to sit
-in front of a review.
+### What this does not protect
+
+The node itself. Fork code runs as the runner's user, with
+whatever that user can do. **Treat the ability to dispatch
+a fork pull request as equivalent to shell access on the
+lab node.**
+
+On the current node the runner user also has passwordless
+`sudo`, so that is equivalent to root. Outstanding
+hardening, in rough priority order:
+
+1. Run the runner as a dedicated account with no `sudo`.
+2. Give that account its own `/local/<user>` workspace and
+   `/opt/qemu-images` group access, rather than reusing a
+   developer's.
+3. Consider an ephemeral runner, so each job starts from a
+   clean machine state.
+
+Until those land, only dispatch fork pull requests whose
+diff you have actually read.
 
 The workflow also takes a `concurrency` lock. Two
 simultaneous runs would collide on VM ssh ports, the
@@ -188,16 +211,20 @@ The dispatcher reacts to the comment, dispatches the
 workflow against the right ref, and replies with a link
 to the run.
 
-Three properties keep this safe on a public repository:
+Three properties keep this honest on a public repository:
 
 1. The dispatcher runs on `ubuntu-latest`, never on the
    self-hosted runner, so untrusted comment text is
    never processed on the lab node.
 2. The commenter must have write access or above,
    checked against the API at trigger time.
-3. Only refs in this repository can be dispatched.
-   Comments on fork pull requests are refused, so fork
-   code cannot reach the lab node.
+3. The dispatch always targets the workflow file on the
+   default branch and passes the pull request number as an
+   input, so a fork supplies the code under test but not
+   the workflow that runs it.
+
+Fork pull requests are eligible. See *What this does not
+protect* above before running one.
 
 `issue_comment` always runs the workflow file from the
 default branch, so this gate cannot be weakened by a

--- a/ci/jobs/perf.sh
+++ b/ci/jobs/perf.sh
@@ -52,6 +52,9 @@ ci_ansible() {
     return "${rc}"
 }
 
+# stdin is redirected from /dev/null: ansible refuses to
+# start if it inherits a non-blocking stdin, which happens
+# whenever this script is driven from a background shell.
 _ci_ansible_run() {
     ansible-playbook ci-site.yml \
         -e "ernic_project_root=${PROJECT_ROOT}" \
@@ -64,10 +67,25 @@ _ci_ansible_run() {
         -e "ernic_golden_image=false" \
         -e "ernic_build=false" \
         -e "ernic_gpu_passthrough=${CI_GPU_PASSTHROUGH}" \
-        "$@"
+        "$@" </dev/null
 }
 
 cd "${ANSIBLE_DIR}"
+
+# The perf job brings up its own VMs, and vm-down.sh deleted
+# the overlays the functional job left behind, so these guests
+# are freshly cloned from the golden image: no driver loaded
+# and no address on the emulated NIC.  Without this the very
+# first check fails with "Ping failed between VMs" and every
+# subsequent measurement records FAIL.
+group_start "Guest setup (driver + rdma-core)"
+run_check perf "guest-setup" ci_ansible --tags guest-setup
+group_end
+
+# Measuring against unprovisioned guests produces a wall of
+# FAIL rows that looks like a device regression, so stop here
+# instead.
+require_guests_ready || die "guest provisioning failed; not measuring"
 
 group_start "TCP/IP throughput (iperf3)"
 run_check perf "tcp-perf" ci_ansible --tags tcp-perf
@@ -92,3 +110,18 @@ run_check perf "csv-produced" test "${csv_count}" -gt 0
 group_end
 
 log_info "perf job complete; results in ${CI_RESULTS}/perf.jsonl"
+
+# run_check records failures without aborting, so that every
+# check still runs.  Without this the job exited 0 even when
+# every sweep failed, and only the report job noticed.
+failed=$(python3 -c "
+import json,sys
+try:
+    print(sum(1 for l in open('${CI_RESULTS}/perf.jsonl')
+              if json.loads(l).get('status') == 'fail'))
+except OSError:
+    print(0)")
+if [ "${failed}" -gt 0 ]; then
+    log_error "${failed} perf check(s) failed"
+    exit 1
+fi

--- a/ci/jobs/vm-functional.sh
+++ b/ci/jobs/vm-functional.sh
@@ -72,7 +72,7 @@ _ci_ansible_run() {
         -e "ernic_golden_image=false" \
         -e "ernic_build=false" \
         -e "ernic_gpu_passthrough=${CI_GPU_PASSTHROUGH}" \
-        "$@"
+        "$@" </dev/null
 }
 
 cd "${ANSIBLE_DIR}"

--- a/ci/lib/common.sh
+++ b/ci/lib/common.sh
@@ -233,6 +233,38 @@ PY
     return 0
 }
 
+# Verify each guest is actually provisioned: RDMA device
+# present, port active, and an address on the emulated NIC.
+#
+# The perf job clones fresh guests from the golden image, so
+# skipping guest-setup leaves them with no driver and no
+# address.  Every measurement then records FAIL, which reads
+# like a device regression rather than a setup mistake.
+require_guests_ready() {
+    local i ok=0
+    for i in $(seq 1 "${ERNIC_INSTANCES}"); do
+        if ! vm_ssh "${i}" 'ibv_devices' 2>/dev/null \
+                | grep -qE 'rocm-rdma-ernic|rocep'; then
+            log_error "guest ${i}: no RDMA device"
+            ok=1
+            continue
+        fi
+        if ! vm_ssh "${i}" 'ibv_devinfo' 2>/dev/null \
+                | grep -q 'PORT_ACTIVE'; then
+            log_error "guest ${i}: port not active"
+            ok=1
+            continue
+        fi
+        if ! vm_ssh "${i}" \
+                'ip -4 -br addr show rocm-ernic0' 2>/dev/null \
+                | grep -qE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'; then
+            log_error "guest ${i}: no address on rocm-ernic0"
+            ok=1
+        fi
+    done
+    return "${ok}"
+}
+
 require_kvm() {
     if [ ! -r /dev/kvm ] || [ ! -w /dev/kvm ]; then
         log_error "/dev/kvm is not accessible to $(id -un)."


### PR DESCRIPTION
The self-hosted CI has failed every night since it landed, and
this fixes that. While in there, it also changes how the lab
node is reached: manual dispatch only, and fork pull requests
become testable.

## The nightly was broken, and said it wasn't

All three nightlies recorded every one of their 76 performance
measurements as `FAIL`, starting with:

```
Ping failed between VMs. Emulated NIC may not be working.
```

The perf job brings up its own VMs, and the functional job's
teardown deletes the overlays it used, so those guests are
freshly cloned from the golden image: no driver loaded, no
address on the emulated NIC. `perf.sh` only ran the `tcp-perf`
and `rdma-perf` tags; nothing provisioned them. It now runs
`guest-setup` first, as `vm-functional.sh` already did.

This never showed up in local testing because every manual run
happened to provision the guests by hand first.

Three further problems that failure exposed:

- **The job reported success while every measurement failed.**
  `run_check` records failures without aborting, so that all
  checks are attempted, but nothing turned those into a
  non-zero exit. Only the report job noticed.
- **The regression gate said "0 regressions".** With no numeric
  results to compare, a total failure read as a clean bill of
  health. A new `require_guests_ready` check now stops the run
  before measuring, rather than producing a wall of `FAIL` rows
  that looks like a device regression.
- **Ansible refused to start** when it inherited a non-blocking
  stdin, which happens whenever these scripts are driven from a
  background shell. Both wrappers now redirect its stdin, so
  behaviour no longer depends on how the job was invoked.

Separately, guest provisioning raced `unattended-upgrades` for
the dpkg lock. A freshly booted guest holds that lock for the
first minute or so, and CI boots its guests seconds before the
play runs, so only whichever VM lost the race failed. That
looked like a random single-guest fault rather than a timing
problem. The play now waits for the lock.

## Manual trigger only

`self-hosted-ci.yml` no longer triggers on `pull_request`. This
workflow runs on a lab machine rather than a throwaway GitHub
runner, and anyone with write access could previously cause
code to execute there just by opening a pull request touching
`src/` or `ci/`. The only ways in now are `workflow_dispatch`
and the nightly schedule, so every run traces back to someone
asking for one.

The twelve GitHub-hosted workflows are untouched and still run
on every pull request, so contributors keep their usual
feedback.

## Fork pull requests are now testable

Through a new `pr` input:

```bash
gh workflow run self-hosted-ci.yml --ref main -f pr=123
```

or `/run-ci` on the pull request, which previously refused
forks.

What makes this acceptable is the split between the workflow
and the code it tests. The dispatch targets the workflow file
on the **default branch** and passes only a pull request
number; each job then checks out `refs/pull/<pr>/head`, which
resolves for forks. A fork supplies code to compile and run but
cannot change what the workflow does with it, and cannot start
a run at all, since `workflow_dispatch` requires write access.

The per-job fork guard is removed. It tested
`github.event_name != 'pull_request'`, which is now never true,
so it was dead code asserting a property the trigger list
already guarantees.

### What this does not protect

The node itself. Fork code runs as the runner's user, which on
the current node also has passwordless `sudo`. **Dispatching a
fork pull request is equivalent to granting shell access on the
lab node.** `ci/README.md` now says so plainly and lists the
hardening still outstanding, starting with moving the runner to
a dedicated account with no `sudo`.

## Verification

Ran the job exactly as the workflow does, `vm-up.sh` then
`perf.sh` with no manual setup:

| | |
|---|---|
| guest-setup | passes in 75s |
| tcp-perf | passes |
| RDMA sweep | 76 rows, **0 failures** |
| regression gate | exits 0 against the stored baseline |

Checkout ref resolution was checked across all four cases:

| Event | Checks out |
|---|---|
| nightly (schedule) | `refs/heads/main` |
| dispatch, no `pr` | `refs/heads/main` |
| `/run-ci` on same-repo PR | `refs/pull/<n>/head` |
| `/run-ci` on **fork** PR | `refs/pull/<n>/head` |

All 13 workflows parse; shellcheck and spell check clean.

## Note on ordering

`ci-command.yml` only takes effect once it is on the default
branch, so fork support via `/run-ci` goes live on merge. Until
then fork pull requests can be dispatched manually with the
`gh` command above, which works as soon as `self-hosted-ci.yml`
lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
