### PR TITLE
fix(tcp): zero the mesh topology payload before broadcasting

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -392,7 +392,7 @@ jobs:
     - name: Install kernel-version-specific packages in VM
       shell: bash
       run: |
-        echo "=== Installing kernel headers and modules in VM ==="
+        echo "=== Installing kernel headers and modules-extra in VM ==="
         SSH_PORT="$SSH_PORT"
         VM_USER="$VM_USER"
         ssh -o StrictHostKeyChecking=no -p "$SSH_PORT" "${VM_USER}@localhost" << 'EOFVM'
@@ -405,22 +405,9 @@ jobs:
         for i in 1 2 3; do
           sudo apt-get $APT_LOCK_WAIT update -qq && break || { echo "apt-get update retry $i/3"; sleep 5; }
         done
-        # Ubuntu 25.10+ dropped the linux-modules-extra-<ver> split; the
-        # infiniband modules (ib_core, ib_uverbs) now ship in linux-modules
-        # instead, which is already installed as a dep of linux-image. Ask
-        # for whichever one this release actually publishes.
-        KERNEL_PKGS="linux-headers-${KVER}"
-        for pkg in linux-modules-extra-${KVER} linux-modules-${KVER}; do
-          if apt-cache show "$pkg" 2>/dev/null | grep -q '^Version:'; then
-            KERNEL_PKGS="${KERNEL_PKGS} ${pkg}"
-            break
-          fi
-        done
-        echo "Installing: ${KERNEL_PKGS}"
         for i in 1 2 3 4 5; do
-          # shellcheck disable=SC2086  # KERNEL_PKGS is a deliberate word list
           sudo DEBIAN_FRONTEND=noninteractive apt-get $APT_LOCK_WAIT install -y -qq \
-            $KERNEL_PKGS && break
+            linux-headers-${KVER} linux-modules-extra-${KVER} && break
           [ "$i" -eq 5 ] && { echo "apt-get install failed after 5 attempts"; exit 1; }
           echo "apt-get install retry $i/5"; sleep 10
         done
@@ -517,9 +504,8 @@ jobs:
           echo "Checking available modules:"
           find /lib/modules/$(uname -r) -name "*ib_core*" 2>/dev/null || echo "No ib_core module found"
           echo ""
-          echo "You may need to install the kernel modules package:"
-          echo "  sudo apt-get update && sudo apt-get install linux-modules-$(uname -r)"
-          echo "  (on Ubuntu 25.04 and older: linux-modules-extra-$(uname -r))"
+          echo "You may need to install linux-modules-extra:"
+          echo "  sudo apt-get update && sudo apt-get install linux-modules-extra-$(uname -r)"
           exit 1
         fi
         
@@ -1684,22 +1670,9 @@ jobs:
         for i in 1 2 3; do
           sudo apt-get $APT_LOCK_WAIT update -qq && break || { echo "apt-get update retry $i/3"; sleep 5; }
         done
-        # Ubuntu 25.10+ dropped the linux-modules-extra-<ver> split; the
-        # infiniband modules (ib_core, ib_uverbs) now ship in linux-modules
-        # instead, which is already installed as a dep of linux-image. Ask
-        # for whichever one this release actually publishes.
-        KERNEL_PKGS="linux-headers-${KVER}"
-        for pkg in linux-modules-extra-${KVER} linux-modules-${KVER}; do
-          if apt-cache show "$pkg" 2>/dev/null | grep -q '^Version:'; then
-            KERNEL_PKGS="${KERNEL_PKGS} ${pkg}"
-            break
-          fi
-        done
-        echo "Installing: ${KERNEL_PKGS}"
         for i in 1 2 3 4 5; do
-          # shellcheck disable=SC2086  # KERNEL_PKGS is a deliberate word list
           sudo DEBIAN_FRONTEND=noninteractive apt-get $APT_LOCK_WAIT install -y -qq \
