### PR TITLE
server: add a runtime log level and default it to warn

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -480,6 +480,7 @@ FAILs
 GiB
 hardcoding
 hoc
+ARP
 ICMP
 IPv
 Mbit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@
 
 ### Added
 
+* `-L` / `--log-level` and the `ERNIC_LOG_LEVEL` environment variable select
+  the server log verbosity (`none`, `error`, `warn`, `info`, `debug`).
+
 ### Changed
+
+* The server now defaults to the `warn` log level, so the per-operation `INFO:`
+  lines (BAR writes, QP operations, ARP/ICMP packets, TCP mesh events) are
+  suppressed in steady state. Use `--log-level info` to restore the previous
+  output. `-v` / `--verbose` is now shorthand for `--log-level debug`.
 
 ### Removed
 

--- a/ansible/roles/ernic_host_setup/README.md
+++ b/ansible/roles/ernic_host_setup/README.md
@@ -42,7 +42,8 @@ ernic_install_prefix: /usr/local
 ernic_instances: 2
 ernic_tcp_port: 6320
 ernic_manager_ip: 127.0.0.1
-ernic_verbose: "false"
+ernic_log_level: warn           # none|error|warn|info|debug
+ernic_verbose: "false"          # legacy shorthand for debug
 ernic_debug_mesh: true
 ernic_debug_dma_map: false
 

--- a/ansible/roles/ernic_host_setup/defaults/main.yml
+++ b/ansible/roles/ernic_host_setup/defaults/main.yml
@@ -23,6 +23,12 @@ ernic_tcp_port: 6320
 ernic_manager_ip: 127.0.0.1
 ernic_verbose: "false"
 
+# Server log verbosity written into the env file: one of
+# none, error, warn, info, debug.  warn keeps steady-state
+# logs to WARN/ERROR plus a short startup banner.  Note that
+# ernic_verbose: "true" overrides this with debug.
+ernic_log_level: warn
+
 # When true, /etc/rocm-ernic/rocm-ernic.env sets ERNIC_DEBUG_MESH=1
 # so rocm-ernic logs rate-limited mesh Ethernet diagnostics (EAGAIN
 # drops, inject failures, etc.).  Set false on production hosts to

--- a/ansible/roles/ernic_host_setup/templates/rocm-ernic.env.j2
+++ b/ansible/roles/ernic_host_setup/templates/rocm-ernic.env.j2
@@ -26,12 +26,18 @@ ERNIC_INSTANCES={{ ernic_instances }}
 ERNIC_TCP_PORT={{ ernic_tcp_port }}
 ERNIC_MANAGER_IP={{ ernic_manager_ip }}
 
-# Enable verbose server logging (true / false).
+# Server log verbosity: none | error | warn | info | debug.
+# warn keeps the steady-state logs to WARN/ERROR plus a short
+# startup banner; info restores the per-operation INFO lines.
+ERNIC_LOG_LEVEL={{ ernic_log_level | default('warn') }}
+
+# Legacy shorthand for ERNIC_LOG_LEVEL=debug (true / false).
 ERNIC_VERBOSE={{ ernic_verbose }}
 
 # Mesh Ethernet debug (1 / 0).  When 1, rdma_backend_tcp emits
 # rate-limited WARN lines for EAGAIN drops, truncated sends, inject
 # failures, and zero-peer forwards (see ERNIC_DEBUG_MESH in source).
+# These are WARN lines, so they survive the default log level.
 ERNIC_DEBUG_MESH={{ '1' if (ernic_debug_mesh | default(true) | bool) else '0' }}
 
 # Log every rdma_pci_dma_map (1 / 0).  Extremely verbose; default off.

--- a/docs/service.rst
+++ b/docs/service.rst
@@ -120,9 +120,14 @@ Server settings
    * - ``ERNIC_MANAGER_IP``
      - ``127.0.0.1``
      - IP address workers connect to
+   * - ``ERNIC_LOG_LEVEL``
+     - ``warn``
+     - Server log verbosity:
+       ``none|error|warn|info|debug``
    * - ``ERNIC_VERBOSE``
      - ``false``
-     - Enable verbose server logging
+     - Legacy shorthand for
+       ``ERNIC_LOG_LEVEL=debug``
 
 MAC address overrides
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -11,19 +11,61 @@ Start the server with a UNIX socket and the desired backend:
    # Loopback backend (no external dependencies)
    ./build/rocm-ernic \
      --socket /tmp/vfio-user-rocm-ernic.sock \
