### PR TITLE
ci: fix guest apt lock, wrong report ref, and noise-driven perf gate

### DIFF
--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -281,15 +281,14 @@ jobs:
               echo "| Run | ${URL} |"
             fi
             echo
+            # GitHub renders comment bodies with hard line breaks, so each
+            # echo becomes a literal <br>. Keep one echo per paragraph and
+            # let the reader's client wrap it.
             if [ "${ACCEL}" = "tcg" ]; then
-              echo "> Running under emulation."
-              echo "> Performance sweeps are skipped;"
-              echo "> emulated numbers are not recorded."
+              echo "> Running under emulation. Performance sweeps are skipped; emulated numbers are not recorded."
               echo
             fi
-            echo "The functional and performance report is"
-            echo "attached to the run as the \`ci-report\` artifact"
-            echo "and mirrored into its job summary."
+            echo "The functional and performance report is attached to the run as the \`ci-report\` artifact and mirrored into its job summary."
           } > body.md
           gh api -X POST \
             "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \

--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MIT
+#
+# Keeps the Nix flake honest. The flake sits alongside the autotools /
+# CMake build rather than feeding it, so nothing else in CI would notice
+# if it stopped evaluating -- it would simply rot until someone tried to
+# use it.
+#
+# This deliberately stops at evaluation plus the dev shell. Building the
+# analysis toolkit or the cross/OCI targets pulls a very large closure and
+# belongs in a scheduled job, not on every pull request.
+name: Nix Check
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - '.github/workflows/nix-check.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: nix-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  flake-check:
+    name: nix flake check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Show flake metadata
+        run: nix flake metadata
+
+      # Evaluation only. --no-build keeps this to a few minutes and still
+      # catches the failure mode that matters here: a flake that no longer
+      # evaluates after a nixpkgs bump or a refactor under nix/.
+      - name: Evaluate the flake
+        run: nix flake check --no-build --all-systems
+
+      - name: List exposed packages
+        run: nix flake show

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -289,7 +289,15 @@ jobs:
       - name: Generate functional and performance report
         id: report
         continue-on-error: true
+        env:
+          # What was actually checked out and tested. github.sha still
+          # points at main for a `pr`-dispatched run, so reporting it
+          # would label the report with the wrong tree.
+          CI_TESTED_REF: ${{ env.CI_CHECKOUT_REF }}
         run: |
+          CI_TESTED_SHA="$(git rev-parse HEAD)"
+          export CI_TESTED_SHA
+          echo "reporting against ${CI_TESTED_SHA} (${CI_TESTED_REF})"
           baseline="${CI_WORK}/baseline/summary.json"
           args=(--results "${CI_WORK}/results"
                 --out "${CI_WORK}/report")

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -398,11 +398,15 @@ jobs:
         ssh -o StrictHostKeyChecking=no -p "$SSH_PORT" "${VM_USER}@localhost" << 'EOFVM'
         set -e
         KVER=$(uname -r)
+        # unattended-upgrades runs on a timer inside the guest image and
+        # holds /var/lib/dpkg/lock-frontend for minutes. Retrying against a
+        # held lock just burns the attempts, so wait for it instead.
+        APT_LOCK_WAIT="-o DPkg::Lock::Timeout=300"
         for i in 1 2 3; do
-          sudo apt-get update -qq && break || { echo "apt-get update retry $i/3"; sleep 5; }
+          sudo apt-get $APT_LOCK_WAIT update -qq && break || { echo "apt-get update retry $i/3"; sleep 5; }
         done
         for i in 1 2 3 4 5; do
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+          sudo DEBIAN_FRONTEND=noninteractive apt-get $APT_LOCK_WAIT install -y -qq \
             linux-headers-${KVER} linux-modules-extra-${KVER} && break
           [ "$i" -eq 5 ] && { echo "apt-get install failed after 5 attempts"; exit 1; }
           echo "apt-get install retry $i/5"; sleep 10
@@ -1659,11 +1663,15 @@ jobs:
         #!/bin/bash
         set -e
         KVER=$(uname -r)
+        # unattended-upgrades runs on a timer inside the guest image and
+        # holds /var/lib/dpkg/lock-frontend for minutes. Retrying against a
+        # held lock just burns the attempts, so wait for it instead.
+        APT_LOCK_WAIT="-o DPkg::Lock::Timeout=300"
         for i in 1 2 3; do
-          sudo apt-get update -qq && break || { echo "apt-get update retry $i/3"; sleep 5; }
+          sudo apt-get $APT_LOCK_WAIT update -qq && break || { echo "apt-get update retry $i/3"; sleep 5; }
         done
         for i in 1 2 3 4 5; do
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+          sudo DEBIAN_FRONTEND=noninteractive apt-get $APT_LOCK_WAIT install -y -qq \
             linux-headers-${KVER} linux-modules-extra-${KVER} && break
           [ "$i" -eq 5 ] && { echo "apt-get install failed after 5 attempts"; exit 1; }
           echo "apt-get install retry $i/5"; sleep 10

--- a/ci/report/gen-report.py
+++ b/ci/report/gen-report.py
@@ -244,8 +244,17 @@ def _size_key(size):
 # reported, just not failed on. Override with --gate-metric.
 DEFAULT_GATE_METRICS = ("lat_typical_us", "lat_max_us")
 
+# The spreads above were measured across repeated sweeps. A
+# single sweep gives none of that: the median of one sample is
+# that sample, so an ordinary outlier reads as a regression.
+# Require a few successful samples on both sides before a
+# metric may fail the build -- otherwise the sweep is only
+# descriptive, and it is reported without gating.
+DEFAULT_MIN_SAMPLES = 3
 