-            $KERNEL_PKGS && break
+            linux-headers-${KVER} linux-modules-extra-${KVER} && break
           [ "$i" -eq 5 ] && { echo "apt-get install failed after 5 attempts"; exit 1; }
           echo "apt-get install retry $i/5"; sleep 10
         done

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -392,7 +392,7 @@ jobs:
     - name: Install kernel-version-specific packages in VM
       shell: bash
       run: |
-        echo "=== Installing kernel headers and modules-extra in VM ==="
+        echo "=== Installing kernel headers and modules in VM ==="
         SSH_PORT="$SSH_PORT"
         VM_USER="$VM_USER"
         ssh -o StrictHostKeyChecking=no -p "$SSH_PORT" "${VM_USER}@localhost" << 'EOFVM'
@@ -405,9 +405,22 @@ jobs:
         for i in 1 2 3; do
           sudo apt-get $APT_LOCK_WAIT update -qq && break || { echo "apt-get update retry $i/3"; sleep 5; }
         done
+        # Ubuntu 25.10+ dropped the linux-modules-extra-<ver> split; the
+        # infiniband modules (ib_core, ib_uverbs) now ship in linux-modules
+        # instead, which is already installed as a dep of linux-image. Ask
+        # for whichever one this release actually publishes.
+        KERNEL_PKGS="linux-headers-${KVER}"
+        for pkg in linux-modules-extra-${KVER} linux-modules-${KVER}; do
+          if apt-cache show "$pkg" 2>/dev/null | grep -q '^Version:'; then
+            KERNEL_PKGS="${KERNEL_PKGS} ${pkg}"
+            break
+          fi
+        done
+        echo "Installing: ${KERNEL_PKGS}"
         for i in 1 2 3 4 5; do
+          # shellcheck disable=SC2086  # KERNEL_PKGS is a deliberate word list
           sudo DEBIAN_FRONTEND=noninteractive apt-get $APT_LOCK_WAIT install -y -qq \
-            linux-headers-${KVER} linux-modules-extra-${KVER} && break
+            $KERNEL_PKGS && break
           [ "$i" -eq 5 ] && { echo "apt-get install failed after 5 attempts"; exit 1; }
           echo "apt-get install retry $i/5"; sleep 10
         done
@@ -504,8 +517,9 @@ jobs:
           echo "Checking available modules:"
           find /lib/modules/$(uname -r) -name "*ib_core*" 2>/dev/null || echo "No ib_core module found"
           echo ""
-          echo "You may need to install linux-modules-extra:"
-          echo "  sudo apt-get update && sudo apt-get install linux-modules-extra-$(uname -r)"
+          echo "You may need to install the kernel modules package:"
+          echo "  sudo apt-get update && sudo apt-get install linux-modules-$(uname -r)"
+          echo "  (on Ubuntu 25.04 and older: linux-modules-extra-$(uname -r))"
           exit 1
         fi
         
@@ -1670,9 +1684,22 @@ jobs:
         for i in 1 2 3; do
           sudo apt-get $APT_LOCK_WAIT update -qq && break || { echo "apt-get update retry $i/3"; sleep 5; }
         done
+        # Ubuntu 25.10+ dropped the linux-modules-extra-<ver> split; the
+        # infiniband modules (ib_core, ib_uverbs) now ship in linux-modules
+        # instead, which is already installed as a dep of linux-image. Ask
+        # for whichever one this release actually publishes.
+        KERNEL_PKGS="linux-headers-${KVER}"
+        for pkg in linux-modules-extra-${KVER} linux-modules-${KVER}; do
+          if apt-cache show "$pkg" 2>/dev/null | grep -q '^Version:'; then
+            KERNEL_PKGS="${KERNEL_PKGS} ${pkg}"
+            break
+          fi
+        done
+        echo "Installing: ${KERNEL_PKGS}"
         for i in 1 2 3 4 5; do