-     --backend loopback \
-     --verbose
+     --backend loopback
 
    # RDMA verbs backend (requires RDMA hardware)
    ./build/rocm-ernic \
      --socket /tmp/vfio-user-rocm-ernic.sock \
      --backend verbs:device=mlx5_0,ethdev=eth0,port=1 \
-     --verbose
+     --log-level info
 
    # No backend (minimal stubs)
    ./build/rocm-ernic \
      --socket /tmp/vfio-user-rocm-ernic.sock \
      --backend none
+
+Log Levels
+----------
+
+``--log-level`` (short ``-L``) sets how much the server
+prints.  It can also be set with the ``ERNIC_LOG_LEVEL``
+environment variable; the command line wins when both are
+given.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 85
+
+   * - Level
+     - Output
+   * - ``none``
+     - Nothing at all.
+   * - ``error``
+     - ``ERROR:`` lines only.
+   * - ``warn``
+     - **Default.** ``ERROR:`` and ``WARN:`` lines, plus a
+       short startup/shutdown banner.
+   * - ``info``
+     - Adds the per-operation ``INFO:`` lines (BAR writes,
+       QP operations, ARP/ICMP packets, TCP mesh events).
+   * - ``debug``
+     - Everything, including libvfio-user debug output.
+
+``-v`` / ``--verbose`` remains as shorthand for
+``--log-level debug``.
+
+.. code-block:: bash
+
+   # Quiet by default -- only warnings and errors
+   ./build/rocm-ernic --backend loopback
+
+   # Full per-operation tracing
+   ERNIC_LOG_LEVEL=info ./build/rocm-ernic --backend loopback
+
+``ERNIC_DEBUG_MESH=1`` is unaffected: it is a separate
+mesh-specific toggle whose rate-limited diagnostics are
+emitted as ``WARN:`` lines, so they remain visible at the
+default level.
 
 Launching a VM
 --------------