-def compare(current, baseline, threshold, gate_metrics=None):
+
+def compare(current, baseline, threshold, gate_metrics=None,
+            min_samples=DEFAULT_MIN_SAMPLES):
     """Flag gated metrics that moved beyond threshold percent."""
     gate = set(gate_metrics or DEFAULT_GATE_METRICS)
     regressions = []
@@ -254,18 +263,24 @@ def compare(current, baseline, threshold, gate_metrics=None):
         for row in rows:
             key = (kind, row["verb"], row["size"],
                    row["metric"])
-            base_index[key] = row.get("median")
+            base_index[key] = (row.get("median"),
+                               row.get("n_ok", 0))
 
     for kind, rows in current.items():
         for row in rows:
             key = (kind, row["verb"], row["size"],
                    row["metric"])
-            base = base_index.get(key)
+            base, base_n = base_index.get(key, (None, 0))
             cur = row.get("median")
             if base is None or cur is None or base == 0:
                 continue
             metric = row["metric"]
             if metric not in gate:
+                continue
+            # Too few samples on either side to distinguish a
+            # regression from noise.
+            if (row.get("n_ok", 0) < min_samples
+                    or base_n < min_samples):
                 continue
             delta_pct = (cur - base) / abs(base) * 100.0
             # Normalise so negative always means "worse".
@@ -416,6 +431,12 @@ def main():
                     help="metric to gate regressions on; repeatable. "
                          "Defaults to "
                          + ", ".join(DEFAULT_GATE_METRICS))
+    ap.add_argument("--min-samples", type=int,
+                    default=DEFAULT_MIN_SAMPLES, metavar="N",
+                    help="minimum successful samples on both sides "
+                         "before a metric may gate; below this the "
+                         "median is too noisy to judge "
+                         f"(default {DEFAULT_MIN_SAMPLES})")
     ap.add_argument("--no-fail", action="store_true",
                     help="always exit 0")
     args = ap.parse_args()
@@ -432,12 +453,19 @@ def main():
         with open(args.baseline) as fh:
             baseline = json.load(fh)
         regressions = compare(perf, baseline, args.threshold,
-                              args.gate_metrics)
+                              args.gate_metrics, args.min_samples)
 
+    # GITHUB_SHA / GITHUB_REF_NAME describe what *triggered* the
+    # workflow, not what was checked out. A self-hosted run dispatched
+    # with a `pr` input still reports main there while testing the PR
+    # head, so the workflow passes the resolved ref explicitly. Fall
+    # back to the trigger values for local runs.
     meta = {
         "run_id": os.environ.get("GITHUB_RUN_ID", "local"),
-        "sha": os.environ.get("GITHUB_SHA", "unknown"),
-        "ref": os.environ.get("GITHUB_REF_NAME", "unknown"),
+        "sha": (os.environ.get("CI_TESTED_SHA")
+                or os.environ.get("GITHUB_SHA", "unknown")),
+        "ref": (os.environ.get("CI_TESTED_REF")
+                or os.environ.get("GITHUB_REF_NAME", "unknown")),
         "node": os.environ.get("RUNNER_NAME",
                                os.uname().nodename),
         "accel": os.environ.get("CI_VM_ACCEL", "n/a"),


### PR DESCRIPTION
Four CI defects surfaced while draining the pull request queue, each reproduced more than once.

apt lock in the guests. unattended-upgrades runs on a timer inside the VM image and holds /var/lib/dpkg/lock-frontend for minutes. Both guest setup paths retried *into* the held lock -- five attempts, ten seconds apart -- and then failed the job. That cost a full system-test cycle on #67, #74 and #80. Pass -o DPkg::Lock::Timeout=300 so apt waits for the lock instead of racing it; the surrounding retry loops stay for the unrelated transient failures they were written for.

Report labelled with the wrong tree. gen-report.py read GITHUB_SHA and GITHUB_REF_NAME, which describe what triggered the workflow rather than what was checked out. A self-hosted run dispatched with a `pr` input still reports main there while testing the PR head, so every lab report on a pull request named the wrong commit -- observed twice on #77. The workflow now passes the resolved ref and the HEAD it actually tested; the environment variables remain the fallback for local runs.

Perf gate fired on single samples. compare() ignored the sample count that summarize() already records, so a metric with n_ok=1 gated exactly like one with twenty -- and the median of one sample is that sample. Every row in the #77 sweep had n_ok=1, which produced four "regressions" alongside 330/421 functional checks and zero failures, and put main's nightly red three nights running. Require DEFAULT_MIN_SAMPLES successful samples on both sides before a metric may fail the build, overridable with --min-samples. The gated metric set is deliberately unchanged: the existing comment records measured run-to-run spreads for both metrics and they do not support dropping either one.

Nix flake had no CI. The flake sits alongside the CMake build rather than feeding it, so nothing would have noticed it ceasing to evaluate. Add a paths-filtered `nix flake check --no-build` job; building the analysis toolkit or the cross/OCI targets pulls too large a closure for per-pull-request CI and belongs in a scheduled run.

Also fold the /run-ci acknowledgement comment onto one line per paragraph. GitHub renders comment bodies with hard line breaks, so the three echos became literal <br> tags and the text was frozen at the width it happened to be typed at in the YAML.

Verified by regenerating the #77 lab report from its real artifact: meta now reads 70b28c9 / refs/pull/77/head instead of main's SHA, and the four regressions become zero while the functional counts are unchanged. A synthetic 30% latency regression is still caught once both sides carry enough samples.