+          # shellcheck disable=SC2086  # KERNEL_PKGS is a deliberate word list
           sudo DEBIAN_FRONTEND=noninteractive apt-get $APT_LOCK_WAIT install -y -qq \
-            linux-headers-${KVER} linux-modules-extra-${KVER} && break
+            $KERNEL_PKGS && break
           [ "$i" -eq 5 ] && { echo "apt-get install failed after 5 attempts"; exit 1; }
           echo "apt-get install retry $i/5"; sleep 10
         done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,6 @@ target_compile_definitions(rocm-ernic PRIVATE
     GIT_SHA_FULL="${GIT_SHA_FULL}"
     GIT_SHA_SHORT="${GIT_SHA_SHORT}"
     _GNU_SOURCE
-    TARGET_PAGE_SIZE=4096
 )
 
 target_compile_options(rocm-ernic PRIVATE

--- a/src/from-qemu/hw/rdma/rdma_backend_tcp.c
+++ b/src/from-qemu/hw/rdma/rdma_backend_tcp.c
@@ -2328,7 +2328,12 @@ static void tcp_broadcast_mesh_topology(TcpBackendPrivate *priv)
         return;
     }
 
+    /* The whole payload goes on the wire, including the node slots past
+     * num_nodes, so the struct MUST be zeroed to avoid sending stack
+     * contents when there are unused nodes.
+     */
     TcpMeshTopologyPayload topo;
+    memset(&topo, 0, sizeof(topo));
     uint32_t num_nodes = 0;
 
     qemu_mutex_lock(&priv->mesh_table_lock);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -317,6 +317,31 @@ target_link_directories(test_loopback_sge_copy PRIVATE
 target_link_libraries(test_loopback_sge_copy PRIVATE
     ${GLIB2_LIBRARIES} ${IBVERBS_LIBRARIES})
 
+# TCP mesh-topology broadcast test. It #includes the TCP backend translation
+# unit to reach its static helpers and stubs the backend's externals, so no
+# RDMA subsystem link is needed; the broadcast goes over a socketpair.
+add_executable(test_tcp_mesh_topology test_tcp_mesh_topology.c)
+target_include_directories(test_tcp_mesh_topology PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/from-qemu
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/hw/rdma
+    ${CMAKE_SOURCE_DIR}/src/from-qemu/include/qemu-extra
+    ${GLIB2_INCLUDE_DIRS}
+    ${ERNIC_IBVERBS_INCLUDE_DIRS}
+)
+target_compile_definitions(test_tcp_mesh_topology PRIVATE
+    _GNU_SOURCE TARGET_PAGE_SIZE=4096)
+# -w: this test #includes the ported TCP backend translation unit, so warnings
+# would come from that ported C rather than the test itself; suppress them
+# to match how the ported sources are compiled in the main build.
+target_compile_options(test_tcp_mesh_topology PRIVATE
+    -w ${ERNIC_UNIT_TEST_SAN})
+target_link_options(test_tcp_mesh_topology PRIVATE ${ERNIC_UNIT_TEST_SAN_LINK})
+target_link_directories(test_tcp_mesh_topology PRIVATE
+    ${GLIB2_LIBRARY_DIRS} ${IBVERBS_LIBRARY_DIRS})
+target_link_libraries(test_tcp_mesh_topology PRIVATE
+    ${GLIB2_LIBRARIES} ${IBVERBS_LIBRARIES} pthread)
+
 # ---------------------------------------------------------------
 # Register tests with CTest
 # ---------------------------------------------------------------
@@ -432,6 +457,14 @@ add_test(
     COMMAND $<TARGET_FILE:test_loopback_sge_copy>
 )
 set_tests_properties(loopback-sge-copy-unit PROPERTIES TIMEOUT 30 RUN_SERIAL TRUE)
+
+# TCP mesh-topology broadcast unit test: asserts the unused node slots in the
+# fixed-size payload are zeroed rather than carrying stack contents.
+add_test(
+    NAME tcp-mesh-topology-unit
+    COMMAND $<TARGET_FILE:test_tcp_mesh_topology>
+)
+set_tests_properties(tcp-mesh-topology-unit PROPERTIES TIMEOUT 30 RUN_SERIAL TRUE)
 
 # ionic server smoke test: start server in --ionic mode, verify socket and banner.
 # Tests that the ionic emulation layer initialises without crashing.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,7 +81,7 @@ target_include_directories(test_rdma_backend_query_port PRIVATE
     ${ERNIC_IBVERBS_INCLUDE_DIRS}
 )
 target_compile_definitions(test_rdma_backend_query_port PRIVATE
-    _GNU_SOURCE TARGET_PAGE_SIZE=4096)
+    _GNU_SOURCE)
 # -w: this test links the ported RDMA-backend translation units, so warnings
 # would come from that ported C rather than the test itself; suppress them
 # to match how the ported sources are compiled in the main build.