--- a/service/ernicctl
+++ b/service/ernicctl
@@ -35,6 +35,7 @@ DEFAULTS = {
     "ERNIC_TCP_PORT": "6320",
     "ERNIC_MANAGER_IP": "127.0.0.1",
     "ERNIC_VERBOSE": "false",
+    "ERNIC_LOG_LEVEL": "warn",
     "ERNIC_DRIVER_SOURCE": "/usr/share/rocm-ernic/driver",
     "ERNIC_DRIVER_TARBALL": "/tmp/rocm-ernic-driver.tar.gz",
     "ERNIC_QEMU_MINIMAL": os.path.expanduser(
@@ -1265,9 +1266,10 @@ def cmd_hot_reload(args):
 
     # Step 4: start new server
     print("Step 4/6: Starting new server...")
-    verbose_flag = ""
+    # ERNIC_VERBOSE=true is legacy shorthand for the debug log level.
+    level = CFG["ERNIC_LOG_LEVEL"]
     if CFG["ERNIC_VERBOSE"] == "true":
-        verbose_flag = "--verbose"
+        level = "debug"
 
     backend = (
         f"tcp:manager:listen:{CFG['ERNIC_TCP_PORT']}"
@@ -1288,9 +1290,8 @@ def cmd_hot_reload(args):
         "--mac", inst["mac"],
         "--backend", backend,
         "--log-file", logfile,
+        "--log-level", level,
     ]
-    if verbose_flag:
-        cmd.append(verbose_flag)
 
     proc = subprocess.Popen(cmd)
 

--- a/service/rocm-ernic-launcher
+++ b/service/rocm-ernic-launcher
@@ -30,6 +30,7 @@ ERNIC_INSTANCES="${ERNIC_INSTANCES:-4}"
 ERNIC_TCP_PORT="${ERNIC_TCP_PORT:-6320}"
 ERNIC_MANAGER_IP="${ERNIC_MANAGER_IP:-127.0.0.1}"
 ERNIC_VERBOSE="${ERNIC_VERBOSE:-false}"
+ERNIC_LOG_LEVEL="${ERNIC_LOG_LEVEL:-warn}"
 
 MANIFEST="${ERNIC_RUN_DIR}/instances.json"
 
@@ -165,9 +166,10 @@ start_instance() {
     local stats="${ERNIC_RUN_DIR}/${id}.stats"
     local logfile="${ERNIC_LOG_DIR}/${id}.log"
 
-    local verbose_flag=""
+    # ERNIC_VERBOSE=true is legacy shorthand for the debug log level.
+    local level="${ERNIC_LOG_LEVEL}"
     if [ "${ERNIC_VERBOSE}" = "true" ]; then
-        verbose_flag="--verbose"
+        level="debug"
     fi
 
     local backend
@@ -185,7 +187,7 @@ start_instance() {
         --mac "${mac}" \
         --backend "${backend}" \
         --log-file "${logfile}" \
-        ${verbose_flag} &
+        --log-level "${level}" &
     local pid=$!
 
     if ! wait_for_socket "${sock}" 15; then

--- a/service/rocm-ernic.env
+++ b/service/rocm-ernic.env
@@ -22,7 +22,12 @@ ERNIC_INSTANCES=4
 ERNIC_TCP_PORT=6320
 ERNIC_MANAGER_IP=127.0.0.1
 
-# Enable verbose server logging (true / false).
+# Server log verbosity: none | error | warn | info | debug.
+# warn keeps the steady-state logs to WARN/ERROR plus a short
+# startup banner; info restores the per-operation INFO lines.
+ERNIC_LOG_LEVEL=warn
+
+# Legacy shorthand for ERNIC_LOG_LEVEL=debug (true / false).
 ERNIC_VERBOSE=false
 
 # ── MAC addresses ──────────────────────────────────

--- a/src/from-qemu/hw/rdma/vmw/pvrdma_dev_ring.c
+++ b/src/from-qemu/hw/rdma/vmw/pvrdma_dev_ring.c
@@ -68,18 +68,11 @@ int pvrdma_ring_init(PvrdmaRing *ring, const char *name, PCIDevice *dev,
         }
 
         mapped_addr = rdma_pci_dma_map(dev, tbl[i], PAGE_SIZE);
-        printf("DIRECT_PRINTF: page[%d] mapped_addr=%p (uintptr=%#lx)\n", i,
-               mapped_addr, (uintptr_t)mapped_addr);
-        fflush(stdout);
         rdma_info_report(">>> pvrdma_ring_init: page[%d]: guest=0x%lx -> "
                          "mapped_addr=%p (as lx=%#lx)",
                          i, tbl[i], mapped_addr, (unsigned long)mapped_addr);
 
         ring->pages[i] = mapped_addr;
-        printf("DIRECT_PRINTF: page[%d] STORED ring->pages[%d]=%p "
-               "(uintptr=%#lx)\n",
-               i, i, ring->pages[i], (uintptr_t)ring->pages[i]);
-        fflush(stdout);
         rdma_info_report(">>> pvrdma_ring_init: page[%d]: STORED "
                          "ring->pages[%d]=%p (as lx=%#lx)",
                          i, i, ring->pages[i], (unsigned long)ring->pages[i]);

--- a/src/from-qemu/include/qemu-extra/qemu/error-report.h
+++ b/src/from-qemu/include/qemu-extra/qemu/error-report.h
@@ -8,6 +8,29 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdbool.h>
+
+/*
+ * Runtime log level.  Set from the --log-level command line option or
+ * the ERNIC_LOG_LEVEL environment variable; defaults to ERNIC_LOG_WARN
+ * so per-operation INFO chatter stays out of the steady-state logs.
+ */
+typedef enum {
+    ERNIC_LOG_NONE = 0,
+    ERNIC_LOG_ERROR,
+    ERNIC_LOG_WARN,
+    ERNIC_LOG_INFO,
+    ERNIC_LOG_DEBUG,
+} ErnicLogLevel;
+
+bool ernic_log_parse_level(const char *s, ErnicLogLevel *out);
+const char *ernic_log_level_name(ErnicLogLevel lvl);
+void ernic_log_set_level(ErnicLogLevel lvl);
+ErnicLogLevel ernic_log_get_level(void);
+bool ernic_log_enabled(ErnicLogLevel lvl);
+
+/* One-shot startup/shutdown lines: unprefixed, printed at WARN and above. */
+void ernic_startup_report(const char *fmt, ...);
 
 /* Simple implementations that just print to stderr/stdout */
 
@@ -24,25 +47,6 @@ static inline int error_printf(const char *fmt, ...)
     ret = vfprintf(stderr, fmt, ap);
     va_end(ap);
     return ret;
-}
-
-static inline void error_vreport(const char *fmt, va_list ap)
-{
-    vfprintf(stderr, fmt, ap);
-    fprintf(stderr, "\n");
-}
-
-static inline void warn_vreport(const char *fmt, va_list ap)
-{
-    fprintf(stderr, "Warning: ");
-    vfprintf(stderr, fmt, ap);
-    fprintf(stderr, "\n");
-}
-
-static inline void info_vreport(const char *fmt, va_list ap)
-{
-    vfprintf(stdout, fmt, ap);
-    fprintf(stdout, "\n");
 }
 
 /* Declarations - implementations in error-report.c */

--- a/src/from-qemu/utils/error-report.c
+++ b/src/from-qemu/utils/error-report.c
@@ -1,5 +1,100 @@
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#include "qemu/error-report.h"
+
+/*
+ * Log level state.  Initialised lazily from ERNIC_LOG_LEVEL so that
+ * anything logged before main() finishes parsing its options already
+ * honours the environment; an explicit ernic_log_set_level() from the
+ * command line overrides it.
+ */
+static ErnicLogLevel g_log_level = ERNIC_LOG_WARN;
+static bool g_log_level_resolved = false;
+
+bool ernic_log_parse_level(const char *s, ErnicLogLevel *out)
+{
+    static const struct {
+        const char *name;
+        ErnicLogLevel level;
+    } levels[] = {
+        {"none", ERNIC_LOG_NONE},   {"0", ERNIC_LOG_NONE},
+        {"error", ERNIC_LOG_ERROR}, {"1", ERNIC_LOG_ERROR},
+        {"warn", ERNIC_LOG_WARN},   {"warning", ERNIC_LOG_WARN},
+        {"2", ERNIC_LOG_WARN},      {"info", ERNIC_LOG_INFO},
+        {"3", ERNIC_LOG_INFO},      {"debug", ERNIC_LOG_DEBUG},
+        {"4", ERNIC_LOG_DEBUG},
+    };
+
+    if (!s || s[0] == '\0') {
+        return false;
+    }
+
+    for (size_t i = 0; i < sizeof(levels) / sizeof(levels[0]); i++) {
+        if (!strcasecmp(s, levels[i].name)) {
+            *out = levels[i].level;
+            return true;
+        }
+    }
+    return false;
+}
+
+const char *ernic_log_level_name(ErnicLogLevel lvl)
+{
+    switch (lvl) {
+    case ERNIC_LOG_NONE:
+        return "none";
+    case ERNIC_LOG_ERROR:
+        return "error";
+    case ERNIC_LOG_WARN:
+        return "warn";
+    case ERNIC_LOG_INFO:
+        return "info";
+    case ERNIC_LOG_DEBUG:
+        return "debug";
+    default:
+        return "unknown";
+    }
+}
+
+void ernic_log_set_level(ErnicLogLevel lvl)
+{
+    g_log_level = lvl;
+    g_log_level_resolved = true;
+}
+
+ErnicLogLevel ernic_log_get_level(void)
+{
+    if (!g_log_level_resolved) {
+        const char *env = getenv("ERNIC_LOG_LEVEL");
+        ErnicLogLevel lvl;
+
+        /* Mark resolved first: the bad-value warning below logs, and
+         * that would otherwise recurse back into this function. */
+        g_log_level = ERNIC_LOG_WARN;
+        g_log_level_resolved = true;
+
+        if (env && env[0] != '\0') {
+            if (ernic_log_parse_level(env, &lvl)) {
+                g_log_level = lvl;
+            } else {
+                warn_report("Ignoring invalid ERNIC_LOG_LEVEL='%s' "
+                            "(expected none|error|warn|info|debug)",
+                            env);
+            }
+        }
+    }
+    return g_log_level;
+}
+
+bool ernic_log_enabled(ErnicLogLevel lvl)
+{
+    return ernic_log_get_level() >= lvl;
+}
 
 void error_vreport(const char *fmt, va_list ap)
 {
@@ -28,6 +123,10 @@ void info_vreport(const char *fmt, va_list ap)
 void error_report(const char *fmt, ...)
 {
     va_list ap;
+
+    if (!ernic_log_enabled(ERNIC_LOG_ERROR)) {
+        return;
+    }
     va_start(ap, fmt);
     error_vreport(fmt, ap);
     va_end(ap);
@@ -36,6 +135,10 @@ void error_report(const char *fmt, ...)
 void warn_report(const char *fmt, ...)
 {
     va_list ap;
+
+    if (!ernic_log_enabled(ERNIC_LOG_WARN)) {
+        return;
+    }
     va_start(ap, fmt);
     warn_vreport(fmt, ap);
     va_end(ap);
@@ -44,7 +147,25 @@ void warn_report(const char *fmt, ...)
 void info_report(const char *fmt, ...)
 {
     va_list ap;
+
+    if (!ernic_log_enabled(ERNIC_LOG_INFO)) {
+        return;
+    }
     va_start(ap, fmt);
     info_vreport(fmt, ap);
     va_end(ap);
+}
+
+void ernic_startup_report(const char *fmt, ...)
+{
+    va_list ap;
+
+    if (!ernic_log_enabled(ERNIC_LOG_WARN)) {
+        return;
+    }
+    va_start(ap, fmt);
+    vprintf(fmt, ap);
+    va_end(ap);
+    printf("\n");
+    fflush(stdout);
 }

--- a/src/rocm_ernic_server.c
+++ b/src/rocm_ernic_server.c
@@ -38,6 +38,7 @@
 /* Internal headers */
 #include "rocm_ernic_internal.h"
 #include "rocm_ernic_compat.h"
+#include "qemu/error-report.h"
 
 /* AMD ROCm ERNIC device IDs (for vfio-user).
  * 0x1484 = GPP Bridge, 0x1485 = Reserved SPP, 0x1486 = CCP/PSP, 0x1487 = HD
@@ -84,20 +85,48 @@ static void vfu_log_cb(vfu_ctx_t *vfu_ctx, int level, const char *msg)
     case LOG_ALERT:
     case LOG_CRIT:
     case LOG_ERR:
-        fprintf(stderr, "%s: ERROR: %s\n", prefix, msg);
+        if (ernic_log_enabled(ERNIC_LOG_ERROR)) {
+            fprintf(stderr, "%s: ERROR: %s\n", prefix, msg);
+        }
         break;
     case LOG_WARNING:
-        fprintf(stderr, "%s: WARN: %s\n", prefix, msg);
+        if (ernic_log_enabled(ERNIC_LOG_WARN)) {
+            fprintf(stderr, "%s: WARN: %s\n", prefix, msg);
+        }
         break;
     case LOG_NOTICE:
     case LOG_INFO:
-        printf("%s: %s\n", prefix, msg);
+        if (ernic_log_enabled(ERNIC_LOG_INFO)) {
+            printf("%s: %s\n", prefix, msg);
+        }
         break;
     case LOG_DEBUG:
-        printf("%s: DEBUG: %s\n", prefix, msg);
+        if (ernic_log_enabled(ERNIC_LOG_DEBUG)) {
+            printf("%s: DEBUG: %s\n", prefix, msg);
+        }
         break;
     default:
         break;
+    }
+}
+
+/**
+ * Map the runtime log level onto the libvfio-user syslog threshold, so
+ * the library skips formatting messages we would drop anyway.
+ */
+static int vfu_log_threshold(ErnicLogLevel lvl)
+{
+    switch (lvl) {
+    case ERNIC_LOG_DEBUG:
+        return LOG_DEBUG;
+    case ERNIC_LOG_INFO:
+        return LOG_INFO;
+    case ERNIC_LOG_WARN:
+        return LOG_WARNING;
+    case ERNIC_LOG_ERROR:
+    case ERNIC_LOG_NONE:
+    default:
+        return LOG_ERR;
     }
 }
 
@@ -353,8 +382,9 @@ static int pvrdma_device_init(rocm_ernic_dev_t *dev)
 
     dev->device_initialized = true;
 
-    printf("PVRDMA device initialized successfully with '%s' backend\n",
-           dev->backend_type_str);
+    ernic_startup_report(
+        "PVRDMA device initialized successfully with '%s' backend",
+        dev->backend_type_str);
 
     return 0;
 }
@@ -385,8 +415,10 @@ static int setup_pci_config(vfu_ctx_t *vfu_ctx, rocm_ernic_dev_t *dev)
                       0x00); /* Prog-if */
 
 
-    vfu_log(vfu_ctx, LOG_INFO, "PCI device configured: vendor=%#x device=%#x",
-            (unsigned)PCI_VENDOR_ID_AMD, (unsigned)PCI_DEVICE_ID_ROCM_ERNIC);
+    ernic_startup_report("rocm-ernic: PCI device configured: vendor=%#x "
+                         "device=%#x",
+                         (unsigned)PCI_VENDOR_ID_AMD,
+                         (unsigned)PCI_DEVICE_ID_ROCM_ERNIC);
 
     return 0;
 }
@@ -432,10 +464,11 @@ static int setup_bars(vfu_ctx_t *vfu_ctx, rocm_ernic_dev_t *dev)
         err(EXIT_FAILURE, "Failed to setup BAR2");
     }
 
-    vfu_log(vfu_ctx, LOG_INFO, "BARs configured: BAR0=%zu BAR1=%zu BAR2=%zu",
-            (size_t)RDMA_BAR0_MSIX_SIZE,
-            (size_t)(RDMA_BAR1_REGS_SIZE * sizeof(uint32_t)),
-            (size_t)(RDMA_BAR2_UAR_SIZE * sizeof(uint32_t)));
+    ernic_startup_report(
+        "rocm-ernic: BARs configured: BAR0=%zu BAR1=%zu BAR2=%zu",
+        (size_t)RDMA_BAR0_MSIX_SIZE,
+        (size_t)(RDMA_BAR1_REGS_SIZE * sizeof(uint32_t)),
+        (size_t)(RDMA_BAR2_UAR_SIZE * sizeof(uint32_t)));
 
     return 0;
 }
@@ -502,7 +535,8 @@ static int setup_interrupts(vfu_ctx_t *vfu_ctx, rocm_ernic_dev_t *dev)
         return (int)ret;
     }
 
