### PR TITLE
ci: add opt-in non-blocking nix analysis workflows (static, dynamic/memory, fuzz)

### DIFF
--- a/.github/workflows/dynamic-analysis.yml
+++ b/.github/workflows/dynamic-analysis.yml
@@ -1,0 +1,153 @@
+# Dynamic / memory analysis via the Nix analysis toolkit (nix/analysis/).
+#
+# Instrumented builds that exercise the server on the loopback backend under:
+#   * sanitizers  — AddressSanitizer + LeakSanitizer + UBSan  (.#analysis-sanitizers)
+#   * valgrind    — memcheck (ptrace-free leak/memory-error detector) (.#analysis-valgrind)
+#   * tsan        — ThreadSanitizer                              (.#analysis-tsan)
+#
+# OPT-IN and INFORMATIONAL. It does not run on ordinary pushes and never
+# blocks a merge. Trigger it either by:
+#   * adding the `run-dynamic` label to a pull request (re-runs on each new
+#     push while the label is present) — runs all three tools, or
+#   * the manual "Run workflow" button (workflow_dispatch), choosing which
+#     tool(s) to run.
+#
+# Each target captures whatever the sanitizer/valgrind runtime reports and
+# always exits 0 (the findings are the deliverable, not a build failure), so
+# a detected leak or data race never fails the check. Counts go to the job
+# summary; the per-tool report (summary.txt + server/client logs) uploads as
+# a `dynamic-<tool>` artifact.
+#
+# Note: LSan's leak check uses ptrace at exit, which some Nix sandboxes
+# restrict; ASan/UBSan still fire during the run, and valgrind is a
+# ptrace-free second opinion for leaks.
+name: Dynamic Analysis (nix)
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      tool:
+        description: "Which dynamic analysis to run"
+        default: all
+        type: choice
+        options:
+          - all         # sanitizers + valgrind + tsan
+          - memory      # sanitizers + valgrind
+          - sanitizers
+          - valgrind
+          - tsan
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dynamic-analysis-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Resolve which tools to run into a matrix. Label-triggered runs do all
+  # three; workflow_dispatch honours the chosen option.
+  select:
+    name: select tools
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'run-dynamic')
+    runs-on: ubuntu-24.04
+    outputs:
+      tools: ${{ steps.pick.outputs.tools }}
+    steps:
+      - name: Pick tool set
+        id: pick
+        # `tool` is a constrained choice input; default to `all` for the
+        # label-triggered path. Resolved via env, never interpolated into
+        # the shell command.
+        env:
+          TOOL: ${{ github.event.inputs.tool || 'all' }}
+        run: |
+          case "$TOOL" in
+            all)     tools='["sanitizers","valgrind","tsan"]' ;;
+            memory)  tools='["sanitizers","valgrind"]' ;;
+            valgrind) tools='["valgrind"]' ;;
+            tsan)    tools='["tsan"]' ;;
+            *)       tools='["sanitizers"]' ;;
+          esac
+          echo "tools=$tools" >> "$GITHUB_OUTPUT"
+          echo "Selected: $tools"
+
+  dynamic:
+    name: nix dynamic
+    needs: select
+    runs-on: ubuntu-24.04
+    # Non-merge-blocking: informational only, never gates a PR.
+    continue-on-error: true
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        tool: ${{ fromJSON(needs.select.outputs.tools) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Nix build cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Run ${{ matrix.tool }}
+        id: run
+        env:
+          TOOL: ${{ matrix.tool }}
+        run: |
+          echo "Running: nix build .#analysis-$TOOL"
+          if nix build ".#analysis-$TOOL" --print-build-logs --out-link "result-$TOOL"; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::nix build .#analysis-$TOOL did not complete cleanly (informational check, does not block merges)."
+          fi
+
+      - name: Collect report
+        if: always()
+        env:
+          TOOL: ${{ matrix.tool }}
+        run: |
+          mkdir -p "report-$TOOL"
+          if [ -e "result-$TOOL" ]; then
+            cp -rL "result-$TOOL"/. "report-$TOOL"/ 2>/dev/null || true
+          fi
+
+      - name: Publish job summary
+        if: always()
+        env:
+          TOOL: ${{ matrix.tool }}
+        run: |
+          {
+            echo "## Dynamic analysis — \`$TOOL\`"
+            echo ""
+            if [ "${{ steps.run.outputs.ok }}" != "true" ]; then
+              echo "> ⚠️ The build did not complete cleanly — see the job log. This check does not block merges."
+              echo ""
+            fi
+            if [ -f "report-$TOOL/summary.txt" ]; then
+              echo '```text'
+              cat "report-$TOOL/summary.txt"
+              echo '```'
+            else
+              echo "_No summary was produced._"
+            fi
+            echo ""
+            echo "_Informational only — this workflow never blocks merges. Full logs are in the **dynamic-$TOOL** artifact._"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dynamic-${{ matrix.tool }}
+          path: report-${{ matrix.tool }}/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,116 @@
+# Opt-in fuzzing via the Nix fuzz harnesses (nix/analysis/fuzz/).
+#
+# libFuzzer harnesses for the untrusted wire-format parsers
+# (rdma_cm_process_message, dhcp_server_process, net_headers parsers), each
+# built with -fsanitize=fuzzer,address,undefined.
+#
+# This job is OPT-IN and INFORMATIONAL — it does not run on ordinary pushes
+# and never blocks a merge. Trigger it either by:
+#   * adding the `run-fuzz` label to a pull request (re-runs on each new push
+#     while the label is present), or
+#   * the manual "Run workflow" button (workflow_dispatch), with a chosen
+#     per-harness duration.
+#
+# The fuzzers always exit 0 — any crash inputs and symbolized repros are the
+# deliverable, uploaded as the `fuzz-report` artifact and summarised in the
+# job summary — so a discovered crash never fails the check.
+name: Fuzz (nix, opt-in)
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      fuzz_seconds:
+        description: "Seconds to fuzz each harness"
+        default: "60"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fuzz-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: nix fuzz
+    # Opt-in gate: run only on manual dispatch, or when the PR carries the
+    # `run-fuzz` label. Ordinary pushes to an unlabelled PR are skipped.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'run-fuzz')
+    runs-on: ubuntu-24.04
+    # Non-merge-blocking: informational only, never gates a PR.
+    continue-on-error: true
+    timeout-minutes: 30
+    # Resolve the duration into an env var (never interpolated into a shell
+    # command); defaults to 60s for the label-triggered path.
+    env:
+      FUZZ_SECONDS: ${{ github.event.inputs.fuzz_seconds || '60' }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Nix build cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build fuzz harnesses
+        run: nix build .#fuzz --print-build-logs --out-link fuzz
+
+      - name: Run fuzzers
+        id: fuzz
+        run: |
+          # Guard: only accept a positive integer duration; fall back to 60.
+          case "$FUZZ_SECONDS" in
+            ''|*[!0-9]*) FUZZ_SECONDS=60 ;;
+          esac
+          echo "Fuzzing ${FUZZ_SECONDS}s per harness"
+          mkdir -p fuzz-work
+          FUZZ_TIME="$FUZZ_SECONDS" FUZZ_WORKDIR="$PWD/fuzz-work" \
+            ./fuzz/bin/run-fuzzers | tee run-fuzzers.out || true
+          total=$(find fuzz-work -name 'crash-*' 2>/dev/null | wc -l)
+          echo "total=$total" >> "$GITHUB_OUTPUT"
+          echo "Total crash inputs: $total"
+
+      - name: Publish job summary
+        if: always()
+        run: |
+          {
+            echo "## Fuzz (nix) — ${FUZZ_SECONDS}s per harness"
+            echo ""
+            total="${{ steps.fuzz.outputs.total }}"
+            if [ -z "$total" ]; then
+              echo "> ⚠️ The fuzz run did not complete — see the job log. This check does not block merges."
+            elif [ "$total" = "0" ]; then
+              echo "✅ No crashes found across the harnesses (rdma_cm_proto, dhcp_server, net_headers)."
+            else
+              echo "🐛 **$total crash input(s) found.** Crash inputs and symbolized repros are in the **fuzz-report** artifact."
+            fi
+            echo ""
+            if [ -f run-fuzzers.out ]; then
+              echo '```text'
+              cat run-fuzzers.out
+              echo '```'
+            fi
+            echo ""
+            echo "_Opt-in, informational only — this workflow never blocks merges._"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload fuzz report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          # Logs (which contain the symbolized crash stack when a harness
+          # aborts) and any crash inputs — not the whole accumulated corpus.
+          name: fuzz-report
+          path: |
+            fuzz-work/*.log
+            fuzz-work/**/crash-*
+            run-fuzzers.out
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,127 @@
+# Static analysis via the Nix analysis toolkit (nix/analysis/).
+#
+# This runs the project's hermetic static-analysis aggregate on every pull
+# request and surfaces the triaged findings in the job summary plus a
+# downloadable artifact. It is INFORMATIONAL ONLY: `continue-on-error` keeps
+# the job green regardless of what the tools report (or if the analysis build
+# itself fails), so it can never block a merge. Findings are for reviewers to
+# read, not a gate.
+#
+# The `standard` level = clang-tidy + cppcheck + flawfinder + clang-analyzer +
+# gcc-warnings, then the triage prioritiser (nix/analysis/triage/). Use the
+# manual "Run workflow" button to run `quick` or `deep` on demand.
+name: Static Analysis (nix)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      level:
+        description: "Analysis level"
+        default: standard
+        type: choice
+        options:
+          - quick
+          - standard
+          - deep
+
+# Read-only: the job never writes to the repo or the PR, so it works
+# unchanged for pull requests from forks.
+permissions:
+  contents: read
+
+# One run per PR/branch; newer pushes cancel older in-flight runs.
+concurrency:
+  group: static-analysis-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: nix analysis
+    runs-on: ubuntu-24.04
+    # Non-merge-blocking: this converts any failure below into a neutral/green
+    # conclusion so the check is purely informational and never gates a PR.
+    continue-on-error: true
+    timeout-minutes: 45
+    # Resolve the level once, into an env var, so it's never interpolated
+    # directly into a shell command. `inputs.level` is a constrained choice
+    # (quick|standard|deep); defaulting to standard for pull_request runs.
+    env:
+      LEVEL: ${{ github.event.inputs.level || 'standard' }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      # Determinate Systems' installer enables flakes + nix-command by default.
+      # Maintainers may pin these to a release tag/SHA per their action policy.
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      # Optional but recommended: caches the Nix store between runs so the
+      # analysis tools and their closure aren't rebuilt every time. Safe to
+      # remove (or swap for Cachix/FlakeHub) if the org prefers.
+      - name: Nix build cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Run static analysis
+        id: analysis
+        run: |
+          echo "Running: nix build .#analysis-$LEVEL"
+          if nix build ".#analysis-$LEVEL" --print-build-logs --out-link result; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::nix build .#analysis-$LEVEL did not complete cleanly (informational check, does not block merges)."
+          fi
+
+      # Dereference the store symlinks into a real directory so the summary
+      # and artifact steps don't depend on /nix/store being readable there.
+      - name: Collect reports
+        if: always()
+        run: |
+          mkdir -p analysis-report
+          if [ -e result ]; then
+            cp -rL result/. analysis-report/ 2>/dev/null || true
+          fi
+
+      - name: Publish job summary
+        if: always()
+        run: |
+          {
+            echo "## Static Analysis (nix \`$LEVEL\`)"
+            echo ""
+            if [ "${{ steps.analysis.outputs.ok }}" != "true" ]; then
+              echo "> ⚠️ The analysis build did not complete cleanly — see the job log."
+              echo "> This check is informational and does not block merges."
+              echo ""
+            fi
+            if [ -f analysis-report/summary.txt ]; then
+              echo '```text'
+              cat analysis-report/summary.txt
+              echo '```'
+            else
+              echo "_No summary was produced._"
+            fi
+            if [ -s analysis-report/triage/high-confidence.txt ]; then
+              echo ""
+              echo "<details><summary>High-confidence triaged findings</summary>"
+              echo ""
+              echo '```text'
+              cat analysis-report/triage/high-confidence.txt
+              echo '```'
+              echo ""
+              echo "</details>"
+            fi
+            echo ""
+            echo "_Informational only — this workflow never blocks merges. Full per-tool reports are in the **ci-analysis-report** artifact._"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload analysis report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-analysis-report
+          path: analysis-report/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,20 +1,23 @@
 # Static analysis via the Nix analysis toolkit (nix/analysis/).
 #
-# This runs the project's hermetic static-analysis aggregate on every pull
-# request and surfaces the triaged findings in the job summary plus a
-# downloadable artifact. It is INFORMATIONAL ONLY: `continue-on-error` keeps
-# the job green regardless of what the tools report (or if the analysis build
-# itself fails), so it can never block a merge. Findings are for reviewers to
-# read, not a gate.
+# OPT-IN and INFORMATIONAL. It does not run on ordinary pushes and never
+# blocks a merge. Trigger it either by:
+#   * adding the `run-static` label to a pull request (re-runs on each new
+#     push while the label is present), or
+#   * the manual "Run workflow" button (workflow_dispatch), choosing a level.
+#
+# Runs the project's hermetic static-analysis aggregate and surfaces the
+# triaged findings in the job summary plus a downloadable artifact.
+# `continue-on-error` keeps the job green regardless of what the tools report
+# (or if the analysis build itself fails), so it is purely informational.
 #
 # The `standard` level = clang-tidy + cppcheck + flawfinder + clang-analyzer +
-# gcc-warnings, then the triage prioritiser (nix/analysis/triage/). Use the
-# manual "Run workflow" button to run `quick` or `deep` on demand.
+# gcc-warnings, then the triage prioritiser (nix/analysis/triage/).
 name: Static Analysis (nix)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [labeled, synchronize, reopened]
   workflow_dispatch:
     inputs:
       level:
@@ -39,6 +42,11 @@ concurrency:
 jobs:
   analysis:
     name: nix analysis
+    # Opt-in gate: run only on manual dispatch, or when the PR carries the
+    # `run-static` label. Ordinary pushes to an unlabelled PR are skipped.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'run-static')
     runs-on: ubuntu-24.04
     # Non-merge-blocking: this converts any failure below into a neutral/green
     # conclusion so the check is purely informational and never gates a PR.


### PR DESCRIPTION
Adds three **opt-in, non-merge-blocking** GitHub Actions workflows built on the Nix analysis toolkit (`nix/analysis/`, merged in the flake PR). None run on ordinary pushes; each is triggered per-PR by a label (or manual dispatch), surfaces its results in the job summary + an artifact, and can never gate a merge (`continue-on-error: true`, `permissions: contents: read`, so they also work for fork PRs).

| Workflow | Opt-in label | Runs |
|---|---|---|
| `static-analysis.yml` | `run-static` | clang-tidy + cppcheck + flawfinder + clang-analyzer + gcc-warnings → triage |
| `dynamic-analysis.yml` | `run-dynamic` | ASan+LSan+UBSan, valgrind memcheck, ThreadSanitizer (loopback exercise) |
| `fuzz.yml` | `run-fuzz` | libFuzzer harnesses for the wire-format parsers |

Add the relevant label to a PR to run that suite (it re-runs on each new push while the label is present); each also has a manual **Run workflow** button.

## 1. Static analysis — `run-static`
`nix build .#analysis-standard` then the triage prioritiser (`nix/analysis/triage/`). Writes `summary.txt` + high-confidence findings to the job summary; full per-tool + triage report uploads as **`ci-analysis-report`**. `workflow_dispatch` picks `quick`/`standard`/`deep`.

Sample (`.#analysis-standard` on current `main`): clang-tidy 3798 / cppcheck 204 / flawfinder 137 / clang-analyzer 1 / gcc-warnings 4 → **73 high-confidence** after triage.

## 2. Dynamic / memory analysis — `run-dynamic`
Instrumented builds that exercise the server on the **loopback backend** (no RDMA hardware) under:
- **sanitizers** — ASan + LSan + UBSan (`.#analysis-sanitizers`)
- **valgrind** — memcheck, a ptrace-free leak/memory-error detector (`.#analysis-valgrind`)
- **tsan** — ThreadSanitizer (`.#analysis-tsan`)

The label runs all three (in a parallel matrix); `workflow_dispatch` offers `all` / `memory` (san+valgrind) / individual tools. Each captures whatever the runtime reports and **always exits 0**, so a detected leak or race never fails the check. Counts → job summary; per-tool report + server/client logs → **`dynamic-<tool>`** artifact. (Note: LSan's ptrace-based leak check may be restricted in the Nix sandbox; valgrind is the ptrace-free second opinion.)

## 3. Opt-in fuzzing — `run-fuzz`
`nix build .#fuzz` then `run-fuzzers`: libFuzzer harnesses for `rdma_cm_process_message()`, `dhcp_server_process()`, and the `net_headers.h` parsers, each `-fsanitize=fuzzer,address,undefined`. Configurable per-harness duration via dispatch (default 60s). Always exits 0; crash counts → job summary; logs (with symbolized crash stack) + any crash inputs → **`fuzz-report`** artifact.

## Notes for maintainers
- Create the `run-static`, `run-dynamic`, and `run-fuzz` labels (GitHub creates a label on first apply) and add whichever you want on a given PR.
- Uses the Determinate Systems Nix installer + `magic-nix-cache-action`; both marked in-file as pin-/swap-able (Cachix / FlakeHub / self-hosted) per your action policy. Caching is an optimisation, not required for correctness.
- First Nix-based CI in the repo; no RDMA hardware needed — everything runs on `ubuntu-24.04`.
- Validated locally: every target builds and produces the exact report paths the workflows read — static → 73 high-confidence findings; sanitizers → 0 violations; valgrind → 0 leaks / 0 errors; fuzz harnesses build + run clean — and `actionlint` passes on all workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