@@ -305,7 +305,7 @@ target_include_directories(test_loopback_sge_copy PRIVATE
     ${IBVERBS_INCLUDE_DIRS}
 )
 target_compile_definitions(test_loopback_sge_copy PRIVATE
-    _GNU_SOURCE TARGET_PAGE_SIZE=4096)
+    _GNU_SOURCE)
 # -w: this test #includes the ported loopback translation unit, so warnings
 # would come from that ported C rather than the test itself; suppress them
 # to match how the ported sources are compiled in the main build.
@@ -330,7 +330,7 @@ target_include_directories(test_tcp_mesh_topology PRIVATE
     ${ERNIC_IBVERBS_INCLUDE_DIRS}
 )
 target_compile_definitions(test_tcp_mesh_topology PRIVATE
-    _GNU_SOURCE TARGET_PAGE_SIZE=4096)
+    _GNU_SOURCE)
 # -w: this test #includes the ported TCP backend translation unit, so warnings
 # would come from that ported C rather than the test itself; suppress them
 # to match how the ported sources are compiled in the main build.

--- a/tests/test_tcp_mesh_topology.c
+++ b/tests/test_tcp_mesh_topology.c
@@ -1,0 +1,409 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Unit tests for tcp_broadcast_mesh_topology() in rdma_backend_tcp.c.
+ *
+ * Regression coverage for a stack-memory disclosure: the manager sends the
+ * full fixed-size TcpMeshTopologyPayload (~17 KB, TOPO_MAXNODE node slots) on
+ * every broadcast, but only filled in nodes[0..num_nodes). The struct was an
+ * uninitialised stack local, so the unused tail slots put whatever the
+ * thread's stack happened to hold -- including live pointers -- on the wire.
+ *
+ * Each case runs the broadcast on a thread whose stack the test allocated
+ * and pre-filled with a poison byte, then reads the message back off a
+ * socketpair and asserts every byte past num_nodes is zero. Without the
+ * zero-fill the poison shows up on the wire and the test fails.
+ *
+ * The static function is reached by #including the translation unit; the
+ * broadcast path only needs the mesh/connection hash tables, so the rest of
+ * the backend's externals are stubbed out.
+ *
+ * Table-driven: empty mesh (every slot unused), single node, a few nodes, and
+ * a full mesh (no tail at all).
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+/* Pull in the code under test (including its static functions) */
+#include "hw/rdma/rdma_backend_tcp.c"
+
+/* ---- Stubs for the TU's external symbols -------------------------------
+ * None of these are reachable from the topology-broadcast path; they exist
+ * only to satisfy the linker
+ */
+void error_report(const char *fmt, ...)
+{
+    (void)fmt;
+}
+void warn_report(const char *fmt, ...)
+{
+    (void)fmt;
+}
+void info_report(const char *fmt, ...)
+{
+    (void)fmt;
+}
+int qemu_thread_create(QemuThread *thread, const char *name,
+                       void *(*start_routine)(void *), void *arg, int mode)
+{
+    (void)thread;
+    (void)name;
+    (void)start_routine;
+    (void)arg;
+    (void)mode;
+    return 0;
+}
+void qemu_thread_exit(void *retval)
+{
+    (void)retval;
+    abort();
+}
+void qemu_thread_join(QemuThread *thread)
+{
+    (void)thread;
+}
+void *pci_dma_map(PCIDevice *dev, uint64_t addr, uint64_t *len, int dir)
+{
+    (void)dev;
+    (void)addr;
+    (void)len;
+    (void)dir;
+    return NULL;
+}
+void pci_dma_unmap(PCIDevice *dev, void *buffer, uint64_t len, int dir,
+                   uint64_t access_len)
+{
+    (void)dev;
+    (void)buffer;
+    (void)len;
+    (void)dir;
+    (void)access_len;
+}
+int pci_dma_sync(PCIDevice *dev, uint64_t guest_addr, uint64_t len)
+{
+    (void)dev;
+    (void)guest_addr;
+    (void)len;
+    return 0;
+}
+size_t dhcp_server_process(DhcpServer *server, const struct dhcp_packet *req,
+                           size_t req_len, struct dhcp_packet *resp,
+                           size_t max_resp_len)
+{
+    (void)server;
+    (void)req;
+    (void)req_len;
+    (void)resp;
+    (void)max_resp_len;
+    return 0;
+}
+int eth_rx_inject_frame_mesh_blocking(PVRDMADev *dev, const void *frame_data,
+                                      size_t len)
+{
+    (void)dev;
+    (void)frame_data;
+    (void)len;
+    return 0;
+}
+void rdma_backend_complete_work(enum ibv_wc_status status, uint32_t vendor_err,
+                                uint32_t byte_len, uint32_t qp_num,
+                                enum ibv_wc_opcode opcode, void *ctx)
+{
+    (void)status;
+    (void)vendor_err;
+    (void)byte_len;
+    (void)qp_num;
+    (void)opcode;
+    (void)ctx;
+}
+RdmaRmMR *rdma_rm_get_mr(RdmaDeviceResources *dev_res, uint32_t mr_handle)
+{
+    (void)dev_res;
+    (void)mr_handle;
+    return NULL;
+}
+
+/* ---- Test helpers ------------------------------------------------------ */
+
+/*
+ * Derived from the payload rather than hardcoded: if nodes[] is ever resized,
+ * a literal here would silently check a short tail instead of failing
+ */
+#define TOPO_MAXNODE \
+    (sizeof(((TcpMeshTopologyPayload *)0)->nodes) / sizeof(TcpMeshNodeInfo))
+
+struct testcase {
+    const char *name;
+    uint32_t num_nodes;
+};
+
+/* Read exactly len bytes, or return -1. */
+static int read_exact(int fd, void *buf, size_t len)
+{
+    size_t got = 0;
+
+    while (got < len) {
+        ssize_t ret = recv(fd, (char *)buf + got, len - got, 0);
+        if (ret <= 0) {
+            return -1;
+        }
+        got += (size_t)ret;
+    }
+    return 0;
+}
+
+/*
+ * Run tcp_broadcast_mesh_topology() on a thread whose stack we allocate and
+ * pre-fill with a poison pattern.
+ *
+ * Poisoning the caller's own frame and hoping the payload lands on it is not
+ * reliable -- the compiler is free to place the ~17 KB struct anywhere, and
+ * ASan's redzones shift frames further. Owning the whole stack removes the
+ * guesswork: wherever the payload lands, it lands on POISON_BYTE, so any
+ * unused slot that reaches the wire un-zeroed is unambiguous.
+ */
+#define POISON_BYTE     0xAB
+#define POISON_STACK_SZ (1024 * 1024)
+
+/*
+ * ASan's use-after-return detection relocates large frames off the real
+ * stack into freshly-zeroed heap "fake stacks", which would hide the poison
+ * and make this test vacuously pass. Turn it off for this binary; the
+ * address/leak checks the project cares about here are unaffected.
+ */
+const char *__asan_default_options(void);
+const char *__asan_default_options(void)
+{
+    return "detect_stack_use_after_return=0";
+}
+
+/*
+ * Address of a local in the broadcast thread's frame, recorded so the caller
+ * can prove the payload really landed on the stack we poisoned.
+ *
+ * __asan_default_options() above is only a *default*: an ASAN_OPTIONS in the
+ * environment overrides it, ASan moves the ~17 KB frame to a freshly-zeroed
+ * fake stack, and the tail then reads as zero no matter what the code under
+ * test does -- the test would pass vacuously. Checking where the frame landed
+ * turns that silent hole into a loud failure.
+ */
+static uintptr_t broadcast_frame;
+
+static void *broadcast_thread(void *opaque)
+{
+    int frame_marker;
+
+    broadcast_frame = (uintptr_t)&frame_marker;
+    tcp_broadcast_mesh_topology((TcpBackendPrivate *)opaque);
+    return NULL;
+}
+
+static int broadcast_on_poisoned_stack(TcpBackendPrivate *priv)
+{
+    pthread_attr_t attr;
+    pthread_t tid;
+    void *stack;
+    int ret;
+
+    if (posix_memalign(&stack, sysconf(_SC_PAGESIZE), POISON_STACK_SZ) != 0) {
+        return -1;
+    }
+    memset(stack, POISON_BYTE, POISON_STACK_SZ);
+
+    /* Cleared per run so a value left by an earlier case can never stand in
+     * for one this thread failed to record. pthread_join() below orders the
+     * thread's write against our read.
+     */
+    broadcast_frame = 0;
+
+    pthread_attr_init(&attr);
+    pthread_attr_setstack(&attr, stack, POISON_STACK_SZ);
+    ret = pthread_create(&tid, &attr, broadcast_thread, priv);
+    pthread_attr_destroy(&attr);
+    if (ret != 0) {
+        free(stack);
+        return -1;
+    }
+    pthread_join(tid, NULL);
+
+    /* Compared as uintptr_t: relational operators on pointers into different
+     * objects are unspecified in C, and the frame is not part of `stack` as
+     * far as the language is concerned. */
+    uintptr_t base = (uintptr_t)stack;
+    bool on_poisoned_stack =
+        broadcast_frame >= base && broadcast_frame < base + POISON_STACK_SZ;
+
+    free(stack);
+    return on_poisoned_stack ? 0 : -1;
+}
+
+/* Populate the mesh table with `n` nodes whose fields encode their index */
+static void fill_mesh(GHashTable *mesh_nodes, uint32_t n)
+{
+    for (uint32_t i = 0; i < n; i++) {
+        char hostname[64];
+        snprintf(hostname, sizeof(hostname), "node-%u.example", i);
+        MeshNodeInfo *node =
+            mesh_node_info_new(i + 100, hostname, (uint16_t)(9000 + i));
+        g_hash_table_insert(mesh_nodes, GUINT_TO_POINTER(i + 100), node);
+    }
+}
+
+static void empty_mesh(GHashTable *mesh_nodes)
+{
+    GHashTableIter iter;
+    gpointer key, value;
+
+    g_hash_table_iter_init(&iter, mesh_nodes);
+    while (g_hash_table_iter_next(&iter, &key, &value)) {
+        mesh_node_info_free((MeshNodeInfo *)value);
+    }
+    g_hash_table_remove_all(mesh_nodes);
+}
+
+static int run_case(const struct testcase *tc)
+{
+    TcpBackendPrivate priv;
+    TcpConnection conn;
+    TcpMsgHeader hdr;
+    TcpMeshTopologyPayload wire;
+    int sv[2];
+    int fail = 0;
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
+        printf("FAIL %-16s: socketpair failed\n", tc->name);
+        return 1;
+    }
+
+    memset(&priv, 0, sizeof(priv));
+    priv.is_manager = true;
+    priv.local_node_id = 1;
+    priv.mesh_nodes = g_hash_table_new(g_direct_hash, g_direct_equal);
+    priv.connections = g_hash_table_new(g_direct_hash, g_direct_equal);
+    qemu_mutex_init(&priv.mesh_table_lock);
+    qemu_mutex_init(&priv.conn_table_lock);
+
+    /* One "worker" on the near end of the socketpair */
+    memset(&conn, 0, sizeof(conn));
+    conn.node_id = 42;
+    conn.sockfd = sv[0];
+    conn.is_connected = true;
+    conn.priv = &priv;
+    qemu_mutex_init(&conn.lock);
+    g_hash_table_insert(priv.connections, GUINT_TO_POINTER(42u), &conn);
+
+    fill_mesh(priv.mesh_nodes, tc->num_nodes);
+
+    if (broadcast_on_poisoned_stack(&priv) != 0) {
+        printf("FAIL %-16s: broadcast did not run on the poisoned stack "
+               "(thread setup failed, or ASan relocated the frame to a fake "
+               "stack -- the tail check below would be vacuous)\n",
+               tc->name);
+        fail = 1;
+        goto out;
+    }
+
+    if (read_exact(sv[1], &hdr, sizeof(hdr)) != 0 ||
+        read_exact(sv[1], &wire, sizeof(wire)) != 0) {
+        printf("FAIL %-16s: short read from socketpair\n", tc->name);
+        fail = 1;
+        goto out;
+    }
+
+    if (ntohl(hdr.msg_type) != TCP_MSG_MESH_TOPOLOGY ||
+        ntohl(hdr.msg_len) != sizeof(wire)) {
+        printf("FAIL %-16s: unexpected header type=%u len=%u\n", tc->name,
+               ntohl(hdr.msg_type), ntohl(hdr.msg_len));
+        fail = 1;
+    }
+
+    if (ntohl(wire.num_nodes) != tc->num_nodes) {
+        printf("FAIL %-16s: num_nodes %u, expected %u\n", tc->name,
+               ntohl(wire.num_nodes), tc->num_nodes);
+        fail = 1;
+    }
+
+    /* Live entries: hash-table order is unspecified, so match by node_id */
+    for (uint32_t i = 0; i < tc->num_nodes; i++) {
+        uint32_t id = ntohl(wire.nodes[i].node_id);
+        char expect_host[64];
+
+        if (id < 100 || id >= 100 + tc->num_nodes) {
+            printf("FAIL %-16s: slot %u has bogus node_id %u\n", tc->name, i,
+                   id);
+            fail = 1;
+            continue;
+        }
+        snprintf(expect_host, sizeof(expect_host), "node-%u.example", id - 100);
+        if (strcmp(wire.nodes[i].hostname, expect_host) != 0) {
+            printf("FAIL %-16s: slot %u hostname '%s', expected '%s'\n",
+                   tc->name, i, wire.nodes[i].hostname, expect_host);
+            fail = 1;
+        }
+        if (ntohs(wire.nodes[i].port) != 9000 + (id - 100)) {
+            printf("FAIL %-16s: slot %u port %u\n", tc->name, i,
+                   ntohs(wire.nodes[i].port));
+            fail = 1;
+        }
+    }
+
+    /* The point of the test: every byte past the live entries is zero */
+    const uint8_t *tail = (const uint8_t *)&wire.nodes[tc->num_nodes];
+    size_t tail_len =
+        (size_t)(TOPO_MAXNODE - tc->num_nodes) * sizeof(TcpMeshNodeInfo);
+    for (size_t i = 0; i < tail_len; i++) {
+        if (tail[i] != 0) {
+            printf("FAIL %-16s: unused slot byte %zu of %zu is 0x%02x, "
+                   "expected 0 (stack contents leaked on the wire)\n",
+                   tc->name, i, tail_len, tail[i]);
+            fail = 1;
+            break;
+        }
+    }
+
+    if (!fail) {
+        printf("PASS %-16s: %u node(s), %zu-byte tail all zero\n", tc->name,
+               tc->num_nodes, tail_len);
+    }
+
+out:
+    close(sv[0]);
+    close(sv[1]);
+    qemu_mutex_destroy(&conn.lock);
+    qemu_mutex_destroy(&priv.conn_table_lock);
+    qemu_mutex_destroy(&priv.mesh_table_lock);
+    g_hash_table_destroy(priv.connections);
+    empty_mesh(priv.mesh_nodes);
+    g_hash_table_destroy(priv.mesh_nodes);
+    return fail;
+}
+
+int main(void)
+{
+    static const struct testcase cases[] = {
+        {"empty-mesh", 0}, /* every slot unused */
+        {"single-node", 1},
+        {"few-nodes", 3},
+        {"full-mesh", (uint32_t)TOPO_MAXNODE}, /* no tail at all */
+    };
+    int failures = 0;
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        failures += run_case(&cases[i]);
+    }
+
+    if (failures) {
+        printf("\n%d test case(s) FAILED\n", failures);
+        return 1;
+    }
+    printf("\nAll %zu test cases passed\n", sizeof(cases) / sizeof(cases[0]));
+    return 0;
+}