-    vfu_log(vfu_ctx, LOG_INFO, "Added MSI-X capability at offset 0x%zd", ret);
+    ernic_startup_report("rocm-ernic: Added MSI-X capability at offset 0x%zd",
+                         ret);
 
     /* Ensure standard PCI header tail (0x34-0x3f) is set for config reads */
     {
@@ -523,11 +557,12 @@ static int setup_interrupts(vfu_ctx_t *vfu_ctx, rocm_ernic_dev_t *dev)
         return (int)ret;
     }
 
-    vfu_log(vfu_ctx, LOG_INFO,
-            "Interrupts configured: INTx=1, MSI-X=%d vectors "
-            "(table=BAR%d:0x%x, pba=BAR%d:0x%x)",
-            RDMA_MAX_INTRS, MSIX_TABLE_BIR, (unsigned)MSIX_TABLE_OFFSET,
-            MSIX_PBA_BIR, (unsigned)MSIX_PBA_OFFSET);
+    ernic_startup_report("rocm-ernic: Interrupts configured: INTx=1, "
+                         "MSI-X=%d vectors "
+                         "(table=BAR%d:0x%x, pba=BAR%d:0x%x)",
+                         RDMA_MAX_INTRS, MSIX_TABLE_BIR,
+                         (unsigned)MSIX_TABLE_OFFSET, MSIX_PBA_BIR,
+                         (unsigned)MSIX_PBA_OFFSET);
 
     return 0;
 }
