### PR TITLE
ci: Add concurrency section to GitHub actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   TCP_PORT: 5000
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,6 +13,10 @@ on:
       - '.github/workflows/build-test.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     name: Build and Test on ${{ matrix.os }}

--- a/.github/workflows/dc-tests.yml
+++ b/.github/workflows/dc-tests.yml
@@ -19,6 +19,10 @@ on:
       - '.github/workflows/dc-tests.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dc-build-and-ctest:
     name: DC unit tests (cmocka)

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -15,6 +15,10 @@ on:
       - 'requirements.txt'
       - '.github/workflows/docs-check.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sphinx:
     name: sphinx-build

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -22,6 +22,14 @@ on:
       - 'requirements.txt'
       - '.github/workflows/docs-deploy.yml'
 
+# Serialise deploys to Pages.  Unlike the pull request workflows this does
+# NOT cancel in progress: a half-finished deploy would leave the published
+# site in whatever state actions/deploy-pages had reached, so a superseded
+# run queues behind the current one and then publishes the newer docs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/driver-build.yml
+++ b/.github/workflows/driver-build.yml
@@ -12,6 +12,10 @@ on:
       - '.github/workflows/driver-build.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   driver-build:
     name: Build Legacy Kernel Driver on ${{ matrix.os }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,10 @@ on:
       - '.github/workflows/lint.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-clang-format:
     name: clang-format

--- a/.github/workflows/service-test.yml
+++ b/.github/workflows/service-test.yml
@@ -10,6 +10,10 @@ on:
       - '.github/workflows/service-test.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ernicctl-syntax:
     name: ernicctl Python syntax and imports

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -6,6 +6,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   spell-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -6,6 +6,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Container image with QEMU and libvfio-user pre-built
 env:
   TCP_PORT: 5000


### PR DESCRIPTION
## Motivation

We don't set concurrency in GitHub actions

## Technical Details

Add a concurrency block where it makes sense to do so. Also sets the docs-deploy action to false to avoid messing up the queue.

## Test Plan

CI passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md#pull-requests.