### PR DESCRIPTION
## Motivation

tcp_broadcast_mesh_topology() built TcpMeshTopologyPayload as an uninitialised stack local, filled in nodes[0..num_nodes), and then sent the whole fixed-size struct -- 64 node slots, ~17 KB -- to every connected worker.  The slots past num_nodes went out carrying whatever the manager's stack happened to hold at that address, which on a typical run includes live binary, libc and stack pointers.  Any worker, or anything on the path between them, could read them straight off the wire and defeat ASLR on the manager.

## Technical Details

This change zeros the struct before filling it.  The wire format is unchanged: the payload was always sent at full size, and workers already read only nodes[0..num_nodes), so the tail was ignored on receipt.

## Test Plan

Adds tests/test_tcp_mesh_topology.c, registered as the ctest tcp-mesh-topology-unit.  It reaches the static broadcast function by including the translation unit, stubs the backend's externals, and reads the message back off a socketpair, asserting the bytes past num_nodes are all zero.  Table-driven over 0, 1, 3 and a full mesh of nodes; the full-mesh case is the control, since it has no tail either way.  The slot count is derived from sizeof(payload->nodes) rather than hardcoded, so resizing nodes[] cannot leave the test silently checking a short tail.

Getting the test to fail on the old code took some care.  Poisoning the caller's own frame is not enough -- the compiler places the 17 KB struct where it likes, so the poison and the payload need not overlap -- so the broadcast runs on a thread whose stack the test allocates and pre-fills itself.  ASan's detect_stack_use_after_return also relocates a frame that large onto a freshly-zeroed fake stack, which hides the disclosure entirely; the test turns that off via __asan_default_options().  Because that is only a default and an ASAN_OPTIONS in the environment overrides it, the broadcast thread records the address of one of its locals and the test asserts the frame really landed on the poisoned stack.  Without that check a CI runner exporting ASAN_OPTIONS would get a vacuous pass.

## Test Result

Verified: ctest is 16/16 (3 hardware-dependent tests skip, as before). Removing the memset and rebuilding makes tcp-mesh-topology-unit fail on 3 of its 4 cases, and forcing detect_stack_use_after_return=1 makes all 4 fail on the frame-location check rather than passing silently. clang-format-18 clean.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md#pull-requests.