@@ -544,7 +579,11 @@ static void usage(const char *progname)
     fprintf(stderr,
             "  -b, --backend TYPE   RDMA backend: none|loopback|verbs|tcp\n");
     fprintf(stderr, "                       (default: loopback)\n");
-    fprintf(stderr, "  -v, --verbose        Enable verbose logging\n");
+    fprintf(stderr, "  -L, --log-level LEVEL Log verbosity: "
+                    "none|error|warn|info|debug\n");
+    fprintf(stderr, "                       (default: warn; also settable via "
+                    "ERNIC_LOG_LEVEL)\n");
+    fprintf(stderr, "  -v, --verbose        Shorthand for --log-level debug\n");
     fprintf(stderr, "  -S, --stats-file PATH Statistics output file path\n");
     fprintf(stderr, "                       (stats written every ~1 second)\n");
     fprintf(stderr, "  -l, --log-file PATH  Write all output to PATH (default: "
@@ -824,6 +863,8 @@ int main(int argc, char *argv[])
     rocm_ernic_dev_t *dev;
     const char *socket_path = DEFAULT_SOCKET_PATH;
     const char *log_file_path = NULL;
+    ErnicLogLevel log_level = ERNIC_LOG_WARN;
+    bool log_level_set = false;
     struct sigaction sa;
     int ret, opt;
 
@@ -833,6 +874,7 @@ int main(int argc, char *argv[])
         {"socket", required_argument, 0, 's'},
         {"backend", required_argument, 0, 'b'},
         {"verbose", no_argument, 0, 'v'},
+        {"log-level", required_argument, 0, 'L'},
         {"stats-file", required_argument, 0, 'S'},
         {"log-file", required_argument, 0, 'l'},
         {"mac", required_argument, 0, 'm'},
@@ -867,7 +909,7 @@ int main(int argc, char *argv[])
     dev->mac_addr[5] = 0x6e;
 
     /* Parse command line options */
-    while ((opt = getopt_long(argc, argv, "s:b:vS:m:l:h", long_options,
+    while ((opt = getopt_long(argc, argv, "s:b:vL:S:m:l:h", long_options,
                               NULL)) != -1) {
         switch (opt) {
         /* Common options */
@@ -880,6 +922,17 @@ int main(int argc, char *argv[])
             break;
         case 'v':
             dev->verbose = true;
+            break;
+        case 'L':
+            if (!ernic_log_parse_level(optarg, &log_level)) {
+                fprintf(stderr, "Error: Invalid log level: %s\n", optarg);
+                fprintf(stderr,
+                        "  Expected one of: none, error, warn, info, debug\n");
+                free(dev->backend_type_str);
+                free(dev);
+                exit(EXIT_FAILURE);
+            }
+            log_level_set = true;
             break;
         case 'S':
             /* Store stats file path - will be set after device init */
@@ -929,6 +982,14 @@ int main(int argc, char *argv[])
         }
     }
 
+    /* Log level precedence: --log-level, then --verbose, then the
+     * ERNIC_LOG_LEVEL environment variable (resolved lazily), then warn. */
+    if (log_level_set) {
+        ernic_log_set_level(log_level);
+    } else if (dev->verbose) {
+        ernic_log_set_level(ERNIC_LOG_DEBUG);
+    }
+
     /* Validate backend-specific options */
     if (validate_backend_options(dev) < 0) {
         free(dev->backend_type_str);
@@ -959,39 +1020,32 @@ int main(int argc, char *argv[])
         err(EXIT_FAILURE, "Failed to setup signal handlers");
     }
 
-    printf("rocm-ernic: Starting rocm-ernic device server (Multi-Backend "
-           "Support)\n");
-    printf("  Socket: %s\n", socket_path);
-    printf("  Backend: %s\n", dev->backend_type_str);
+    ernic_startup_report("rocm-ernic: Starting rocm-ernic device server "
+                         "(Multi-Backend Support)");
+    ernic_startup_report("  Socket: %s", socket_path);
+    ernic_startup_report("  Backend: %s", dev->backend_type_str);
+    ernic_startup_report("  Log level: %s",
+                         ernic_log_level_name(ernic_log_get_level()));
     if (log_file_path) {
-        printf("  Log file: %s\n", log_file_path);
+        ernic_startup_report("  Log file: %s", log_file_path);
     }
 
     /* Show backend-specific options only for verbs backend */
     if (!strcmp(get_backend_type_base(dev->backend_type_str), "verbs")) {
         if (dev->backend_device_name) {
-            printf("  IB Device: %s\n", dev->backend_device_name);
+            ernic_startup_report("  IB Device: %s", dev->backend_device_name);
         }
         if (dev->backend_eth_device) {
-            printf("  Eth Device: %s\n", dev->backend_eth_device);
+            ernic_startup_report("  Eth Device: %s", dev->backend_eth_device);
         }
-        printf("  IB Port: %u\n", dev->backend_port_num);
+        ernic_startup_report("  IB Port: %u", dev->backend_port_num);
     }
-    printf("\n");
-    printf("Features in this build:\n");
-    printf("  ✓ PCI device enumeration\n");
-    printf("  ✓ BAR0/1/2 access\n");
-    printf("  ✓ DSR register handling (QEMU integration)\n");
-    printf("  ✓ Command channel framework\n");
-    printf("  ✓ Multi-backend support (none/loopback/verbs)\n");
-    printf("  ⚠ Full command processing (in progress)\n");
-    printf("\n");
 
     /* Remove old socket if it exists - try multiple approaches */
     struct stat st;
     if (stat(socket_path, &st) == 0) {
         if (S_ISSOCK(st.st_mode)) {
-            printf("Removing stale socket file: %s\n", socket_path);
+            ernic_startup_report("Removing stale socket file: %s", socket_path);
             if (unlink(socket_path) != 0) {
                 warn("Failed to unlink existing socket");
             }
@@ -1012,8 +1066,8 @@ int main(int argc, char *argv[])
     dev->vfu_ctx = vfu_ctx;
 
     /* Setup logging */
-    ret =
-        vfu_setup_log(vfu_ctx, vfu_log_cb, dev->verbose ? LOG_DEBUG : LOG_INFO);
+    ret = vfu_setup_log(vfu_ctx, vfu_log_cb,
+                        vfu_log_threshold(ernic_log_get_level()));
     if (ret < 0) {
         err(EXIT_FAILURE, "vfu_setup_log() failed");
     }
@@ -1031,9 +1085,9 @@ int main(int argc, char *argv[])
                                        dev->backend_type_str);
         pvrdma_set_stats_pci_ids(dev->pvrdma_handle, PCI_VENDOR_ID_AMD,
                                  PCI_DEVICE_ID_ROCM_ERNIC);
-        printf("rocm-ernic: Statistics will be written to: %s (every ~1 "
-               "second)\n",
-               dev->stats_file_path);
+        ernic_startup_report("rocm-ernic: Statistics will be written to: %s "
+                             "(every ~1 second)",
+                             dev->stats_file_path);
         pvrdma_write_stats(dev->pvrdma_handle);
     }
 
@@ -1084,22 +1138,22 @@ int main(int argc, char *argv[])
                 "rocm-ernic: You may need to manually run: sudo chmod 666 %s\n",
                 socket_path);
     } else {
-        printf(
-            "rocm-ernic: ✓ Socket permissions set to 0666 (rw-rw-rw-) for %s\n",
-            socket_path);
-        fflush(stdout);
+        ernic_startup_report("rocm-ernic: ✓ Socket permissions set to 0666 "
+                             "(rw-rw-rw-) for %s",
+                             socket_path);
     }
 
     /* Log MAC address if set */
     if (dev->mac_addr_set) {
-        vfu_log(vfu_ctx, LOG_INFO,
-                "Device MAC address: %02x:%02x:%02x:%02x:%02x:%02x",
-                dev->mac_addr[0], dev->mac_addr[1], dev->mac_addr[2],
-                dev->mac_addr[3], dev->mac_addr[4], dev->mac_addr[5]);
+        ernic_startup_report("rocm-ernic: Device MAC address: "
+                             "%02x:%02x:%02x:%02x:%02x:%02x",
+                             dev->mac_addr[0], dev->mac_addr[1],
+                             dev->mac_addr[2], dev->mac_addr[3],
+                             dev->mac_addr[4], dev->mac_addr[5]);
     }
 
-    vfu_log(vfu_ctx, LOG_INFO,
-            "Device realized, waiting for client connection...");
+    ernic_startup_report("rocm-ernic: Device realized, waiting for client "
+                         "connection...");
 
     /* Main loop */
     while (!g_shutdown_requested) {
@@ -1120,7 +1174,7 @@ int main(int argc, char *argv[])
             err(EXIT_FAILURE, "vfu_attach_ctx() failed");
         }
 
-        vfu_log(vfu_ctx, LOG_INFO, "Client connected!");
+        ernic_startup_report("rocm-ernic: Client connected!");
         if (dev->pvrdma_handle) {
             pvrdma_set_stats_connection_state(dev->pvrdma_handle, "connected");
         }
@@ -1156,8 +1210,9 @@ int main(int argc, char *argv[])
 
             if (ret < 0) {
                 if (errno == ENOTCONN) {
-                    vfu_log(vfu_ctx, LOG_INFO,
-                            "Client disconnected after %d loops", loop_count);
+                    ernic_startup_report(
+                        "rocm-ernic: Client disconnected after %d loops",
+                        loop_count);
                     if (dev->pvrdma_handle) {
                         pvrdma_set_stats_connection_state(
                             dev->pvrdma_handle, "disconnected (client closed)");
@@ -1194,7 +1249,7 @@ int main(int argc, char *argv[])
         g_main_context_pop_thread_default(main_context);
     }
 
-    vfu_log(vfu_ctx, LOG_INFO, "Shutting down");
+    ernic_startup_report("rocm-ernic: Shutting down");
 
     /* Mark cleanup in progress to prevent signal handler re-entry */
     g_cleanup_in_progress = 1;
@@ -1234,7 +1289,7 @@ int main(int argc, char *argv[])
 
     unlink(socket_path);
 
-    printf("rocm-ernic: Shutdown complete\n");
+    ernic_startup_report("rocm-ernic: Shutdown complete");
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Every BAR write, QP operation, ARP/ICMP packet and TCP mesh event went out through rdma_info_report() -> info_report() as an unconditional INFO: line, so a running mesh buried its logs in per-operation chatter with no way to turn it down.

Gate the three report functions in error-report.c on a new runtime ErnicLogLevel (none|error|warn|info|debug).  Putting the check there covers all 388 info_report call sites without touching any of them. The level resolves lazily from ERNIC_LOG_LEVEL on first use, so output emitted before the option parsing finishes honours the environment too.

The server gains -L/--log-level; -v/--verbose becomes shorthand for debug.  Precedence is --log-level, then --verbose, then ERNIC_LOG_LEVEL, then the warn default.  vfu_log_cb and the vfu_setup_log threshold follow the same level, and the one-shot startup and shutdown lines move to ernic_startup_report() so they survive at warn but go quiet at error and none.

Also drop three dead static inline *_vreport definitions from error-report.h, which shadowed the real ones and blocked the .c file from including its own header, and two leftover DIRECT_PRINTF debug lines in pvrdma_dev_ring.c that duplicated adjacent info reports.

The launcher and ernicctl now pass --log-level, mapping the legacy ERNIC_VERBOSE=true to debug; they no longer pass --verbose, which the explicit flag would have overridden.  ERNIC_DEBUG_MESH is unchanged: it reports at WARN, so it stays visible at the new default.
